### PR TITLE
infra: rename module to github.com/trentas/ptop

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,4 +1,4 @@
-# bpf-inspector
+# xray
 
 TUI interativa para inspeção profunda de processos Linux via eBPF.
 Permite diagnóstico ao vivo de CPU, syscalls, rede, I/O, memória, threads e file descriptors
@@ -40,7 +40,7 @@ teal:    #2dd4bf
 ## Estrutura do projeto
 
 ```
-bpf-inspector/
+xray/
 ├── CLAUDE.md
 ├── go.mod
 ├── go.sum
@@ -246,11 +246,11 @@ gen:
 	go generate ./internal/bpf/...
 
 build: gen
-	go build -o bin/bpf-inspector ./cmd/inspector
+	go build -o bin/xray ./cmd/xray
 
 # requer root para eBPF
 run: build
-	sudo ./bin/bpf-inspector --pid $(PID)
+	sudo ./bin/xray --pid $(PID)
 
 clean:
 	rm -rf bin/
@@ -261,10 +261,10 @@ clean:
 ## Flags de linha de comando
 
 ```
-bpf-inspector --pid <PID>            # inspecionar processo específico
-bpf-inspector --pid <PID> --fps 10   # taxa de atualização (default: 5)
-bpf-inspector --pid <PID> --export   # salvar snapshot JSON ao sair (tecla 'e')
-bpf-inspector --pid <PID> --no-ebpf  # modo degradado: só /proc, sem eBPF (para testes)
+xray --pid <PID>            # inspecionar processo específico
+xray --pid <PID> --fps 10   # taxa de atualização (default: 5)
+xray --pid <PID> --export   # salvar snapshot JSON ao sair (tecla 'e')
+xray --pid <PID> --no-ebpf  # modo degradado: só /proc, sem eBPF (para testes)
 ```
 
 ---

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,7 @@
-.PHONY: build run gen clean dev
+.PHONY: build run gen clean dev test vet lint
+
+BINARY := xray
+PKG    := ./cmd/xray
 
 # Compila programas eBPF (.c → .o) e embute no binário via go:generate
 gen:
@@ -6,19 +9,25 @@ gen:
 
 # Build completo com eBPF
 build: gen
-	go build -o bin/bpf-inspector ./cmd/inspector
+	go build -o bin/$(BINARY) $(PKG)
 
 # Build sem eBPF (para desenvolvimento/teste sem root)
 build-dev:
-	go build -tags noebpf -o bin/bpf-inspector ./cmd/inspector
+	go build -tags noebpf -o bin/$(BINARY) $(PKG)
 
 # Requer root para eBPF
 run: build
-	sudo ./bin/bpf-inspector --pid $(PID)
+	sudo ./bin/$(BINARY) --pid $(PID)
 
 # Modo desenvolvimento: sem eBPF, dados de /proc
 dev: build-dev
-	./bin/bpf-inspector --pid $(PID) --no-ebpf
+	./bin/$(BINARY) --pid $(PID) --no-ebpf
+
+test:
+	go test ./...
+
+vet:
+	go vet ./...
 
 clean:
 	rm -rf bin/

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
-# bpf-inspector
+# xray
 
 TUI para inspeção profunda de processos Linux via eBPF.
 
 ```
-⬡ bpf-inspector  api-server  PID 18423  Go 1.22  RUNNING  15 fds
+⬡ xray  api-server  PID 18423  Go 1.22  RUNNING  15 fds
 ────────────────────────────────────────────────────────────────
  F1 Overview │ F2 Syscalls │ F3 Network │ F4 Threads │ F5 I/O │ F6 FD │ F7 Timeline
 ```
@@ -18,8 +18,8 @@ TUI para inspeção profunda de processos Linux via eBPF.
 ## Instalação
 
 ```bash
-git clone https://github.com/yourusername/bpf-inspector
-cd bpf-inspector
+git clone git@github.com:trentas/xray.git
+cd xray
 make build
 ```
 
@@ -27,13 +27,13 @@ make build
 
 ```bash
 # modo completo (requer root)
-sudo ./bin/bpf-inspector --pid 1234
+sudo ./bin/xray --pid 1234
 
 # modo desenvolvimento (sem eBPF, lê /proc)
-./bin/bpf-inspector --pid 1234 --no-ebpf
+./bin/xray --pid 1234 --no-ebpf
 
 # com taxa de atualização customizada
-sudo ./bin/bpf-inspector --pid 1234 --fps 10
+sudo ./bin/xray --pid 1234 --fps 10
 ```
 
 ## Navegação

--- a/cmd/xray/main.go
+++ b/cmd/xray/main.go
@@ -6,7 +6,7 @@ import (
 	"os"
 
 	tea "github.com/charmbracelet/bubbletea"
-	"github.com/yourusername/bpf-inspector/internal/tui"
+	"github.com/trentas/xray/internal/tui"
 )
 
 func main() {
@@ -18,7 +18,7 @@ func main() {
 
 	if *pid == 0 {
 		fmt.Fprintln(os.Stderr, "erro: --pid é obrigatório")
-		fmt.Fprintln(os.Stderr, "uso:  bpf-inspector --pid <PID> [--fps 5] [--no-ebpf]")
+		fmt.Fprintln(os.Stderr, "uso:  xray --pid <PID> [--fps 5] [--no-ebpf]")
 		os.Exit(1)
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/yourusername/bpf-inspector
+module github.com/trentas/xray
 
 go 1.22
 

--- a/internal/tui/header.go
+++ b/internal/tui/header.go
@@ -10,7 +10,7 @@ import (
 
 // renderHeader desenha a barra superior:
 //
-//	⬡ bpf-inspector │ <process> [PID N] [Go 1.22] [STATE] [N fds]            uptime MM:SS │ HH:MM:SS
+//	⬡ xray │ <process> [PID N] [Go 1.22] [STATE] [N fds]            uptime MM:SS │ HH:MM:SS
 //
 // O resultado é SEMPRE truncado para caber em m.Width. Se a linha estourar a
 // largura, o terminal faz line-wrap e o resto da TUI vira de ponta-cabeça —
@@ -22,7 +22,7 @@ func renderHeader(m Model) string {
 		Foreground(ColorCyan).
 		Background(headerBg).
 		Bold(true).
-		Render("⬡ bpf-inspector")
+		Render("⬡ xray")
 
 	sep := lipgloss.NewStyle().
 		Foreground(ColorBorder).

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -11,7 +11,7 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 
-	"github.com/yourusername/bpf-inspector/internal/collector"
+	"github.com/trentas/xray/internal/collector"
 )
 
 // simInterval define a granularidade da simulação. O TickMsg dispara no FPS

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -35,7 +35,7 @@ func TestRenderAllTabs(t *testing.T) {
 			if out == "" {
 				t.Errorf("size=%dx%d tab=%d: vazio", sz.w, sz.h, tab)
 			}
-			if !strings.Contains(out, "bpf-inspector") {
+			if !strings.Contains(out, "xray") {
 				t.Errorf("size=%dx%d tab=%d: header ausente", sz.w, sz.h, tab)
 			}
 		}

--- a/internal/tui/panels.go
+++ b/internal/tui/panels.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/charmbracelet/lipgloss"
 
-	"github.com/yourusername/bpf-inspector/internal/collector"
+	"github.com/trentas/xray/internal/collector"
 )
 
 // ─── CPU ─────────────────────────────────────────────────────────────────────

--- a/internal/tui/view_fd.go
+++ b/internal/tui/view_fd.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/charmbracelet/lipgloss"
 
-	"github.com/yourusername/bpf-inspector/internal/collector"
+	"github.com/trentas/xray/internal/collector"
 )
 
 // renderFDView (F6) — assets/mockup.jsx → FDView

--- a/internal/tui/view_io.go
+++ b/internal/tui/view_io.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/charmbracelet/lipgloss"
 
-	"github.com/yourusername/bpf-inspector/internal/collector"
+	"github.com/trentas/xray/internal/collector"
 )
 
 // renderIOView (F5) — assets/mockup.jsx → IOView

--- a/internal/tui/view_syscalls.go
+++ b/internal/tui/view_syscalls.go
@@ -3,7 +3,7 @@ package tui
 import (
 	"github.com/charmbracelet/lipgloss"
 
-	"github.com/yourusername/bpf-inspector/internal/collector"
+	"github.com/trentas/xray/internal/collector"
 )
 
 // renderSyscallsView (F2) — assets/mockup.jsx → SyscallView

--- a/internal/tui/view_timeline.go
+++ b/internal/tui/view_timeline.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/charmbracelet/lipgloss"
 
-	"github.com/yourusername/bpf-inspector/internal/collector"
+	"github.com/trentas/xray/internal/collector"
 )
 
 // renderTimelineView (F7) — assets/mockup.jsx → TimelineView


### PR DESCRIPTION
Closes #1.

## Mudanças

- `go.mod`: module `github.com/yourusername/bpf-inspector` → `github.com/trentas/xray`
- Diretório `cmd/inspector/` → `cmd/xray/` (binário default vira `xray`)
- `Makefile`: `BINARY=xray`, `PKG=./cmd/xray`, alvos `test`/`vet` adicionais
- `README.md` + `CLAUDE.md`: nome do projeto, URL de clone, referências ao binário
- TUI logo: `⬡ bpf-inspector` → `⬡ xray`
- `model_test.go`: ajuste do `strings.Contains(out, "xray")`
- `main.go`: banner de uso

## Verificação

```
go vet ./...      # ok
go test ./...     # PASS (6 testes)
go build ./...    # bin/xray (~4.7MB)
```

Zero referências a `yourusername`/`bpf-inspector` no código pós-merge.