### PR TITLE
collector: CPU/threads/memory via /proc (Linux fallback)

### DIFF
--- a/internal/collector/cpu_proc.go
+++ b/internal/collector/cpu_proc.go
@@ -1,0 +1,128 @@
+package collector
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+)
+
+// CPUCollector lê /proc/<pid>/stat polling a cada 500ms para calcular % de uso
+// de CPU do processo via delta de (utime+stime) entre amostras.
+//
+// Funciona sem root, sem eBPF. Em macOS/Windows o Start falha silenciosamente
+// porque /proc não existe — o model continua usando dados simulados.
+type CPUCollector struct {
+	pid  int
+	ch   chan interface{}
+	stop chan struct{}
+	mu   sync.Mutex
+
+	lastTicks    uint64
+	lastSampleAt time.Time
+}
+
+func NewCPUCollector() *CPUCollector {
+	return &CPUCollector{
+		ch:   make(chan interface{}, 16),
+		stop: make(chan struct{}),
+	}
+}
+
+func (c *CPUCollector) Start(pid int) error {
+	c.pid = pid
+	if _, err := os.Stat(fmt.Sprintf("/proc/%d/stat", pid)); err != nil {
+		return fmt.Errorf("processo %d não encontrado: %w", pid, err)
+	}
+	go c.loop()
+	return nil
+}
+
+func (c *CPUCollector) Stop()                          { close(c.stop) }
+func (c *CPUCollector) Subscribe() <-chan interface{}  { return c.ch }
+
+func (c *CPUCollector) loop() {
+	t := time.NewTicker(500 * time.Millisecond)
+	defer t.Stop()
+	for {
+		select {
+		case <-c.stop:
+			return
+		case <-t.C:
+			if s, err := c.sample(); err == nil {
+				select {
+				case c.ch <- s:
+				default:
+				}
+			}
+		}
+	}
+}
+
+// clkTck assume CONFIG_HZ=100, default em x86/x86_64 Linux há ~20 anos.
+// Em ARM pode ser 250 — corrigir via sysconf(_SC_CLK_TCK) quando virar problema.
+const clkTck = 100
+
+func (c *CPUCollector) sample() (CpuSample, error) {
+	data, err := os.ReadFile(fmt.Sprintf("/proc/%d/stat", c.pid))
+	if err != nil {
+		return CpuSample{}, err
+	}
+	utime, stime, _, _, err := parseProcStatTimes(data)
+	if err != nil {
+		return CpuSample{}, err
+	}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	now := time.Now()
+	totalTicks := utime + stime
+
+	var pct float64
+	if !c.lastSampleAt.IsZero() {
+		elapsed := now.Sub(c.lastSampleAt).Seconds()
+		if elapsed > 0 {
+			deltaTicks := float64(totalTicks - c.lastTicks)
+			// % single-core: deltaTicks/clkTck = segundos de CPU usados
+			// dividido por elapsed = fração do tempo. ×100 = %.
+			pct = (deltaTicks / clkTck) / elapsed * 100
+		}
+	}
+	c.lastTicks = totalTicks
+	c.lastSampleAt = now
+
+	return CpuSample{
+		UsagePct:  pct,
+		Timestamp: now,
+	}, nil
+}
+
+// parseProcStatTimes extrai utime, stime, minflt, majflt de /proc/<pid>/stat.
+//
+// O campo 2 (comm) é parentesizado e PODE conter espaços/parens — o parser
+// canônico procura o ÚLTIMO `)` na linha; o que vem depois são os campos 3..N
+// space-separated. Index do post (post[i] = campo i+3):
+//
+//	post[7]  = minflt   (campo 10)
+//	post[9]  = majflt   (campo 12)
+//	post[11] = utime    (campo 14)
+//	post[12] = stime    (campo 15)
+func parseProcStatTimes(data []byte) (utime, stime, minflt, majflt uint64, err error) {
+	s := string(data)
+	end := strings.LastIndex(s, ")")
+	if end < 0 {
+		return 0, 0, 0, 0, fmt.Errorf("malformed /proc stat: ')' ausente")
+	}
+	fields := strings.Fields(strings.TrimSpace(s[end+1:]))
+	if len(fields) < 13 {
+		return 0, 0, 0, 0, fmt.Errorf("malformed /proc stat: %d campos", len(fields))
+	}
+	utime, _ = strconv.ParseUint(fields[11], 10, 64)
+	stime, _ = strconv.ParseUint(fields[12], 10, 64)
+	minflt, _ = strconv.ParseUint(fields[7], 10, 64)
+	majflt, _ = strconv.ParseUint(fields[9], 10, 64)
+	return
+}

--- a/internal/collector/mem_proc.go
+++ b/internal/collector/mem_proc.go
@@ -1,0 +1,105 @@
+package collector
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+)
+
+// MemCollector lê /proc/<pid>/statm + /proc/<pid>/stat a cada 1s para popular
+// RSS, heap aproximado, page faults acumulados e taxa de allocs/s estimada
+// (usa total de page faults como proxy — não é perfeito mas é o melhor que
+// /proc oferece sem instrumentação).
+type MemCollector struct {
+	pid  int
+	ch   chan interface{}
+	stop chan struct{}
+	mu   sync.Mutex
+
+	lastFaults uint64
+	lastAt     time.Time
+}
+
+func NewMemCollector() *MemCollector {
+	return &MemCollector{
+		ch:   make(chan interface{}, 16),
+		stop: make(chan struct{}),
+	}
+}
+
+func (c *MemCollector) Start(pid int) error {
+	c.pid = pid
+	if _, err := os.Stat(fmt.Sprintf("/proc/%d/statm", pid)); err != nil {
+		return fmt.Errorf("processo %d não encontrado: %w", pid, err)
+	}
+	go c.loop()
+	return nil
+}
+
+func (c *MemCollector) Stop()                          { close(c.stop) }
+func (c *MemCollector) Subscribe() <-chan interface{}  { return c.ch }
+
+func (c *MemCollector) loop() {
+	t := time.NewTicker(1 * time.Second)
+	defer t.Stop()
+	for {
+		select {
+		case <-c.stop:
+			return
+		case <-t.C:
+			if s, err := c.sample(); err == nil {
+				select {
+				case c.ch <- s:
+				default:
+				}
+			}
+		}
+	}
+}
+
+func (c *MemCollector) sample() (MemStats, error) {
+	// /proc/<pid>/statm: size resident shared text lib data dirty (em pages)
+	statmData, err := os.ReadFile(fmt.Sprintf("/proc/%d/statm", c.pid))
+	if err != nil {
+		return MemStats{}, err
+	}
+	fields := strings.Fields(string(statmData))
+	if len(fields) < 7 {
+		return MemStats{}, fmt.Errorf("malformed /proc/.../statm: %d campos", len(fields))
+	}
+	pageSize := uint64(os.Getpagesize())
+	resident, _ := strconv.ParseUint(fields[1], 10, 64)
+	dataPages, _ := strconv.ParseUint(fields[5], 10, 64)
+
+	// page faults via /proc/<pid>/stat (campos minflt+majflt)
+	statData, err := os.ReadFile(fmt.Sprintf("/proc/%d/stat", c.pid))
+	if err != nil {
+		return MemStats{}, err
+	}
+	_, _, minflt, majflt, _ := parseProcStatTimes(statData)
+	totalFaults := minflt + majflt
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	now := time.Now()
+	var allocsPerS uint64
+	if !c.lastAt.IsZero() {
+		elapsed := now.Sub(c.lastAt).Seconds()
+		if elapsed > 0 && totalFaults >= c.lastFaults {
+			allocsPerS = uint64(float64(totalFaults-c.lastFaults) / elapsed)
+		}
+	}
+	c.lastFaults = totalFaults
+	c.lastAt = now
+
+	return MemStats{
+		RSSBytes:   resident * pageSize,
+		HeapBytes:  dataPages * pageSize, // aproximação: data segment ~ heap+anon mappings
+		PageFaults: totalFaults,
+		AllocsPerS: allocsPerS,
+	}, nil
+}

--- a/internal/collector/proc_parsing_test.go
+++ b/internal/collector/proc_parsing_test.go
@@ -1,0 +1,103 @@
+package collector
+
+import "testing"
+
+// Stat real coletado de um shell bash em Linux:
+//   pid=12345 comm=(bash) state=S ppid=12340 ... utime=42 stime=18 ... minflt=1234 ... majflt=5
+const sampleStat = `12345 (bash) S 12340 12345 12345 34816 12345 4194304 1234 0 5 0 42 18 0 0 20 0 1 0 88888 8454144 1024 18446744073709551615 1 1 0 0 0 0 0 0 65536 1 0 0 17 2 0 0 0 0 0 0 0 0 0 0 0 0 0`
+
+// Stat com parens dentro do comm — caso real para programas tipo "((sd-pam))":
+const sampleStatTrickyComm = `12345 (sh) (((bad))) S 12340 12345 12345 0 0 0 99 0 7 0 100 200 0 0 20 0 1 0 0 0 0 0 0 0`
+
+func TestParseProcStatTimes_basic(t *testing.T) {
+	utime, stime, minflt, majflt, err := parseProcStatTimes([]byte(sampleStat))
+	if err != nil {
+		t.Fatalf("erro inesperado: %v", err)
+	}
+	if utime != 42 {
+		t.Errorf("utime=%d, esperado 42", utime)
+	}
+	if stime != 18 {
+		t.Errorf("stime=%d, esperado 18", stime)
+	}
+	if minflt != 1234 {
+		t.Errorf("minflt=%d, esperado 1234", minflt)
+	}
+	if majflt != 5 {
+		t.Errorf("majflt=%d, esperado 5", majflt)
+	}
+}
+
+func TestParseProcStatTimes_trickyComm(t *testing.T) {
+	// Garante que o parser usa o ÚLTIMO `)` e não o primeiro
+	utime, stime, _, majflt, err := parseProcStatTimes([]byte(sampleStatTrickyComm))
+	if err != nil {
+		t.Fatalf("erro inesperado: %v", err)
+	}
+	if utime != 100 || stime != 200 {
+		t.Errorf("utime/stime errados: %d/%d", utime, stime)
+	}
+	if majflt != 7 {
+		t.Errorf("majflt=%d, esperado 7", majflt)
+	}
+}
+
+func TestParseProcStatTimes_malformed(t *testing.T) {
+	if _, _, _, _, err := parseProcStatTimes([]byte("garbage no parens here")); err == nil {
+		t.Error("esperava erro pra entrada sem ')'")
+	}
+	if _, _, _, _, err := parseProcStatTimes([]byte("123 (x) S")); err == nil {
+		t.Error("esperava erro pra entrada com poucos campos")
+	}
+}
+
+func TestParseThreadStat_basic(t *testing.T) {
+	comm, state, ticks, ok := parseThreadStat([]byte(sampleStat))
+	if !ok {
+		t.Fatal("parser falhou em entrada válida")
+	}
+	if comm != "bash" {
+		t.Errorf("comm=%q, esperado bash", comm)
+	}
+	if state != 'S' {
+		t.Errorf("state=%c, esperado S", state)
+	}
+	if ticks != 60 { // 42 + 18
+		t.Errorf("ticks=%d, esperado 60", ticks)
+	}
+}
+
+func TestParseThreadStat_trickyComm(t *testing.T) {
+	comm, state, ticks, ok := parseThreadStat([]byte(sampleStatTrickyComm))
+	if !ok {
+		t.Fatal("parser falhou")
+	}
+	// Comm deve incluir tudo entre primeiro `(` e último `)`
+	expected := "sh) (((bad))"
+	if comm != expected {
+		t.Errorf("comm=%q, esperado %q", comm, expected)
+	}
+	if state != 'S' {
+		t.Errorf("state=%c, esperado S", state)
+	}
+	if ticks != 300 {
+		t.Errorf("ticks=%d, esperado 300", ticks)
+	}
+}
+
+func TestMapThreadState(t *testing.T) {
+	cases := map[byte]string{
+		'R': "running",
+		'D': "blocked",
+		'S': "sleeping",
+		'I': "sleeping",
+		'Z': "stopped",
+		'T': "stopped",
+		'?': "unknown",
+	}
+	for c, want := range cases {
+		if got := mapThreadState(c); got != want {
+			t.Errorf("mapThreadState(%c)=%q, esperado %q", c, got, want)
+		}
+	}
+}

--- a/internal/collector/threads_proc.go
+++ b/internal/collector/threads_proc.go
@@ -1,0 +1,169 @@
+package collector
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+)
+
+// ThreadsCollector enumera /proc/<pid>/task/* a cada 1s e produz []ThreadInfo
+// com state, CPU% (via delta de utime+stime) e wchan (kernel function em que
+// está bloqueada).
+type ThreadsCollector struct {
+	pid  int
+	ch   chan interface{}
+	stop chan struct{}
+	mu   sync.Mutex
+
+	prev         map[int]uint64 // tid → totalTicks
+	lastSampleAt time.Time
+}
+
+func NewThreadsCollector() *ThreadsCollector {
+	return &ThreadsCollector{
+		ch:   make(chan interface{}, 16),
+		stop: make(chan struct{}),
+		prev: make(map[int]uint64),
+	}
+}
+
+func (c *ThreadsCollector) Start(pid int) error {
+	c.pid = pid
+	if _, err := os.Stat(fmt.Sprintf("/proc/%d/task", pid)); err != nil {
+		return fmt.Errorf("processo %d não encontrado: %w", pid, err)
+	}
+	go c.loop()
+	return nil
+}
+
+func (c *ThreadsCollector) Stop()                          { close(c.stop) }
+func (c *ThreadsCollector) Subscribe() <-chan interface{}  { return c.ch }
+
+func (c *ThreadsCollector) loop() {
+	t := time.NewTicker(1 * time.Second)
+	defer t.Stop()
+	for {
+		select {
+		case <-c.stop:
+			return
+		case <-t.C:
+			if threads, err := c.collect(); err == nil {
+				select {
+				case c.ch <- threads:
+				default:
+				}
+			}
+		}
+	}
+}
+
+func mapThreadState(c byte) string {
+	switch c {
+	case 'R':
+		return "running"
+	case 'D':
+		return "blocked"
+	case 'S', 'I':
+		return "sleeping"
+	case 'Z', 'T', 't':
+		return "stopped"
+	default:
+		return "unknown"
+	}
+}
+
+func (c *ThreadsCollector) collect() ([]ThreadInfo, error) {
+	taskDir := fmt.Sprintf("/proc/%d/task", c.pid)
+	entries, err := os.ReadDir(taskDir)
+	if err != nil {
+		return nil, err
+	}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	now := time.Now()
+	elapsed := 0.0
+	if !c.lastSampleAt.IsZero() {
+		elapsed = now.Sub(c.lastSampleAt).Seconds()
+	}
+
+	seen := make(map[int]bool, len(entries))
+	out := make([]ThreadInfo, 0, len(entries))
+
+	for _, e := range entries {
+		tid, err := strconv.Atoi(e.Name())
+		if err != nil {
+			continue
+		}
+		seen[tid] = true
+
+		statData, err := os.ReadFile(filepath.Join(taskDir, e.Name(), "stat"))
+		if err != nil {
+			continue
+		}
+
+		comm, state, totalTicks, ok := parseThreadStat(statData)
+		if !ok {
+			continue
+		}
+
+		var cpuPct float64
+		if prev, hadPrev := c.prev[tid]; hadPrev && elapsed > 0 {
+			delta := float64(totalTicks - prev)
+			cpuPct = (delta / clkTck) / elapsed * 100
+		}
+		c.prev[tid] = totalTicks
+
+		// wchan = kernel function em que está dormindo (vazio se running)
+		wchan := ""
+		if w, err := os.ReadFile(filepath.Join(taskDir, e.Name(), "wchan")); err == nil {
+			wchan = strings.TrimSpace(string(w))
+			if wchan == "0" {
+				wchan = ""
+			}
+		}
+
+		out = append(out, ThreadInfo{
+			TID:     tid,
+			Name:    comm,
+			State:   mapThreadState(state),
+			CPUPct:  cpuPct,
+			Waiting: wchan,
+		})
+	}
+
+	// purga cache de threads que sumiram
+	for tid := range c.prev {
+		if !seen[tid] {
+			delete(c.prev, tid)
+		}
+	}
+
+	c.lastSampleAt = now
+	return out, nil
+}
+
+// parseThreadStat extrai (comm, state, utime+stime) de /proc/<pid>/task/<tid>/stat.
+// Mesmo cuidado com o `)` final do campo comm que em parseProcStatTimes.
+func parseThreadStat(data []byte) (comm string, state byte, totalTicks uint64, ok bool) {
+	s := string(data)
+	commStart := strings.Index(s, "(")
+	commEnd := strings.LastIndex(s, ")")
+	if commStart < 0 || commEnd < 0 || commEnd <= commStart {
+		return "", 0, 0, false
+	}
+	comm = s[commStart+1 : commEnd]
+	fields := strings.Fields(strings.TrimSpace(s[commEnd+1:]))
+	if len(fields) < 13 || len(fields[0]) == 0 {
+		return "", 0, 0, false
+	}
+	state = fields[0][0]
+	utime, _ := strconv.ParseUint(fields[11], 10, 64)
+	stime, _ := strconv.ParseUint(fields[12], 10, 64)
+	return comm, state, utime + stime, true
+}

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -62,6 +62,9 @@ type Config struct {
 
 type TickMsg time.Time
 type FDMsg []collector.FDEntry
+type CpuMsg collector.CpuSample
+type ThreadsMsg []collector.ThreadInfo
+type MemMsg collector.MemStats
 
 // ─── Tipos auxiliares ────────────────────────────────────────────────────────
 
@@ -104,13 +107,19 @@ type Model struct {
 	Height    int
 
 	// Collectors
-	fdCollector *collector.FDCollector
+	fdCollector      *collector.FDCollector
+	cpuCollector     *collector.CPUCollector
+	threadsCollector *collector.ThreadsCollector
+	memCollector     *collector.MemCollector
 
 	// Simulação
-	rng          *rand.Rand
-	tickN        int
-	usingMockFDs bool
-	lastSimAt    time.Time
+	rng              *rand.Rand
+	tickN            int
+	usingMockFDs     bool
+	usingMockCPU     bool
+	usingMockThreads bool
+	usingMockMem     bool
+	lastSimAt        time.Time
 
 	// Caches estáveis para evitar reordenação visual entre ticks.
 	// topSyscallNames é recomputado a cada `topRefreshInterval`; entre refreshes
@@ -128,30 +137,44 @@ type Model struct {
 
 func NewModel(cfg Config) Model {
 	m := Model{
-		cfg:           cfg,
-		ProcessName:   "api-server",
-		Runtime:       "Go 1.22",
-		State:         "RUNNING",
-		StartedAt:     time.Now(),
-		ActiveTab:     TabOverview,
-		FDFilter:      "all",
-		SyscallCounts: make(map[string]uint64),
-		rng:           rand.New(rand.NewSource(time.Now().UnixNano())),
-		usingMockFDs:  true,
+		cfg:              cfg,
+		ProcessName:      "api-server",
+		Runtime:          "Go 1.22",
+		State:            "RUNNING",
+		StartedAt:        time.Now(),
+		ActiveTab:        TabOverview,
+		FDFilter:         "all",
+		SyscallCounts:    make(map[string]uint64),
+		rng:              rand.New(rand.NewSource(time.Now().UnixNano())),
+		usingMockFDs:     true,
+		usingMockCPU:     true,
+		usingMockThreads: true,
+		usingMockMem:     true,
 	}
 
 	m.seedMockData()
 
-	// Tenta iniciar o collector real de FDs (lê /proc).
-	// Em --no-ebpf isto continua sendo a fonte real; se falhar (ex: macOS, sem /proc),
-	// caímos em simulação silenciosamente.
+	// Tenta iniciar collectors reais que leem /proc (Linux only).
+	// Falha silenciosa em macOS/Windows: usingMock* permanece true e o model
+	// continua simulando aquele subsistema.
 	if cfg.PID > 0 {
-		c := collector.NewFDCollector()
-		if err := c.Start(cfg.PID); err == nil {
+		if c := collector.NewFDCollector(); c.Start(cfg.PID) == nil {
 			m.fdCollector = c
 			m.usingMockFDs = false
 		} else if !cfg.NoEBPF {
-			fmt.Fprintf(os.Stderr, "aviso: FD collector indisponível: %v\n", err)
+			fmt.Fprintf(os.Stderr, "aviso: FD collector indisponível\n")
+		}
+		if c := collector.NewCPUCollector(); c.Start(cfg.PID) == nil {
+			m.cpuCollector = c
+			m.usingMockCPU = false
+		}
+		if c := collector.NewThreadsCollector(); c.Start(cfg.PID) == nil {
+			m.threadsCollector = c
+			m.usingMockThreads = false
+		}
+		if c := collector.NewMemCollector(); c.Start(cfg.PID) == nil {
+			m.memCollector = c
+			m.usingMockMem = false
 		}
 	}
 
@@ -164,6 +187,15 @@ func (m Model) Init() tea.Cmd {
 	cmds := []tea.Cmd{tick(m.cfg.FPS)}
 	if m.fdCollector != nil {
 		cmds = append(cmds, waitForFD(m.fdCollector))
+	}
+	if m.cpuCollector != nil {
+		cmds = append(cmds, waitForCPU(m.cpuCollector))
+	}
+	if m.threadsCollector != nil {
+		cmds = append(cmds, waitForThreads(m.threadsCollector))
+	}
+	if m.memCollector != nil {
+		cmds = append(cmds, waitForMem(m.memCollector))
 	}
 	return tea.Batch(cmds...)
 }
@@ -196,6 +228,22 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.usingMockFDs = false
 		m.FDCountHistory = appendCapped(m.FDCountHistory, float64(len(m.FDs)), 60)
 		return m, waitForFD(m.fdCollector)
+
+	case CpuMsg:
+		s := collector.CpuSample(v)
+		m.CPUHistory = appendCapped(m.CPUHistory, s.UsagePct, 60)
+		m.usingMockCPU = false
+		return m, waitForCPU(m.cpuCollector)
+
+	case ThreadsMsg:
+		m.Threads = []collector.ThreadInfo(v)
+		m.usingMockThreads = false
+		return m, waitForThreads(m.threadsCollector)
+
+	case MemMsg:
+		m.MemStats = collector.MemStats(v)
+		m.usingMockMem = false
+		return m, waitForMem(m.memCollector)
 	}
 	return m, nil
 }
@@ -460,30 +508,35 @@ func (m *Model) tick() {
 	m.tickN++
 	r := m.rng
 
-	// CPU
-	prev := 20.0
-	if len(m.CPUHistory) > 0 {
-		prev = m.CPUHistory[len(m.CPUHistory)-1]
+	// CPU — só simula se collector real não está rodando.
+	// Quando real, o campo é alimentado via CpuMsg.
+	if m.usingMockCPU {
+		prev := 20.0
+		if len(m.CPUHistory) > 0 {
+			prev = m.CPUHistory[len(m.CPUHistory)-1]
+		}
+		delta := (r.Float64()*2 - 0.9) * 12
+		cpu := clamp(prev+delta, 0, 100)
+		m.CPUHistory = appendCapped(m.CPUHistory, cpu, 60)
 	}
-	delta := (r.Float64()*2 - 0.9) * 12
-	cpu := clamp(prev+delta, 0, 100)
-	m.CPUHistory = appendCapped(m.CPUHistory, cpu, 60)
 
-	// Syscalls — incrementa um aleatório
+	// Syscalls — sem collector real ainda (issue #9 trará via eBPF)
 	for i := 0; i < 3; i++ {
 		k := simSyscalls[r.Intn(len(simSyscalls))]
 		m.SyscallCounts[k] += uint64(r.Intn(20))
 	}
 
-	// Memory
-	if r.Float64() > 0.7 {
-		m.MemStats.RSSBytes += uint64(r.Intn(2 << 20))
+	// Memory — só simula se collector real não está rodando
+	if m.usingMockMem {
+		if r.Float64() > 0.7 {
+			m.MemStats.RSSBytes += uint64(r.Intn(2 << 20))
+		}
+		m.MemStats.HeapBytes = uint64(clamp(float64(m.MemStats.HeapBytes)+(r.Float64()-0.5)*3*(1<<20), 60*(1<<20), 256*(1<<20)))
+		if r.Float64() > 0.8 {
+			m.MemStats.PageFaults++
+		}
+		m.MemStats.AllocsPerS = uint64(clamp(float64(m.MemStats.AllocsPerS)+r.Float64()*8-3, 50, 2000))
 	}
-	m.MemStats.HeapBytes = uint64(clamp(float64(m.MemStats.HeapBytes)+(r.Float64()-0.5)*3*(1<<20), 60*(1<<20), 256*(1<<20)))
-	if r.Float64() > 0.8 {
-		m.MemStats.PageFaults++
-	}
-	m.MemStats.AllocsPerS = uint64(clamp(float64(m.MemStats.AllocsPerS)+r.Float64()*8-3, 50, 2000))
 
 	// Network — jitter de latência + estado oscilante
 	for i := range m.NetConns {
@@ -498,17 +551,19 @@ func (m *Model) tick() {
 		}
 	}
 
-	// Threads — running varia CPU; estado raramente muda
-	states := []string{"running", "blocked", "sleeping"}
-	for i := range m.Threads {
-		t := &m.Threads[i]
-		if t.State == "running" {
-			t.CPUPct = clamp(t.CPUPct+(r.Float64()-0.5)*8, 0, 99)
-		} else {
-			t.CPUPct = 0
-		}
-		if r.Float64() > 0.95 {
-			t.State = states[r.Intn(len(states))]
+	// Threads — só simula se collector real não está rodando
+	if m.usingMockThreads {
+		states := []string{"running", "blocked", "sleeping"}
+		for i := range m.Threads {
+			t := &m.Threads[i]
+			if t.State == "running" {
+				t.CPUPct = clamp(t.CPUPct+(r.Float64()-0.5)*8, 0, 99)
+			} else {
+				t.CPUPct = 0
+			}
+			if r.Float64() > 0.95 {
+				t.State = states[r.Intn(len(states))]
+			}
 		}
 	}
 
@@ -702,7 +757,45 @@ func waitForFD(c *collector.FDCollector) tea.Cmd {
 		if fds, ok := v.([]collector.FDEntry); ok {
 			return FDMsg(fds)
 		}
-		// canal fechou ou tipo inesperado; reagenda sem entregar
+		return TickMsg(time.Now())
+	}
+}
+
+func waitForCPU(c *collector.CPUCollector) tea.Cmd {
+	if c == nil {
+		return nil
+	}
+	return func() tea.Msg {
+		v := <-c.Subscribe()
+		if s, ok := v.(collector.CpuSample); ok {
+			return CpuMsg(s)
+		}
+		return TickMsg(time.Now())
+	}
+}
+
+func waitForThreads(c *collector.ThreadsCollector) tea.Cmd {
+	if c == nil {
+		return nil
+	}
+	return func() tea.Msg {
+		v := <-c.Subscribe()
+		if t, ok := v.([]collector.ThreadInfo); ok {
+			return ThreadsMsg(t)
+		}
+		return TickMsg(time.Now())
+	}
+}
+
+func waitForMem(c *collector.MemCollector) tea.Cmd {
+	if c == nil {
+		return nil
+	}
+	return func() tea.Msg {
+		v := <-c.Subscribe()
+		if s, ok := v.(collector.MemStats); ok {
+			return MemMsg(s)
+		}
 		return TickMsg(time.Now())
 	}
 }


### PR DESCRIPTION
Closes #18.

## Resumo

Três collectors polling-based que populam **F1 (Overview)** e **F4 (Threads)** com dados reais quando rodando contra um PID Linux em modo `--no-ebpf` — o que antes ficava em simulação. Maior unlock individual do MVP `--no-ebpf`.

## Implementação

### Collectors

| Arquivo | Fonte | Periodicidade | Publica |
|---|---|---|---|
| `cpu_proc.go` | `/proc/<pid>/stat` (utime+stime) | 500ms | `CpuSample{UsagePct, Timestamp}` |
| `threads_proc.go` | `/proc/<pid>/task/*/stat` + `wchan` | 1s | `[]ThreadInfo` (state, CPU%, waiting) |
| `mem_proc.go` | `/proc/<pid>/statm` + `stat` (faults) | 1s | `MemStats` (RSS, heap, faults, allocs/s) |

Cada um implementa o mesmo contrato `Start/Stop/Subscribe` do `FDCollector`. Em macOS/Windows o `Start` falha porque `/proc` não existe — flag `usingMockX` permanece `true` e a simulação continua governando aquele subsistema.

### Model

- 3 message types novos (`CpuMsg`, `ThreadsMsg`, `MemMsg`)
- `Init()` dispara `waitForCPU`/`waitForThreads`/`waitForMem` quando os collectors estão ativos
- `tick()` ganha gates `if m.usingMockX` — a sim só toca campo que não tem fonte real
- Quando msg real chega, `usingMockX = false` definitivo

### Parser cuidadoso de `/proc/<pid>/stat`

O campo `comm` é parentesizado e PODE conter espaços e parens (caso real: \`(((sd-pam)))\` do systemd). O parser canônico usa \`strings.LastIndex(s, \")\")\` pra dividir o pre/post — o que vem depois é os campos 3..N.

Coberto por \`TestParseProcStatTimes_trickyComm\` e \`TestParseThreadStat_trickyComm\`.

## Verificação

\`\`\`
go vet ./...                 # ok
go test ./...                # PASS (12 testes — 6 novos)
go build -o bin/xray ./cmd/xray
\`\`\`

## Limitações conhecidas (defer pra próximas issues)

- **CLK_TCK hardcoded 100**: assume CONFIG_HZ=100 (default x86/x86_64). ARM com 250 ticks/s vai relatar CPU% 2.5x menor. Fix futuro: \`unix.Sysconf(unix.SC_CLK_TCK)\` (precisa lidar com diferenças darwin/linux na build tag — issue #3).
- **AllocsPerS é proxy**: usa delta de minflt+majflt como estimativa. Não captura allocs que reusam memória já mapeada (a maioria). Resolveria via eBPF em \`mm_page_alloc\` (issue #14).
- **Heap aproximado**: usa o data segment de \`statm\` (campo 6). Inclui anonymous mappings mas não sabe distinguir heap real vs mmap. Aceitável pra MVP.
- **CPU% pode passar de 100% em multi-thread**: o cálculo é (delta_ticks / clkTck) / wallclock × 100, sem normalizar por NCPU. Coerente com \`top\` em modo \"single-CPU\".

## Como testar manualmente em Linux

\`\`\`bash
sudo ./bin/xray --pid \$(pgrep -f my-process) --no-ebpf
\`\`\`

F1 deve mostrar sparkline de CPU real, painel Memory com RSS real, F4 lista as threads com state e CPU% reais.