### PR TITLE
collector: I/O wait via /proc/<pid>/stat field 42

### DIFF
--- a/internal/collector/cpu_proc.go
+++ b/internal/collector/cpu_proc.go
@@ -70,7 +70,7 @@ func (c *CPUCollector) sample() (CpuSample, error) {
 	if err != nil {
 		return CpuSample{}, err
 	}
-	utime, stime, _, _, err := parseProcStatTimes(data)
+	utime, stime, _, _, _, err := parseProcStatTimes(data)
 	if err != nil {
 		return CpuSample{}, err
 	}
@@ -100,29 +100,36 @@ func (c *CPUCollector) sample() (CpuSample, error) {
 	}, nil
 }
 
-// parseProcStatTimes extrai utime, stime, minflt, majflt de /proc/<pid>/stat.
+// parseProcStatTimes extrai campos numéricos chave de /proc/<pid>/stat.
 //
 // O campo 2 (comm) é parentesizado e PODE conter espaços/parens — o parser
 // canônico procura o ÚLTIMO `)` na linha; o que vem depois são os campos 3..N
 // space-separated. Index do post (post[i] = campo i+3):
 //
-//	post[7]  = minflt   (campo 10)
-//	post[9]  = majflt   (campo 12)
-//	post[11] = utime    (campo 14)
-//	post[12] = stime    (campo 15)
-func parseProcStatTimes(data []byte) (utime, stime, minflt, majflt uint64, err error) {
+//	post[7]  = minflt              (campo 10)
+//	post[9]  = majflt              (campo 12)
+//	post[11] = utime               (campo 14)
+//	post[12] = stime               (campo 15)
+//	post[39] = delayacct_blkio_ticks (campo 42)
+//
+// `blkio` retorna 0 se o kernel não exporta o campo (CONFIG_TASK_DELAY_ACCT
+// off, ou kernel 5.14+ sem boot param `delayacct=on`).
+func parseProcStatTimes(data []byte) (utime, stime, minflt, majflt, blkio uint64, err error) {
 	s := string(data)
 	end := strings.LastIndex(s, ")")
 	if end < 0 {
-		return 0, 0, 0, 0, fmt.Errorf("malformed /proc stat: ')' ausente")
+		return 0, 0, 0, 0, 0, fmt.Errorf("malformed /proc stat: ')' ausente")
 	}
 	fields := strings.Fields(strings.TrimSpace(s[end+1:]))
 	if len(fields) < 13 {
-		return 0, 0, 0, 0, fmt.Errorf("malformed /proc stat: %d campos", len(fields))
+		return 0, 0, 0, 0, 0, fmt.Errorf("malformed /proc stat: %d campos", len(fields))
 	}
 	utime, _ = strconv.ParseUint(fields[11], 10, 64)
 	stime, _ = strconv.ParseUint(fields[12], 10, 64)
 	minflt, _ = strconv.ParseUint(fields[7], 10, 64)
 	majflt, _ = strconv.ParseUint(fields[9], 10, 64)
+	if len(fields) > 39 {
+		blkio, _ = strconv.ParseUint(fields[39], 10, 64)
+	}
 	return
 }

--- a/internal/collector/iowait_proc.go
+++ b/internal/collector/iowait_proc.go
@@ -1,0 +1,103 @@
+package collector
+
+import (
+	"fmt"
+	"os"
+	"sync"
+	"time"
+)
+
+// IOWaitCollector lê /proc/<pid>/stat campo 42 (delayacct_blkio_ticks)
+// e converte em % do wallclock que o processo passou bloqueado em block I/O
+// síncrono no último intervalo.
+//
+// Esta é a fonte canônica para "este processo está esperando disco?" — o
+// `iowait` global de top/vmstat é uma estatística system-wide de CPU ociosa,
+// NÃO atribuível a um PID. delayacct_blkio_ticks é per-task e exato.
+//
+// Requer kernel com CONFIG_TASK_DELAY_ACCT (default em distros modernas).
+// Em kernels 5.14+ pode requerer boot param `delayacct=on`. Quando o kernel
+// não exporta o campo, parseProcStatTimes retorna blkio=0 sem erro — o
+// collector continua publicando 0%, sinalizando "sem dados".
+type IOWaitCollector struct {
+	pid  int
+	ch   chan interface{}
+	stop chan struct{}
+	mu   sync.Mutex
+
+	lastBlkio uint64
+	lastAt    time.Time
+}
+
+func NewIOWaitCollector() *IOWaitCollector {
+	return &IOWaitCollector{
+		ch:   make(chan interface{}, 16),
+		stop: make(chan struct{}),
+	}
+}
+
+func (c *IOWaitCollector) Start(pid int) error {
+	c.pid = pid
+	if _, err := os.Stat(fmt.Sprintf("/proc/%d/stat", pid)); err != nil {
+		return fmt.Errorf("processo %d não encontrado: %w", pid, err)
+	}
+	go c.loop()
+	return nil
+}
+
+func (c *IOWaitCollector) Stop()                          { close(c.stop) }
+func (c *IOWaitCollector) Subscribe() <-chan interface{}  { return c.ch }
+
+func (c *IOWaitCollector) loop() {
+	t := time.NewTicker(500 * time.Millisecond)
+	defer t.Stop()
+	for {
+		select {
+		case <-c.stop:
+			return
+		case <-t.C:
+			if s, err := c.sample(); err == nil {
+				select {
+				case c.ch <- s:
+				default:
+				}
+			}
+		}
+	}
+}
+
+func (c *IOWaitCollector) sample() (IOWaitSample, error) {
+	data, err := os.ReadFile(fmt.Sprintf("/proc/%d/stat", c.pid))
+	if err != nil {
+		return IOWaitSample{}, err
+	}
+	_, _, _, _, blkio, err := parseProcStatTimes(data)
+	if err != nil {
+		return IOWaitSample{}, err
+	}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	now := time.Now()
+	var pct float64
+	if !c.lastAt.IsZero() {
+		elapsed := now.Sub(c.lastAt).Seconds()
+		if elapsed > 0 && blkio >= c.lastBlkio {
+			deltaTicks := float64(blkio - c.lastBlkio)
+			// % do wallclock: deltaTicks/clkTck = segundos esperando I/O.
+			// Dividido por elapsed = fração; ×100 = %.
+			pct = (deltaTicks / clkTck) / elapsed * 100
+			if pct > 100 {
+				pct = 100 // saturação multi-thread em rare cases
+			}
+		}
+	}
+	c.lastBlkio = blkio
+	c.lastAt = now
+
+	return IOWaitSample{
+		Pct:       pct,
+		Timestamp: now,
+	}, nil
+}

--- a/internal/collector/mem_proc.go
+++ b/internal/collector/mem_proc.go
@@ -79,7 +79,7 @@ func (c *MemCollector) sample() (MemStats, error) {
 	if err != nil {
 		return MemStats{}, err
 	}
-	_, _, minflt, majflt, _ := parseProcStatTimes(statData)
+	_, _, minflt, majflt, _, _ := parseProcStatTimes(statData)
 	totalFaults := minflt + majflt
 
 	c.mu.Lock()

--- a/internal/collector/proc_parsing_test.go
+++ b/internal/collector/proc_parsing_test.go
@@ -10,7 +10,7 @@ const sampleStat = `12345 (bash) S 12340 12345 12345 34816 12345 4194304 1234 0 
 const sampleStatTrickyComm = `12345 (sh) (((bad))) S 12340 12345 12345 0 0 0 99 0 7 0 100 200 0 0 20 0 1 0 0 0 0 0 0 0`
 
 func TestParseProcStatTimes_basic(t *testing.T) {
-	utime, stime, minflt, majflt, err := parseProcStatTimes([]byte(sampleStat))
+	utime, stime, minflt, majflt, blkio, err := parseProcStatTimes([]byte(sampleStat))
 	if err != nil {
 		t.Fatalf("erro inesperado: %v", err)
 	}
@@ -26,11 +26,48 @@ func TestParseProcStatTimes_basic(t *testing.T) {
 	if majflt != 5 {
 		t.Errorf("majflt=%d, esperado 5", majflt)
 	}
+	if blkio != 0 {
+		// no sampleStat, post[39] = "0"
+		t.Errorf("blkio=%d, esperado 0 no sample", blkio)
+	}
+}
+
+// Sample com campo 42 (blkio) > 0 — coloquei 99 no índice post[39]:
+//
+//	pid (comm) state ppid pgrp session tty_nr tpgid flags
+//	minflt cminflt majflt cmajflt utime stime cutime cstime
+//	priority nice num_threads itrealvalue starttime vsize rss
+//	rsslim startcode endcode startstack kstkesp kstkeip signal
+//	blocked sigignore sigcatch wchan nswap cnswap exit_signal
+//	processor rt_priority policy delayacct_blkio_ticks ...
+const sampleStatWithBlkio = `12345 (myapp) R 1 1 1 0 -1 4194304 100 0 0 0 50 25 0 0 20 0 1 0 100 8454144 1024 ` +
+	`18446744073709551615 1 1 0 0 0 0 0 0 65536 1 0 0 17 0 0 0 99 0 0 0 0 0 0 0 0 0`
+
+func TestParseProcStatTimes_blkio(t *testing.T) {
+	_, _, _, _, blkio, err := parseProcStatTimes([]byte(sampleStatWithBlkio))
+	if err != nil {
+		t.Fatalf("erro: %v", err)
+	}
+	if blkio != 99 {
+		t.Errorf("blkio=%d, esperado 99", blkio)
+	}
+}
+
+// Kernel antigo (sem CONFIG_TASK_DELAY_ACCT) ou trunca antes do campo 42 — tem que retornar blkio=0 sem erro.
+func TestParseProcStatTimes_shortNoBlkio(t *testing.T) {
+	short := `12345 (proc) S 1 2 3 0 0 0 1 0 2 0 10 5 0 0 20 0 1 0`
+	_, _, _, _, blkio, err := parseProcStatTimes([]byte(short))
+	if err != nil {
+		t.Fatalf("erro inesperado: %v", err)
+	}
+	if blkio != 0 {
+		t.Errorf("blkio deve ser 0 quando o campo não está presente, got %d", blkio)
+	}
 }
 
 func TestParseProcStatTimes_trickyComm(t *testing.T) {
 	// Garante que o parser usa o ÚLTIMO `)` e não o primeiro
-	utime, stime, _, majflt, err := parseProcStatTimes([]byte(sampleStatTrickyComm))
+	utime, stime, _, majflt, _, err := parseProcStatTimes([]byte(sampleStatTrickyComm))
 	if err != nil {
 		t.Fatalf("erro inesperado: %v", err)
 	}
@@ -43,10 +80,10 @@ func TestParseProcStatTimes_trickyComm(t *testing.T) {
 }
 
 func TestParseProcStatTimes_malformed(t *testing.T) {
-	if _, _, _, _, err := parseProcStatTimes([]byte("garbage no parens here")); err == nil {
+	if _, _, _, _, _, err := parseProcStatTimes([]byte("garbage no parens here")); err == nil {
 		t.Error("esperava erro pra entrada sem ')'")
 	}
-	if _, _, _, _, err := parseProcStatTimes([]byte("123 (x) S")); err == nil {
+	if _, _, _, _, _, err := parseProcStatTimes([]byte("123 (x) S")); err == nil {
 		t.Error("esperava erro pra entrada com poucos campos")
 	}
 }

--- a/internal/collector/types.go
+++ b/internal/collector/types.go
@@ -51,6 +51,14 @@ type ThreadInfo struct {
 
 // ─── I/O ─────────────────────────────────────────────────────────────────────
 
+// IOWaitSample é a fração do wallclock que o processo passou bloqueado em
+// block I/O síncrono no último intervalo. Calculado pelo collector que lê
+// /proc/<pid>/stat campo 42 (delayacct_blkio_ticks).
+type IOWaitSample struct {
+	Pct       float64
+	Timestamp time.Time
+}
+
 type IOEvent struct {
 	Op        string // "read" | "write" | "fsync" | "openat" | "stat"
 	Path      string

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -65,6 +65,7 @@ type FDMsg []collector.FDEntry
 type CpuMsg collector.CpuSample
 type ThreadsMsg []collector.ThreadInfo
 type MemMsg collector.MemStats
+type IOWaitMsg collector.IOWaitSample
 
 // ─── Tipos auxiliares ────────────────────────────────────────────────────────
 
@@ -111,6 +112,7 @@ type Model struct {
 	cpuCollector     *collector.CPUCollector
 	threadsCollector *collector.ThreadsCollector
 	memCollector     *collector.MemCollector
+	iowaitCollector  *collector.IOWaitCollector
 
 	// Simulação
 	rng              *rand.Rand
@@ -119,6 +121,7 @@ type Model struct {
 	usingMockCPU     bool
 	usingMockThreads bool
 	usingMockMem     bool
+	usingMockIOWait  bool
 	lastSimAt        time.Time
 
 	// Caches estáveis para evitar reordenação visual entre ticks.
@@ -150,6 +153,7 @@ func NewModel(cfg Config) Model {
 		usingMockCPU:     true,
 		usingMockThreads: true,
 		usingMockMem:     true,
+		usingMockIOWait:  true,
 	}
 
 	m.seedMockData()
@@ -176,6 +180,10 @@ func NewModel(cfg Config) Model {
 			m.memCollector = c
 			m.usingMockMem = false
 		}
+		if c := collector.NewIOWaitCollector(); c.Start(cfg.PID) == nil {
+			m.iowaitCollector = c
+			m.usingMockIOWait = false
+		}
 	}
 
 	return m
@@ -196,6 +204,9 @@ func (m Model) Init() tea.Cmd {
 	}
 	if m.memCollector != nil {
 		cmds = append(cmds, waitForMem(m.memCollector))
+	}
+	if m.iowaitCollector != nil {
+		cmds = append(cmds, waitForIOWait(m.iowaitCollector))
 	}
 	return tea.Batch(cmds...)
 }
@@ -244,6 +255,11 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.MemStats = collector.MemStats(v)
 		m.usingMockMem = false
 		return m, waitForMem(m.memCollector)
+
+	case IOWaitMsg:
+		m.IOStats.IOWaitPct = collector.IOWaitSample(v).Pct
+		m.usingMockIOWait = false
+		return m, waitForIOWait(m.iowaitCollector)
 	}
 	return m, nil
 }
@@ -601,7 +617,9 @@ func (m *Model) tick() {
 	if r.Float64() > 0.7 {
 		m.IOStats.Opens++
 	}
-	m.IOStats.IOWaitPct = clamp(m.IOStats.IOWaitPct+(r.Float64()-0.5)*2, 0, 40)
+	if m.usingMockIOWait {
+		m.IOStats.IOWaitPct = clamp(m.IOStats.IOWaitPct+(r.Float64()-0.5)*2, 0, 40)
+	}
 
 	for i := range m.IOStats.TopFiles {
 		f := &m.IOStats.TopFiles[i]
@@ -795,6 +813,19 @@ func waitForMem(c *collector.MemCollector) tea.Cmd {
 		v := <-c.Subscribe()
 		if s, ok := v.(collector.MemStats); ok {
 			return MemMsg(s)
+		}
+		return TickMsg(time.Now())
+	}
+}
+
+func waitForIOWait(c *collector.IOWaitCollector) tea.Cmd {
+	if c == nil {
+		return nil
+	}
+	return func() tea.Msg {
+		v := <-c.Subscribe()
+		if s, ok := v.(collector.IOWaitSample); ok {
+			return IOWaitMsg(s)
 		}
 		return TickMsg(time.Now())
 	}


### PR DESCRIPTION
Closes #4.

Implementa o collector canônico de I/O wait per-process via `delayacct_blkio_ticks` (campo 42 de `/proc/<pid>/stat`).

## Mudanças

- `parseProcStatTimes` ganha retorno extra `blkio` (post[39] = campo 42); zero se kernel não exporta
- `internal/collector/iowait_proc.go` (500ms polling) → `IOWaitSample{Pct, Timestamp}`
- `IOWaitSample` em `types.go`
- Model: `IOWaitMsg`, flag `usingMockIOWait`, gate na simulação

## Verificação
- `go vet ./...` ok
- `go test ./...` PASS (14 testes — 2 novos: blkio presente + ausente em kernel curto)
- Build verde

## Limitações conhecidas
- Requer `CONFIG_TASK_DELAY_ACCT` (default em distros modernas)
- Kernel 5.14+ pode requerer boot param `delayacct=on` — quando não, collector publica 0% sem erro