### PR TITLE
collector: I/O throughput via /proc/<pid>/io

### DIFF
--- a/internal/collector/io_proc.go
+++ b/internal/collector/io_proc.go
@@ -1,0 +1,166 @@
+package collector
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+)
+
+// IOThroughputCollector lê /proc/<pid>/io a cada 500ms e calcula:
+//
+//   - ReadBytesPerS / WriteBytesPerS via delta de read_bytes / write_bytes
+//     (camada de storage — exclui hits de cache, mais coerente com `iotop`)
+//   - ReadOps / WriteOps cumulativos via syscr / syscw (camada de syscall)
+//
+// Observação: read_bytes/write_bytes só registra I/O que efetivamente toca o
+// dispositivo. Pra captar throughput "lógico" incluindo cache, usar
+// rchar/wchar — mas a camada lógica infla quando o processo relê o mesmo
+// arquivo várias vezes (cache hit), o que não é o que o usuário quer ver
+// no gráfico de throughput. read_bytes/write_bytes está mais alinhado com
+// o que o `iotop` reporta e com o que vai virar real-deal sob eBPF (#11).
+type IOThroughputCollector struct {
+	pid  int
+	ch   chan interface{}
+	stop chan struct{}
+	mu   sync.Mutex
+
+	lastReadBytes  uint64
+	lastWriteBytes uint64
+	lastAt         time.Time
+}
+
+func NewIOThroughputCollector() *IOThroughputCollector {
+	return &IOThroughputCollector{
+		ch:   make(chan interface{}, 16),
+		stop: make(chan struct{}),
+	}
+}
+
+func (c *IOThroughputCollector) Start(pid int) error {
+	c.pid = pid
+	if _, err := os.Stat(fmt.Sprintf("/proc/%d/io", pid)); err != nil {
+		// /proc/<pid>/io só está disponível pra processos do mesmo UID
+		// (ou root). Se não dá pra ler, falha imediato — modelo cai em mock.
+		return fmt.Errorf("não foi possível abrir /proc/%d/io: %w", pid, err)
+	}
+	go c.loop()
+	return nil
+}
+
+func (c *IOThroughputCollector) Stop()                          { close(c.stop) }
+func (c *IOThroughputCollector) Subscribe() <-chan interface{}  { return c.ch }
+
+func (c *IOThroughputCollector) loop() {
+	t := time.NewTicker(500 * time.Millisecond)
+	defer t.Stop()
+	for {
+		select {
+		case <-c.stop:
+			return
+		case <-t.C:
+			if s, err := c.sample(); err == nil {
+				select {
+				case c.ch <- s:
+				default:
+				}
+			}
+		}
+	}
+}
+
+func (c *IOThroughputCollector) sample() (IOThroughputSample, error) {
+	data, err := os.ReadFile(fmt.Sprintf("/proc/%d/io", c.pid))
+	if err != nil {
+		return IOThroughputSample{}, err
+	}
+	io, err := parseProcIO(data)
+	if err != nil {
+		return IOThroughputSample{}, err
+	}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	now := time.Now()
+	var rps, wps float64
+	if !c.lastAt.IsZero() {
+		elapsed := now.Sub(c.lastAt).Seconds()
+		if elapsed > 0 {
+			if io.readBytes >= c.lastReadBytes {
+				rps = float64(io.readBytes-c.lastReadBytes) / elapsed
+			}
+			if io.writeBytes >= c.lastWriteBytes {
+				wps = float64(io.writeBytes-c.lastWriteBytes) / elapsed
+			}
+		}
+	}
+	c.lastReadBytes = io.readBytes
+	c.lastWriteBytes = io.writeBytes
+	c.lastAt = now
+
+	return IOThroughputSample{
+		ReadBytesPerS:  rps,
+		WriteBytesPerS: wps,
+		ReadOps:        io.syscr,
+		WriteOps:       io.syscw,
+		Timestamp:      now,
+	}, nil
+}
+
+// procIOFields contém os campos de /proc/<pid>/io que nos interessam.
+// Formato canônico (1 par "key: value" por linha):
+//
+//	rchar: 1234
+//	wchar: 5678
+//	syscr: 100
+//	syscw: 50
+//	read_bytes: 4096
+//	write_bytes: 8192
+//	cancelled_write_bytes: 0
+type procIOFields struct {
+	rchar      uint64
+	wchar      uint64
+	syscr      uint64
+	syscw      uint64
+	readBytes  uint64
+	writeBytes uint64
+}
+
+func parseProcIO(data []byte) (procIOFields, error) {
+	var io procIOFields
+	parsed := 0
+	for _, line := range strings.Split(string(data), "\n") {
+		colon := strings.IndexByte(line, ':')
+		if colon < 0 {
+			continue
+		}
+		key := strings.TrimSpace(line[:colon])
+		value := strings.TrimSpace(line[colon+1:])
+		n, err := strconv.ParseUint(value, 10, 64)
+		if err != nil {
+			continue
+		}
+		switch key {
+		case "rchar":
+			io.rchar = n
+		case "wchar":
+			io.wchar = n
+		case "syscr":
+			io.syscr = n
+		case "syscw":
+			io.syscw = n
+		case "read_bytes":
+			io.readBytes = n
+		case "write_bytes":
+			io.writeBytes = n
+		}
+		parsed++
+	}
+	if parsed == 0 {
+		return io, fmt.Errorf("malformed /proc io: nenhum par chave:valor")
+	}
+	return io, nil
+}

--- a/internal/collector/io_proc_test.go
+++ b/internal/collector/io_proc_test.go
@@ -1,0 +1,66 @@
+package collector
+
+import "testing"
+
+const sampleProcIO = `rchar: 1024000
+wchar: 512000
+syscr: 250
+syscw: 100
+read_bytes: 819200
+write_bytes: 409600
+cancelled_write_bytes: 0
+`
+
+func TestParseProcIO_basic(t *testing.T) {
+	io, err := parseProcIO([]byte(sampleProcIO))
+	if err != nil {
+		t.Fatalf("erro: %v", err)
+	}
+	if io.rchar != 1024000 {
+		t.Errorf("rchar=%d", io.rchar)
+	}
+	if io.wchar != 512000 {
+		t.Errorf("wchar=%d", io.wchar)
+	}
+	if io.syscr != 250 {
+		t.Errorf("syscr=%d", io.syscr)
+	}
+	if io.syscw != 100 {
+		t.Errorf("syscw=%d", io.syscw)
+	}
+	if io.readBytes != 819200 {
+		t.Errorf("readBytes=%d", io.readBytes)
+	}
+	if io.writeBytes != 409600 {
+		t.Errorf("writeBytes=%d", io.writeBytes)
+	}
+}
+
+func TestParseProcIO_extraWhitespace(t *testing.T) {
+	// Algumas distros usam tab; algumas variantes têm espaço duplicado
+	noisy := "rchar:\t1000\n  wchar:    2000  \nsyscr:50\n"
+	io, err := parseProcIO([]byte(noisy))
+	if err != nil {
+		t.Fatalf("erro: %v", err)
+	}
+	if io.rchar != 1000 || io.wchar != 2000 || io.syscr != 50 {
+		t.Errorf("parsing tolerante falhou: rchar=%d wchar=%d syscr=%d", io.rchar, io.wchar, io.syscr)
+	}
+}
+
+func TestParseProcIO_malformed(t *testing.T) {
+	if _, err := parseProcIO([]byte("garbage no colons")); err == nil {
+		t.Error("esperava erro pra entrada sem pares chave:valor")
+	}
+}
+
+func TestParseProcIO_unknownFieldsIgnored(t *testing.T) {
+	mixed := "rchar: 100\nfuture_field: 999\nwchar: 200\n"
+	io, err := parseProcIO([]byte(mixed))
+	if err != nil {
+		t.Fatalf("erro: %v", err)
+	}
+	if io.rchar != 100 || io.wchar != 200 {
+		t.Errorf("campos conhecidos não parseados: rchar=%d wchar=%d", io.rchar, io.wchar)
+	}
+}

--- a/internal/collector/types.go
+++ b/internal/collector/types.go
@@ -59,6 +59,18 @@ type IOWaitSample struct {
 	Timestamp time.Time
 }
 
+// IOThroughputSample é o snapshot do throughput de I/O do processo no último
+// intervalo. ReadBytesPerS/WriteBytesPerS são taxas instantâneas; ReadOps/
+// WriteOps são CUMULATIVOS desde o início do processo (mesma semântica de
+// /proc/<pid>/io). Calculado pelo collector que lê /proc/<pid>/io.
+type IOThroughputSample struct {
+	ReadBytesPerS  float64
+	WriteBytesPerS float64
+	ReadOps        uint64
+	WriteOps       uint64
+	Timestamp      time.Time
+}
+
 type IOEvent struct {
 	Op        string // "read" | "write" | "fsync" | "openat" | "stat"
 	Path      string

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -66,6 +66,7 @@ type CpuMsg collector.CpuSample
 type ThreadsMsg []collector.ThreadInfo
 type MemMsg collector.MemStats
 type IOWaitMsg collector.IOWaitSample
+type IOThroughputMsg collector.IOThroughputSample
 
 // ─── Tipos auxiliares ────────────────────────────────────────────────────────
 
@@ -112,17 +113,19 @@ type Model struct {
 	cpuCollector     *collector.CPUCollector
 	threadsCollector *collector.ThreadsCollector
 	memCollector     *collector.MemCollector
-	iowaitCollector  *collector.IOWaitCollector
+	iowaitCollector     *collector.IOWaitCollector
+	ioThroughputCollector *collector.IOThroughputCollector
 
 	// Simulação
-	rng              *rand.Rand
-	tickN            int
-	usingMockFDs     bool
-	usingMockCPU     bool
-	usingMockThreads bool
-	usingMockMem     bool
-	usingMockIOWait  bool
-	lastSimAt        time.Time
+	rng                 *rand.Rand
+	tickN               int
+	usingMockFDs        bool
+	usingMockCPU        bool
+	usingMockThreads    bool
+	usingMockMem        bool
+	usingMockIOWait     bool
+	usingMockIOThrough  bool
+	lastSimAt           time.Time
 
 	// Caches estáveis para evitar reordenação visual entre ticks.
 	// topSyscallNames é recomputado a cada `topRefreshInterval`; entre refreshes
@@ -153,7 +156,8 @@ func NewModel(cfg Config) Model {
 		usingMockCPU:     true,
 		usingMockThreads: true,
 		usingMockMem:     true,
-		usingMockIOWait:  true,
+		usingMockIOWait:    true,
+		usingMockIOThrough: true,
 	}
 
 	m.seedMockData()
@@ -184,6 +188,10 @@ func NewModel(cfg Config) Model {
 			m.iowaitCollector = c
 			m.usingMockIOWait = false
 		}
+		if c := collector.NewIOThroughputCollector(); c.Start(cfg.PID) == nil {
+			m.ioThroughputCollector = c
+			m.usingMockIOThrough = false
+		}
 	}
 
 	return m
@@ -207,6 +215,9 @@ func (m Model) Init() tea.Cmd {
 	}
 	if m.iowaitCollector != nil {
 		cmds = append(cmds, waitForIOWait(m.iowaitCollector))
+	}
+	if m.ioThroughputCollector != nil {
+		cmds = append(cmds, waitForIOThroughput(m.ioThroughputCollector))
 	}
 	return tea.Batch(cmds...)
 }
@@ -260,6 +271,25 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.IOStats.IOWaitPct = collector.IOWaitSample(v).Pct
 		m.usingMockIOWait = false
 		return m, waitForIOWait(m.iowaitCollector)
+
+	case IOThroughputMsg:
+		s := collector.IOThroughputSample(v)
+		m.IOStats.ReadBytesPerS = s.ReadBytesPerS
+		m.IOStats.WriteBytesPerS = s.WriteBytesPerS
+		m.IOStats.ReadOps = s.ReadOps
+		m.IOStats.WriteOps = s.WriteOps
+		m.IOReadHist = appendCapped(m.IOReadHist, s.ReadBytesPerS, 60)
+		m.IOWriteHist = appendCapped(m.IOWriteHist, s.WriteBytesPerS, 60)
+		m.ioMaxRead = math.Max(m.ioMaxRead*0.97, s.ReadBytesPerS)
+		m.ioMaxWrite = math.Max(m.ioMaxWrite*0.97, s.WriteBytesPerS)
+		if m.ioMaxRead < 100*1024 {
+			m.ioMaxRead = 100 * 1024
+		}
+		if m.ioMaxWrite < 100*1024 {
+			m.ioMaxWrite = 100 * 1024
+		}
+		m.usingMockIOThrough = false
+		return m, waitForIOThroughput(m.ioThroughputCollector)
 	}
 	return m, nil
 }
@@ -583,34 +613,36 @@ func (m *Model) tick() {
 		}
 	}
 
-	// I/O throughput
-	nr := r.Float64() * 1200 * 1024
-	if r.Float64() > 0.85 {
-		nr += 2000 * 1024
-	}
-	nw := r.Float64() * 600 * 1024
-	if r.Float64() > 0.9 {
-		nw += 1500 * 1024
-	}
-	m.IOReadHist = appendCapped(m.IOReadHist, nr, 60)
-	m.IOWriteHist = appendCapped(m.IOWriteHist, nw, 60)
-	m.IOStats.ReadBytesPerS = nr
-	m.IOStats.WriteBytesPerS = nw
+	// I/O throughput — só simula se collector real não está rodando
+	if m.usingMockIOThrough {
+		nr := r.Float64() * 1200 * 1024
+		if r.Float64() > 0.85 {
+			nr += 2000 * 1024
+		}
+		nw := r.Float64() * 600 * 1024
+		if r.Float64() > 0.9 {
+			nw += 1500 * 1024
+		}
+		m.IOReadHist = appendCapped(m.IOReadHist, nr, 60)
+		m.IOWriteHist = appendCapped(m.IOWriteHist, nw, 60)
+		m.IOStats.ReadBytesPerS = nr
+		m.IOStats.WriteBytesPerS = nw
 
-	// Máximo "decay": cresce no instante do pico e cai 3% por tick.
-	// Isso evita rescale brusco do sparkline cada vez que aparece um valor
-	// alto isolado e depois some.
-	const decayPerTick = 0.97
-	m.ioMaxRead = math.Max(m.ioMaxRead*decayPerTick, nr)
-	m.ioMaxWrite = math.Max(m.ioMaxWrite*decayPerTick, nw)
-	if m.ioMaxRead < 100*1024 { // piso visual: 100KB/s
-		m.ioMaxRead = 100 * 1024
+		// Máximo "decay": cresce no instante do pico e cai 3% por tick.
+		// Isso evita rescale brusco do sparkline cada vez que aparece um valor
+		// alto isolado e depois some.
+		const decayPerTick = 0.97
+		m.ioMaxRead = math.Max(m.ioMaxRead*decayPerTick, nr)
+		m.ioMaxWrite = math.Max(m.ioMaxWrite*decayPerTick, nw)
+		if m.ioMaxRead < 100*1024 { // piso visual: 100KB/s
+			m.ioMaxRead = 100 * 1024
+		}
+		if m.ioMaxWrite < 100*1024 {
+			m.ioMaxWrite = 100 * 1024
+		}
+		m.IOStats.ReadOps += uint64(r.Intn(12))
+		m.IOStats.WriteOps += uint64(r.Intn(6))
 	}
-	if m.ioMaxWrite < 100*1024 {
-		m.ioMaxWrite = 100 * 1024
-	}
-	m.IOStats.ReadOps += uint64(r.Intn(12))
-	m.IOStats.WriteOps += uint64(r.Intn(6))
 	if r.Float64() > 0.8 {
 		m.IOStats.Fsyncs++
 	}
@@ -826,6 +858,19 @@ func waitForIOWait(c *collector.IOWaitCollector) tea.Cmd {
 		v := <-c.Subscribe()
 		if s, ok := v.(collector.IOWaitSample); ok {
 			return IOWaitMsg(s)
+		}
+		return TickMsg(time.Now())
+	}
+}
+
+func waitForIOThroughput(c *collector.IOThroughputCollector) tea.Cmd {
+	if c == nil {
+		return nil
+	}
+	return func() tea.Msg {
+		v := <-c.Subscribe()
+		if s, ok := v.(collector.IOThroughputSample); ok {
+			return IOThroughputMsg(s)
 		}
 		return TickMsg(time.Now())
 	}


### PR DESCRIPTION
Closes #5.

## Mudanças

- `io_proc.go` (500ms polling) → `IOThroughputSample`
- `IOThroughputSample` em types.go (ReadBytesPerS/WriteBytesPerS/ReadOps/WriteOps/Timestamp)
- Model: `IOThroughputMsg`, flag `usingMockIOThrough`, gate na sim
- Quando msg real chega, atualiza `IOReadHist`/`IOWriteHist` + decay dos máximos

## Decisão de design

Uso `read_bytes`/`write_bytes` (storage layer, exclui cache hits) em vez de `rchar`/`wchar` (syscall layer). Mais alinhado com `iotop` e com o que vai entrar via eBPF na #11. Quando re-leitura de cache importa, dá pra adicionar uma view alternativa depois.

## Verificação
- `go vet ./...` ok
- `go test ./...` PASS (18 testes — 4 novos no parser)
- Build verde