### PR TITLE
collector: real FDs — socket resolver, bytes/active, open/close events

### DIFF
--- a/internal/collector/fds.go
+++ b/internal/collector/fds.go
@@ -10,21 +10,39 @@ import (
 	"time"
 )
 
-// FDCollector lê /proc/{pid}/fd e /proc/{pid}/fdinfo sem precisar de eBPF.
-// É o primeiro collector a implementar — funciona sem root.
+// FDCollector lê /proc/<pid>/fd e /proc/<pid>/fdinfo a cada 500ms.
+// Funciona sem root, sem eBPF — primeiro collector implementado.
+//
+// Publica três tipos de mensagem na mesma channel (consumidor faz
+// type-switch):
+//
+//   - []FDEntry           — snapshot completo do estado atual (cada poll)
+//   - TimelineEvent       — evento "openat fd=N <desc>" / "close fd=N" pra timeline global
+//   - FDEvent             — versão compacta dedicada à F6 ▸ FD Events
 type FDCollector struct {
 	pid      int
 	ch       chan interface{}
 	stop     chan struct{}
 	mu       sync.Mutex
-	baseline map[int]time.Time // fd → tempo de abertura estimado
+	resolver *SocketResolver
+
+	// estado entre polls
+	baseline map[int]fdState // fd → estado da última observação
+}
+
+type fdState struct {
+	openedAt time.Time
+	pos      uint64 // /proc/<pid>/fdinfo/<fd> campo "pos:" — usado pra detectar atividade
+	desc     string // descrição estável (path do file ou TCP IP:port resolvido)
+	fdType   string
 }
 
 func NewFDCollector() *FDCollector {
 	return &FDCollector{
-		ch:       make(chan interface{}, 64),
+		ch:       make(chan interface{}, 128),
 		stop:     make(chan struct{}),
-		baseline: make(map[int]time.Time),
+		baseline: make(map[int]fdState),
+		resolver: NewSocketResolver(),
 	}
 }
 
@@ -48,34 +66,56 @@ func (c *FDCollector) Subscribe() <-chan interface{} {
 func (c *FDCollector) loop() {
 	ticker := time.NewTicker(500 * time.Millisecond)
 	defer ticker.Stop()
+	// Primeira coleta imediata pra UI não esperar 500ms pra mostrar nada
+	c.collectAndEmit()
 	for {
 		select {
 		case <-c.stop:
 			return
 		case <-ticker.C:
-			if fds, err := c.collect(); err == nil {
-				select {
-				case c.ch <- fds:
-				default:
-				}
-			}
+			c.collectAndEmit()
 		}
 	}
 }
 
-func (c *FDCollector) collect() ([]FDEntry, error) {
+// collectAndEmit faz um snapshot e emite os 3 tipos de mensagem na channel.
+// Eventos (open/close) são emitidos ANTES do snapshot para que a UI tenha o
+// histórico antes de re-renderizar a tabela com o estado novo.
+func (c *FDCollector) collectAndEmit() {
+	fds, events, err := c.collect()
+	if err != nil {
+		return
+	}
+	for _, e := range events {
+		c.emit(e)
+	}
+	c.emit(fds)
+}
+
+func (c *FDCollector) emit(msg interface{}) {
+	select {
+	case c.ch <- msg:
+	default:
+		// canal cheio; descarta. UI vai pegar a próxima rodada.
+	}
+}
+
+// collect retorna o snapshot atual + eventos (open/close) detectados desde o
+// último poll.
+func (c *FDCollector) collect() ([]FDEntry, []interface{}, error) {
 	fdDir := fmt.Sprintf("/proc/%d/fd", c.pid)
 	entries, err := os.ReadDir(fdDir)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
 	now := time.Now()
-	seen := make(map[int]bool)
-	var result []FDEntry
+	seen := make(map[int]bool, len(entries))
+	result := make([]FDEntry, 0, len(entries))
+	events := make([]interface{}, 0)
 
 	for _, e := range entries {
 		fdNum, err := strconv.Atoi(e.Name())
@@ -84,30 +124,79 @@ func (c *FDCollector) collect() ([]FDEntry, error) {
 		}
 		seen[fdNum] = true
 
-		// registra tempo de abertura na primeira vez que vemos o fd
-		if _, ok := c.baseline[fdNum]; !ok {
-			c.baseline[fdNum] = now
+		link, _ := os.Readlink(filepath.Join(fdDir, e.Name()))
+		fdType := inferType(fdNum, link)
+		desc := c.describeLink(link)
+		flags := readFlags(c.pid, fdNum)
+		pos := readFDPos(c.pid, fdNum)
+
+		prev, hadPrev := c.baseline[fdNum]
+		// Detecta nova abertura (FD não estava no baseline OU mudou de descrição
+		// — caso de dup2 que reusa o número)
+		if !hadPrev {
+			openedAt := now
+			c.baseline[fdNum] = fdState{
+				openedAt: openedAt,
+				pos:      pos,
+				desc:     desc,
+				fdType:   fdType,
+			}
+			prev = c.baseline[fdNum]
+			events = append(events,
+				FDEvent{Timestamp: now, Message: fmt.Sprintf("openat fd=%d %s", fdNum, desc)},
+				TimelineEvent{Timestamp: now, Category: "fd", Message: fmt.Sprintf("openat → fd=%d %s", fdNum, desc)},
+			)
+		} else if prev.desc != desc {
+			// FD foi reusado (dup2/openat depois de close) — emit close+open
+			events = append(events,
+				FDEvent{Timestamp: now, Message: fmt.Sprintf("reuse fd=%d %s → %s", fdNum, prev.desc, desc)},
+				TimelineEvent{Timestamp: now, Category: "fd", Message: fmt.Sprintf("dup/reuse fd=%d → %s", fdNum, desc)},
+			)
+			c.baseline[fdNum] = fdState{
+				openedAt: now,
+				pos:      pos,
+				desc:     desc,
+				fdType:   fdType,
+			}
+			prev = c.baseline[fdNum]
 		}
 
-		link, _ := os.Readlink(filepath.Join(fdDir, e.Name()))
-		entry := FDEntry{
-			FD:    fdNum,
-			Type:  inferType(fdNum, link),
-			Desc:  describeLink(link),
-			Flags: readFlags(c.pid, fdNum),
-			AgeMs: now.Sub(c.baseline[fdNum]).Milliseconds(),
+		// Active = mudança de pos desde último poll. Faz sentido pra files;
+		// pra sockets/pipes pos é constante 0, então Active fica false.
+		// (eBPF futura via #11 vai dar Active correto pra qualquer fd type.)
+		active := pos != prev.pos
+		c.baseline[fdNum] = fdState{
+			openedAt: prev.openedAt,
+			pos:      pos,
+			desc:     desc,
+			fdType:   fdType,
 		}
-		result = append(result, entry)
+
+		bytes := pos // pra sockets/pipes ignora-se; pra files é cumulative pos
+
+		result = append(result, FDEntry{
+			FD:     fdNum,
+			Type:   fdType,
+			Desc:   desc,
+			Flags:  flags,
+			Bytes:  bytes,
+			AgeMs:  now.Sub(prev.openedAt).Milliseconds(),
+			Active: active,
+		})
 	}
 
-	// limpa baseline de fds que foram fechados
-	for fd := range c.baseline {
+	// Detecta closes (FDs que estavam no baseline e sumiram)
+	for fd, prev := range c.baseline {
 		if !seen[fd] {
+			events = append(events,
+				FDEvent{Timestamp: now, Message: fmt.Sprintf("close fd=%d %s", fd, prev.desc)},
+				TimelineEvent{Timestamp: now, Category: "fd", Message: fmt.Sprintf("close fd=%d %s", fd, prev.desc)},
+			)
 			delete(c.baseline, fd)
 		}
 	}
 
-	return result, nil
+	return result, events, nil
 }
 
 func inferType(fd int, link string) string {
@@ -129,12 +218,20 @@ func inferType(fd int, link string) string {
 	}
 }
 
-func describeLink(link string) string {
+// describeLink resolve o link de /proc/<pid>/fd/<n> em uma descrição legível.
+// Sockets viram "TCP 127.0.0.1:8080" via SocketResolver. Outros casos passam
+// direto.
+func (c *FDCollector) describeLink(link string) string {
 	if link == "" {
 		return "(unknown)"
 	}
-	// para sockets o link é "socket:[inode]" — idealmente resolvemos via /proc/net/tcp
-	// por agora retorna o link diretamente
+	if inode, ok := extractSocketInode(link); ok {
+		if info, ok := c.resolver.Resolve(inode); ok {
+			return fmt.Sprintf("%s %s", info.Family, info.Remote)
+		}
+		// fallback enquanto socket não está resolvido (cache stale ou inode estranho)
+		return link
+	}
 	return link
 }
 
@@ -158,4 +255,22 @@ func readFlags(pid, fd int) string {
 		}
 	}
 	return ""
+}
+
+// readFDPos extrai o campo "pos:" de /proc/<pid>/fdinfo/<fd>.
+// Para arquivos seekable é o offset cumulativo do file pointer; pra
+// sockets/pipes é 0 e não muda. Usado pelo collector pra inferir Active.
+func readFDPos(pid, fd int) uint64 {
+	data, err := os.ReadFile(fmt.Sprintf("/proc/%d/fdinfo/%d", pid, fd))
+	if err != nil {
+		return 0
+	}
+	for _, line := range strings.Split(string(data), "\n") {
+		if strings.HasPrefix(line, "pos:") {
+			s := strings.TrimSpace(strings.TrimPrefix(line, "pos:"))
+			n, _ := strconv.ParseUint(s, 10, 64)
+			return n
+		}
+	}
+	return 0
 }

--- a/internal/collector/sockets.go
+++ b/internal/collector/sockets.go
@@ -1,0 +1,281 @@
+package collector
+
+import (
+	"encoding/hex"
+	"fmt"
+	"net"
+	"os"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+)
+
+// SocketInfo descreve um socket resolvido a partir de /proc/net/*.
+// Family: "TCP", "UDP", "UNIX". Remote: "10.0.1.5:5432" para inet,
+// "/var/run/docker.sock" para unix.
+type SocketInfo struct {
+	Family string
+	Remote string
+	State  string // "ESTABLISHED" | "LISTEN" | ... | "" para UNIX
+}
+
+// SocketResolver mantém um map inode→SocketInfo populado dos arquivos
+// /proc/net/*. Chamadas a Resolve com cache stale acionam refresh.
+//
+// Não é exposto como collector — é usado dentro do FDCollector.
+// Cache TTL: 2s. Sob alta rotatividade de conexões pode aparecer
+// "(socket:[N])" no lugar de TCP IP:port nos primeiros 1-2 polls.
+type SocketResolver struct {
+	mu       sync.Mutex
+	cache    map[uint64]SocketInfo
+	cachedAt time.Time
+	ttl      time.Duration
+}
+
+func NewSocketResolver() *SocketResolver {
+	return &SocketResolver{
+		cache: make(map[uint64]SocketInfo),
+		ttl:   2 * time.Second,
+	}
+}
+
+// Resolve devolve a SocketInfo do inode, atualizando o cache se stale.
+// Se o inode não está no map, retorna SocketInfo{} e ok=false.
+func (r *SocketResolver) Resolve(inode uint64) (SocketInfo, bool) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if time.Since(r.cachedAt) > r.ttl {
+		r.refreshLocked()
+		r.cachedAt = time.Now()
+	}
+	info, ok := r.cache[inode]
+	return info, ok
+}
+
+func (r *SocketResolver) refreshLocked() {
+	r.cache = make(map[uint64]SocketInfo, len(r.cache))
+	parseInetFile("/proc/net/tcp", "TCP", true, r.cache)
+	parseInetFile("/proc/net/tcp6", "TCP", false, r.cache)
+	parseInetFile("/proc/net/udp", "UDP", true, r.cache)
+	parseInetFile("/proc/net/udp6", "UDP", false, r.cache)
+	parseUnixFile("/proc/net/unix", r.cache)
+}
+
+// ─── /proc/net/{tcp,tcp6,udp,udp6} ───────────────────────────────────────────
+//
+// Formato (header + 1 conexão por linha):
+//   sl  local_address       rem_address         st  ...  inode  ...
+//   0:  0100007F:1F90       00000000:0000       0A  ...  12345  ...
+//
+// Address: hex IP em little-endian (IPv4) ou 4×u32 little-endian (IPv6),
+// seguido de `:` e porta em hex.
+
+var tcpStates = map[string]string{
+	"01": "ESTABLISHED",
+	"02": "SYN_SENT",
+	"03": "SYN_RECV",
+	"04": "FIN_WAIT1",
+	"05": "FIN_WAIT2",
+	"06": "TIME_WAIT",
+	"07": "CLOSE",
+	"08": "CLOSE_WAIT",
+	"09": "LAST_ACK",
+	"0A": "LISTEN",
+	"0B": "CLOSING",
+}
+
+func parseInetFile(path, family string, ipv4 bool, out map[uint64]SocketInfo) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return
+	}
+	lines := strings.Split(string(data), "\n")
+	for i, line := range lines {
+		if i == 0 || line == "" { // pula header
+			continue
+		}
+		fields := strings.Fields(line)
+		// Mínimo: sl local rem st tx:rx tr:retr uid timeout inode
+		if len(fields) < 10 {
+			continue
+		}
+		// fields[0] = "0:" — ignorado
+		localAddr := fields[1]
+		remAddr := fields[2]
+		stHex := strings.ToUpper(fields[3])
+		inode, err := strconv.ParseUint(fields[9], 10, 64)
+		if err != nil {
+			continue
+		}
+		// Pula sockets sem inode (estados intermediários do kernel)
+		if inode == 0 {
+			continue
+		}
+
+		state := tcpStates[stHex]
+		if family == "UDP" {
+			state = "" // UDP não tem state TCP — deixa em branco
+		}
+
+		// Remote priorizado; LISTEN não tem remote válido, então mostramos
+		// o local com prefixo "*:" para sinalizar bind.
+		var remote string
+		switch {
+		case stHex == "0A": // LISTEN
+			remote = "*:" + parsePort(localAddr) + " (listen)"
+		default:
+			remote = parseInetAddr(remAddr, ipv4)
+			if remote == "0.0.0.0:0" || remote == "[::]:0" {
+				// Sem peer ainda; mostra local
+				remote = parseInetAddr(localAddr, ipv4)
+			}
+		}
+
+		out[inode] = SocketInfo{
+			Family: family,
+			Remote: remote,
+			State:  state,
+		}
+	}
+}
+
+// parseInetAddr converte "0100007F:1F90" → "127.0.0.1:8080" (ipv4)
+// ou um endereço hexa de 32 chars + ":" + porta para ipv6.
+func parseInetAddr(s string, ipv4 bool) string {
+	colon := strings.LastIndexByte(s, ':')
+	if colon < 0 {
+		return s
+	}
+	addrHex := s[:colon]
+	portStr := parsePortStr(s[colon+1:])
+
+	if ipv4 {
+		ip := parseIPv4Hex(addrHex)
+		return ip + ":" + portStr
+	}
+	ip := parseIPv6Hex(addrHex)
+	return "[" + ip + "]:" + portStr
+}
+
+func parsePort(s string) string {
+	colon := strings.LastIndexByte(s, ':')
+	if colon < 0 {
+		return ""
+	}
+	return parsePortStr(s[colon+1:])
+}
+
+func parsePortStr(hexStr string) string {
+	port, err := strconv.ParseUint(hexStr, 16, 32)
+	if err != nil {
+		return "?"
+	}
+	return strconv.FormatUint(port, 10)
+}
+
+// parseIPv4Hex: 0100007F → 127.0.0.1 (kernel escreve em little-endian byte order)
+func parseIPv4Hex(s string) string {
+	if len(s) != 8 {
+		return s
+	}
+	bytes, err := hex.DecodeString(s)
+	if err != nil || len(bytes) != 4 {
+		return s
+	}
+	// inverte byte order
+	return fmt.Sprintf("%d.%d.%d.%d", bytes[3], bytes[2], bytes[1], bytes[0])
+}
+
+// parseIPv6Hex: 4×u32 little-endian em sequência → IPv6 canônico
+func parseIPv6Hex(s string) string {
+	if len(s) != 32 {
+		return s
+	}
+	bytes, err := hex.DecodeString(s)
+	if err != nil || len(bytes) != 16 {
+		return s
+	}
+	// Reverte cada grupo de 4 bytes para big-endian
+	swapped := make([]byte, 16)
+	for i := 0; i < 4; i++ {
+		swapped[i*4+0] = bytes[i*4+3]
+		swapped[i*4+1] = bytes[i*4+2]
+		swapped[i*4+2] = bytes[i*4+1]
+		swapped[i*4+3] = bytes[i*4+0]
+	}
+	return net.IP(swapped).String()
+}
+
+// ─── /proc/net/unix ──────────────────────────────────────────────────────────
+//
+// Formato:
+//   Num       RefCount Protocol Flags    Type St Inode Path
+//   00000000: 00000002 00000000 00010000 0001 01 12345 /var/run/docker.sock
+
+var unixStates = map[string]string{
+	"01": "FREE",
+	"02": "UNCONNECTED",
+	"03": "CONNECTING",
+	"04": "CONNECTED",
+	"05": "DISCONNECTING",
+}
+
+func parseUnixFile(path string, out map[uint64]SocketInfo) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return
+	}
+	lines := strings.Split(string(data), "\n")
+	for i, line := range lines {
+		if i == 0 || line == "" {
+			continue
+		}
+		fields := strings.Fields(line)
+		// Pode ter 7 (sem path) ou 8 (com path) campos
+		if len(fields) < 7 {
+			continue
+		}
+		inode, err := strconv.ParseUint(fields[6], 10, 64)
+		if err != nil || inode == 0 {
+			continue
+		}
+		path := ""
+		if len(fields) >= 8 {
+			path = strings.Join(fields[7:], " ")
+		}
+		stHex := strings.ToUpper(fields[5])
+		state := unixStates[stHex]
+
+		remote := path
+		if remote == "" {
+			remote = "(anon)"
+		}
+		out[inode] = SocketInfo{
+			Family: "UNIX",
+			Remote: remote,
+			State:  state,
+		}
+	}
+}
+
+// ─── helper exposto pro FDCollector ──────────────────────────────────────────
+
+// extractSocketInode extrai o inode de um link "socket:[12345]".
+// Retorna 0 e false se o formato não bate.
+func extractSocketInode(link string) (uint64, bool) {
+	const prefix = "socket:["
+	if !strings.HasPrefix(link, prefix) {
+		return 0, false
+	}
+	end := strings.IndexByte(link[len(prefix):], ']')
+	if end < 0 {
+		return 0, false
+	}
+	n, err := strconv.ParseUint(link[len(prefix):len(prefix)+end], 10, 64)
+	if err != nil {
+		return 0, false
+	}
+	return n, true
+}

--- a/internal/collector/sockets_test.go
+++ b/internal/collector/sockets_test.go
@@ -1,0 +1,131 @@
+package collector
+
+import (
+	"os"
+	"testing"
+)
+
+func TestParseIPv4Hex(t *testing.T) {
+	cases := map[string]string{
+		"0100007F": "127.0.0.1",
+		"0101A8C0": "192.168.1.1",
+		"00000000": "0.0.0.0",
+	}
+	for hex, want := range cases {
+		if got := parseIPv4Hex(hex); got != want {
+			t.Errorf("parseIPv4Hex(%q)=%q, esperado %q", hex, got, want)
+		}
+	}
+}
+
+func TestParseIPv6Hex_loopback(t *testing.T) {
+	// ::1 em little-endian por grupo de 4 bytes
+	hex := "00000000000000000000000001000000"
+	got := parseIPv6Hex(hex)
+	if got != "::1" {
+		t.Errorf("parseIPv6Hex(::1)=%q", got)
+	}
+}
+
+func TestParsePortStr(t *testing.T) {
+	cases := map[string]string{
+		"1F90": "8080",
+		"01BB": "443",
+		"0050": "80",
+	}
+	for hex, want := range cases {
+		if got := parsePortStr(hex); got != want {
+			t.Errorf("parsePortStr(%q)=%q, esperado %q", hex, got, want)
+		}
+	}
+}
+
+func TestExtractSocketInode(t *testing.T) {
+	cases := []struct {
+		link    string
+		want    uint64
+		wantOk  bool
+	}{
+		{"socket:[12345]", 12345, true},
+		{"socket:[0]", 0, true},
+		{"pipe:[999]", 0, false},
+		{"socket:[abc]", 0, false},
+		{"", 0, false},
+	}
+	for _, c := range cases {
+		got, ok := extractSocketInode(c.link)
+		if got != c.want || ok != c.wantOk {
+			t.Errorf("extractSocketInode(%q)=(%d,%v), esperado (%d,%v)",
+				c.link, got, ok, c.want, c.wantOk)
+		}
+	}
+}
+
+const sampleProcNetTCP = `  sl  local_address rem_address   st tx_queue rx_queue tr tm->when retrnsmt   uid  timeout inode
+   0: 0100007F:1F90 0100007F:E96A 01 00000000:00000000 00:00000000 00000000  1000        0 11111 1 0000000000000000 100 0 0 10 0
+   1: 00000000:1F40 00000000:0000 0A 00000000:00000000 00:00000000 00000000  1000        0 22222 1 0000000000000000 100 0 0 10 0
+`
+
+func TestParseInetFile_tcp(t *testing.T) {
+	tmp := t.TempDir() + "/tcp"
+	if err := writeFileForTest(tmp, sampleProcNetTCP); err != nil {
+		t.Fatal(err)
+	}
+	out := make(map[uint64]SocketInfo)
+	parseInetFile(tmp, "TCP", true, out)
+
+	if len(out) != 2 {
+		t.Fatalf("esperava 2 entradas, got %d", len(out))
+	}
+	if est := out[11111]; est.Family != "TCP" || est.State != "ESTABLISHED" {
+		t.Errorf("inode 11111 esperado ESTABLISHED TCP, got %+v", est)
+	}
+	if est := out[11111]; est.Remote != "127.0.0.1:59754" {
+		t.Errorf("remote inode 11111: got %q", est.Remote)
+	}
+	if lst := out[22222]; lst.State != "LISTEN" {
+		t.Errorf("inode 22222 esperado LISTEN, got %+v", lst)
+	}
+	if !contains(out[22222].Remote, "8000") {
+		t.Errorf("LISTEN deve mostrar porta local 8000, got %q", out[22222].Remote)
+	}
+}
+
+const sampleProcNetUnix = `Num       RefCount Protocol Flags    Type St Inode Path
+00000000: 00000002 00000000 00010000 0001 01 33333 /var/run/docker.sock
+00000000: 00000002 00000000 00010000 0001 01 44444
+`
+
+func TestParseUnixFile(t *testing.T) {
+	tmp := t.TempDir() + "/unix"
+	if err := writeFileForTest(tmp, sampleProcNetUnix); err != nil {
+		t.Fatal(err)
+	}
+	out := make(map[uint64]SocketInfo)
+	parseUnixFile(tmp, out)
+
+	if len(out) != 2 {
+		t.Fatalf("esperava 2 entradas, got %d", len(out))
+	}
+	if got := out[33333]; got.Family != "UNIX" || got.Remote != "/var/run/docker.sock" {
+		t.Errorf("inode 33333: %+v", got)
+	}
+	if got := out[44444]; got.Remote != "(anon)" {
+		t.Errorf("inode anônimo: esperava (anon), got %q", got.Remote)
+	}
+}
+
+// helpers
+
+func writeFileForTest(path, content string) error {
+	return os.WriteFile(path, []byte(content), 0644)
+}
+
+func contains(haystack, needle string) bool {
+	for i := 0; i+len(needle) <= len(haystack); i++ {
+		if haystack[i:i+len(needle)] == needle {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/collector/types.go
+++ b/internal/collector/types.go
@@ -109,6 +109,14 @@ type LatencyBucket struct {
 
 // ─── File Descriptors ────────────────────────────────────────────────────────
 
+// FDEvent é um evento granular do stream de FDs (openat/close/dup2/...).
+// Diferente do snapshot []FDEntry que é o estado atual completo, FDEvent
+// é uma notificação de mudança — usado pra alimentar a F6 ▸ FD Events.
+type FDEvent struct {
+	Timestamp time.Time
+	Message   string
+}
+
 type FDEntry struct {
 	FD     int
 	Type   string // "file" | "socket" | "pipe" | "epoll" | "timer" | "event"

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -67,14 +67,8 @@ type ThreadsMsg []collector.ThreadInfo
 type MemMsg collector.MemStats
 type IOWaitMsg collector.IOWaitSample
 type IOThroughputMsg collector.IOThroughputSample
-
-// ─── Tipos auxiliares ────────────────────────────────────────────────────────
-
-// FDEvent é um evento do stream de FDs (openat/close/dup2/...).
-type FDEvent struct {
-	Timestamp time.Time
-	Message   string
-}
+type TimelineMsg collector.TimelineEvent
+type FDEventMsg collector.FDEvent
 
 // ─── Model ───────────────────────────────────────────────────────────────────
 
@@ -98,7 +92,7 @@ type Model struct {
 	IOWriteHist    []float64
 	FDs            []collector.FDEntry
 	FDCountHistory []float64
-	FDEvents       []FDEvent
+	FDEvents       []collector.FDEvent
 	Timeline       []collector.TimelineEvent
 
 	// Estado da UI
@@ -249,6 +243,22 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.FDs = []collector.FDEntry(v)
 		m.usingMockFDs = false
 		m.FDCountHistory = appendCapped(m.FDCountHistory, float64(len(m.FDs)), 60)
+		return m, waitForFD(m.fdCollector)
+
+	case TimelineMsg:
+		// Timeline é prepend; mais recente em cima. Cap em 120 (mesmo limite
+		// usado pela simulação).
+		m.Timeline = append([]collector.TimelineEvent{collector.TimelineEvent(v)}, m.Timeline...)
+		if len(m.Timeline) > 120 {
+			m.Timeline = m.Timeline[:120]
+		}
+		return m, waitForFD(m.fdCollector)
+
+	case FDEventMsg:
+		m.FDEvents = append([]collector.FDEvent{collector.FDEvent(v)}, m.FDEvents...)
+		if len(m.FDEvents) > 60 {
+			m.FDEvents = m.FDEvents[:60]
+		}
 		return m, waitForFD(m.fdCollector)
 
 	case CpuMsg:
@@ -491,7 +501,7 @@ func (m *Model) seedMockData() {
 
 	// Timeline (semeada vazia — vai sendo preenchida pelo tick)
 	m.Timeline = make([]collector.TimelineEvent, 0, 120)
-	m.FDEvents = make([]FDEvent, 0, 60)
+	m.FDEvents = make([]collector.FDEvent, 0, 60)
 
 	// Inicializa caches estáveis e máximos com decay
 	m.refreshTopN()
@@ -780,7 +790,7 @@ func (m *Model) maybePushFDEvent() {
 		func() string { return fmt.Sprintf("fcntl fd=%d F_SETFL O_NONBLOCK", r.Intn(8)+3) },
 	}
 	t := templates[r.Intn(len(templates))]
-	m.FDEvents = append([]FDEvent{{Timestamp: time.Now(), Message: t()}}, m.FDEvents...)
+	m.FDEvents = append([]collector.FDEvent{{Timestamp: time.Now(), Message: t()}}, m.FDEvents...)
 	if len(m.FDEvents) > 60 {
 		m.FDEvents = m.FDEvents[:60]
 	}
@@ -797,15 +807,21 @@ func tick(fps int) tea.Cmd {
 }
 
 // waitForFD bloqueia até receber uma mensagem do FD collector e a entrega ao Update.
-// Faz type-assertion para []FDEntry; mensagens de tipo desconhecido são ignoradas.
+// O FDCollector publica 3 tipos diferentes na mesma channel; demuxamos via
+// type-switch e mapeamos pra tea.Msg específica.
 func waitForFD(c *collector.FDCollector) tea.Cmd {
 	if c == nil {
 		return nil
 	}
 	return func() tea.Msg {
 		v := <-c.Subscribe()
-		if fds, ok := v.([]collector.FDEntry); ok {
-			return FDMsg(fds)
+		switch t := v.(type) {
+		case []collector.FDEntry:
+			return FDMsg(t)
+		case collector.TimelineEvent:
+			return TimelineMsg(t)
+		case collector.FDEvent:
+			return FDEventMsg(t)
 		}
 		return TickMsg(time.Now())
 	}

--- a/internal/tui/view_fd.go
+++ b/internal/tui/view_fd.go
@@ -270,7 +270,7 @@ func renderFDStats(m Model, w int) string {
 	return strings.Join(lines, "\n")
 }
 
-func renderFDEvents(events []FDEvent, w, h int) string {
+func renderFDEvents(events []collector.FDEvent, w, h int) string {
 	if h <= 0 {
 		return ""
 	}


### PR DESCRIPTION
Closes #6, closes #7, closes #8.

Três melhorias agrupadas por tocarem o mesmo arquivo (`fds.go`).

## #6 — Resolver socket inodes

Antes: `socket:[12345]` na coluna DESCRIPTION da F6
Depois: `TCP 127.0.0.1:8080`, `UNIX /var/run/docker.sock`

- `internal/collector/sockets.go`: `SocketResolver` com cache 2s
- Parseia `/proc/net/{tcp,tcp6,udp,udp6,unix}`
- Hex IP little-endian → IP:port legível (`0100007F:1F90` → `127.0.0.1:8080`)
- IPv6 com 4×u32 little-endian per group
- TCP states decodificados (ESTABLISHED, LISTEN, etc), idem UNIX

## #7 — FDEntry.Bytes + Active flag

- `readFDPos()` lê `pos:` de `/proc/<pid>/fdinfo/<fd>`
- Files seekable: `pos` = bytes cumulativos
- Active = `pos` mudou no último poll
- Limitação: sockets/pipes têm `pos=0` constante; Active fica false. Resolução real virá com eBPF #11.

## #8 — Eventos open/close

`collect()` agora compara `fdNum` vs `c.baseline` e detecta:
- **new fd** → emit `FDEvent` + `TimelineEvent{Category:fd}`
- **closed fd** (estava no baseline, sumiu) → emit close
- **reused fd** (mesmo número, descrição diferente) → emit dup/reuse

Channel agora emite **tipos heterogêneos** via `interface{}`. Consumidor (Model) faz type-switch em `waitForFD`:

```go
switch t := v.(type) {
case []collector.FDEntry: return FDMsg(t)
case collector.TimelineEvent: return TimelineMsg(t)
case collector.FDEvent: return FDEventMsg(t)
}
```

`FDEvent` migrou de `tui/model.go` pra `collector/types.go` (faz sentido como type compartilhado).

## Verificação

- `go vet ./...` ok
- `go test -count=1 ./...` PASS (24 testes — 6 novos)
- Build verde

## Limitações conhecidas

- **Cache stale**: socket aberto entre polls aparece como `socket:[N]` por até 2s antes de ser resolvido
- **macOS**: collector falha em Start (sem /proc); model continua simulando — TUI demonstrável em ambos OS
- **Active heurística**: precisa eBPF (#11) pra ser correto com sockets/pipes