### PR TITLE
infra: GitHub Actions CI (vet + test -race + build)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,30 @@
+name: ci
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    name: vet · test · build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.22'
+          cache: true
+
+      - name: go vet
+        run: go vet ./...
+
+      - name: go test (race detector)
+        run: go test -race -count=1 ./...
+
+      - name: go build
+        run: go build -o /tmp/xray ./cmd/xray


### PR DESCRIPTION
Closes #2.

## Workflow

`.github/workflows/ci.yml` roda em push pra main e em qualquer PR:
- `actions/setup-go@v5` com Go 1.22 + cache
- `go vet ./...`
- `go test -race -count=1 ./...`
- `go build -o /tmp/xray ./cmd/xray`

## Decisões

- **Race detector ativo**: temos 5 collectors com goroutines mexendo em maps/channels. Bug clássico aparece só em prod sem isso.
- **`-count=1`**: desabilita cache de testes — CI deve sempre rodar testes do zero.
- **Sem golangci-lint por enquanto**: adicionar depois com `.golangci.yml` dedicado pra não acoplar este PR com backlog de lint.
- **Sem matrix de OS**: só ubuntu. macOS é dev-time; testar lá custa 10× minutos no plan privado e não pega regressão diferente.

## Próximo passo

Próxima PR habilita branch protection rule exigindo este check verde antes de merge em main.