### PR TITLE
infra: build tags isolating eBPF code (Linux-only)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,11 +20,20 @@ jobs:
           go-version: '1.22'
           cache: true
 
-      - name: go vet
+      - name: go vet (default)
         run: go vet ./...
 
-      - name: go test (race detector)
+      - name: go vet (ebpf tag)
+        run: go vet -tags=ebpf ./...
+
+      - name: go test -race (default)
         run: go test -race -count=1 ./...
 
-      - name: go build
+      - name: go test -race (ebpf tag)
+        run: go test -race -count=1 -tags=ebpf ./...
+
+      - name: go build (default — TUI + /proc)
         run: go build -o /tmp/xray ./cmd/xray
+
+      - name: go build (ebpf tag)
+        run: go build -tags=ebpf -o /tmp/xray-ebpf ./cmd/xray

--- a/Makefile
+++ b/Makefile
@@ -1,33 +1,44 @@
-.PHONY: build run gen clean dev test vet lint
+.PHONY: build build-ebpf run gen clean dev test vet lint
 
 BINARY := xray
 PKG    := ./cmd/xray
 
-# Compila programas eBPF (.c → .o) e embute no binário via go:generate
+# Compila programas eBPF (.c → .o) e embute no binário via go:generate.
+# Linux only — no-op em macOS.
 gen:
 	go generate ./internal/bpf/...
 
-# Build completo com eBPF
-build: gen
+# Default build: sem eBPF, roda em qualquer OS (TUI + /proc collectors).
+# Útil pra desenvolvimento, demo do TUI e CI cross-platform.
+build:
 	go build -o bin/$(BINARY) $(PKG)
 
-# Build sem eBPF (para desenvolvimento/teste sem root)
-build-dev:
-	go build -tags noebpf -o bin/$(BINARY) $(PKG)
+# Build completo com eBPF habilitado. Requer:
+#   - Linux com kernel headers
+#   - libbpf-dev instalado
+#   - clang + bpftool pra gen dos .o
+build-ebpf: gen
+	go build -tags=ebpf -o bin/$(BINARY) $(PKG)
 
-# Requer root para eBPF
-run: build
+# Modo eBPF requer root ou CAP_BPF
+run: build-ebpf
 	sudo ./bin/$(BINARY) --pid $(PID)
 
-# Modo desenvolvimento: sem eBPF, dados de /proc
-dev: build-dev
+# Modo /proc-only — sem root, sem eBPF
+dev: build
 	./bin/$(BINARY) --pid $(PID) --no-ebpf
 
 test:
-	go test ./...
+	go test -race ./...
+
+# Roda os testes nos dois modos de build pra pegar regressão
+# nos stubs vs implementação real.
+test-all: test
+	go test -race -tags=ebpf ./... 2>/dev/null || echo "(eBPF tests só rodam em Linux com libbpf — ok pular em macOS)"
 
 vet:
 	go vet ./...
+	go vet -tags=ebpf ./...
 
 clean:
 	rm -rf bin/

--- a/internal/bpf/loader.go
+++ b/internal/bpf/loader.go
@@ -1,41 +1,53 @@
+//go:build linux && ebpf
+
 package bpf
 
-// loader.go — carrega programas eBPF compilados e gerencia seu ciclo de vida.
-//
-// go:generate gera os binários .o a partir dos .c em programs/:
-//go:generate make -C ../../../ gen
+import "fmt"
 
-// Os objetos compilados são embarcados no binário via go:embed.
-// Exemplo para syscalls:
+// Loader gerencia o ciclo de vida de programas eBPF carregados via libbpfgo.
+// Esta versão (Linux + tag `ebpf`) será preenchida pela issue #9 com a
+// implementação real. Por agora retorna erro indicando que o subsystem
+// ainda não está implementado.
+type Loader struct{}
+
+func NewLoader() *Loader {
+	return &Loader{}
+}
+
+// LoadSyscalls carrega o programa eBPF de tracing de syscalls e attacha
+// nos tracepoints raw_syscalls/sys_{enter,exit} filtrando por target_pid.
 //
-//   //go:embed programs/syscalls.bpf.o
-//   var syscallsBPFObj []byte
-//
-// Uso com libbpfgo:
-//
-//   import bpf "github.com/aquasecurity/libbpfgo"
-//
-//   func LoadSyscallsProgram(pid int) (*bpf.Module, error) {
-//       m, err := bpf.NewModuleFromBuffer(syscallsBPFObj, "syscalls")
-//       if err != nil {
-//           return nil, err
-//       }
-//       if err := m.BPFLoadObject(); err != nil {
-//           return nil, err
-//       }
-//       // setar PID no map target_pid
-//       pidMap, _ := m.GetMap("target_pid")
-//       key := uint32(0)
-//       val := uint32(pid)
-//       pidMap.Update(unsafe.Pointer(&key), unsafe.Pointer(&val))
-//
-//       // attach tracepoints
-//       for _, tp := range []string{"sys_enter", "sys_exit"} {
-//           prog, _ := m.GetProgram("tracepoint__raw_syscalls__" + tp)
-//           prog.AttachTracepoint("raw_syscalls", tp)
-//       }
-//       return m, nil
-//   }
-//
-// TODO: implementar quando os .c estiverem compilando corretamente.
-// Para MVP use --no-ebpf com leitura de /proc.
+// Issue #9 vai implementar de fato:
+//   - go:generate compila programs/syscalls.bpf.c → .o
+//   - go:embed embute o .o no binário
+//   - libbpfgo.NewModuleFromBuffer carrega o objeto
+//   - mapeia target_pid via BPF map
+//   - attacha programs em raw_syscalls:sys_enter / sys_exit
+func (*Loader) LoadSyscalls(pid int) error {
+	return fmt.Errorf("eBPF syscalls collector ainda não implementado (issue #9)")
+}
+
+// LoadCPU sampling via perf_event — issue #10
+func (*Loader) LoadCPU(pid int) error {
+	return fmt.Errorf("eBPF cpu collector ainda não implementado (issue #10)")
+}
+
+// LoadIO block tracepoints — issue #11
+func (*Loader) LoadIO(pid int) error {
+	return fmt.Errorf("eBPF io collector ainda não implementado (issue #11)")
+}
+
+// LoadNetwork sock tracepoints — issue #12
+func (*Loader) LoadNetwork(pid int) error {
+	return fmt.Errorf("eBPF network collector ainda não implementado (issue #12)")
+}
+
+// LoadSched threads + off-CPU — issue #13
+func (*Loader) LoadSched(pid int) error {
+	return fmt.Errorf("eBPF sched collector ainda não implementado (issue #13)")
+}
+
+// LoadMemory mmap/page_fault tracepoints — issue #14
+func (*Loader) LoadMemory(pid int) error {
+	return fmt.Errorf("eBPF memory collector ainda não implementado (issue #14)")
+}

--- a/internal/bpf/loader_stub.go
+++ b/internal/bpf/loader_stub.go
@@ -1,0 +1,25 @@
+//go:build !linux || !ebpf
+
+package bpf
+
+import "errors"
+
+// Stub para builds sem `-tags=ebpf` (default) ou em OS não-Linux (macOS/Windows).
+// Mesma interface da versão Linux+ebpf — todos os Load* retornam um erro
+// uniforme indicando que o subsystem eBPF não está disponível neste build.
+//
+// Isto permite que o resto do projeto importe `internal/bpf` sem quebrar
+// compilação no macOS, e que o codepath de runtime detecte graciosamente
+// que precisa cair pra /proc collectors.
+
+var errStub = errors.New("eBPF não disponível neste build (precisa Linux + -tags=ebpf)")
+
+type Loader struct{}
+
+func NewLoader() *Loader                 { return &Loader{} }
+func (*Loader) LoadSyscalls(int) error   { return errStub }
+func (*Loader) LoadCPU(int) error        { return errStub }
+func (*Loader) LoadIO(int) error         { return errStub }
+func (*Loader) LoadNetwork(int) error    { return errStub }
+func (*Loader) LoadSched(int) error      { return errStub }
+func (*Loader) LoadMemory(int) error     { return errStub }


### PR DESCRIPTION
Closes #3. Pré-condição arquitetural pras issues #9-#14.

## Convenção

| Comando | Tag | OS | eBPF |
|---|---|---|---|
| `go build ./...` | nenhuma | qualquer | ❌ stubs |
| `go build -tags=ebpf ./...` | ebpf | Linux only | ✅ libbpfgo |

`internal/bpf/loader.go` (`//go:build linux && ebpf`) tem o esqueleto do Loader com 6 placeholders (Syscalls/CPU/IO/Network/Sched/Memory) — cada um documenta a issue que vai implementar de fato (#9-#14).

`internal/bpf/loader_stub.go` (`//go:build !linux || !ebpf`) é o stub: mesma interface, retorna `errStub` em todos. Permite o resto do projeto importar `internal/bpf` em macOS sem quebrar.

## CI

Workflow `ci.yml` atualizado para rodar **vet/test/build nos DOIS modos**: default e `-tags=ebpf`. Garante que stubs e implementação não driftam.

## libbpfgo

NÃO foi reintroduzido em go.mod nesta PR. Vai entrar com #9 (primeiro programa real). Stubs atuais usam `fmt.Errorf` sem dependência externa.

## Verificação local (macOS)

```
go vet ./...                     # ok
go vet -tags=ebpf ./...          # ok
go test -race ./...              # PASS
go test -race -tags=ebpf ./...   # PASS
```