### PR TITLE
tui: snapshot (s) + JSON export (e)

### DIFF
--- a/cmd/xray/main.go
+++ b/cmd/xray/main.go
@@ -38,8 +38,21 @@ func main() {
 	m := tui.NewModel(cfg)
 	p := tea.NewProgram(m, tea.WithAltScreen(), tea.WithMouseCellMotion())
 
-	if _, err := p.Run(); err != nil {
+	finalModel, err := p.Run()
+	if err != nil {
 		fmt.Fprintf(os.Stderr, "erro fatal: %v\n", err)
 		os.Exit(1)
+	}
+
+	// Cleanup + snapshot final no modo --export
+	if fm, ok := finalModel.(tui.Model); ok {
+		fm.Close()
+		if cfg.Export {
+			if path, err := tui.SaveSnapshot(fm); err == nil {
+				fmt.Fprintf(os.Stderr, "snapshot final salvo: %s\n", path)
+			} else {
+				fmt.Fprintf(os.Stderr, "aviso: snapshot final falhou: %v\n", err)
+			}
+		}
 	}
 }

--- a/internal/tui/keys.go
+++ b/internal/tui/keys.go
@@ -1,6 +1,8 @@
 package tui
 
 import (
+	"fmt"
+
 	tea "github.com/charmbracelet/bubbletea"
 )
 
@@ -50,8 +52,39 @@ func (m Model) handleKey(msg tea.KeyMsg) (Model, tea.Cmd) {
 			m.FDFilter = fdFilters[0]
 		}
 
-	case "s", "e":
-		// snapshot / export — placeholders. A implementação real grava JSON em disco.
+	case "s":
+		// One-shot snapshot: grava xray-snapshot-<timestamp>.json em cwd.
+		path, err := SaveSnapshot(m)
+		if err != nil {
+			m.toast = fmtToast("⚠ snapshot: %v", err)
+		} else {
+			m.toast = fmtToast("✓ snapshot: %s", path)
+		}
+		return m, clearToastAfter(toastTTL)
+
+	case "e":
+		// Toggle export contínuo: liga/desliga o JSONL.
+		if m.exportFile != nil {
+			_ = m.exportFile.Close()
+			m.exportFile = nil
+			m.toast = "✓ export: OFF"
+			return m, clearToastAfter(toastTTL)
+		}
+		f, err := openExportFile()
+		if err != nil {
+			m.toast = fmtToast("⚠ export: %v", err)
+			return m, clearToastAfter(toastTTL)
+		}
+		m.exportFile = f
+		m.toast = fmtToast("✓ export: %s", f.Name())
+		// Dispara o primeiro tick + clear-toast em paralelo
+		return m, tea.Batch(exportTick(), clearToastAfter(toastTTL))
 	}
 	return m, nil
+}
+
+// fmtToast é um wrapper de fmt.Sprintf isolado pra deixar a chamada legível
+// no switch acima.
+func fmtToast(format string, args ...interface{}) string {
+	return fmt.Sprintf(format, args...)
 }

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -70,6 +70,12 @@ type IOThroughputMsg collector.IOThroughputSample
 type TimelineMsg collector.TimelineEvent
 type FDEventMsg collector.FDEvent
 
+// exportTickMsg dispara periodicamente quando export contínuo está ON.
+type exportTickMsg time.Time
+
+// clearToastMsg apaga o toast/status temporário do statusbar após N segundos.
+type clearToastMsg struct{}
+
 // ─── Model ───────────────────────────────────────────────────────────────────
 
 type Model struct {
@@ -101,6 +107,14 @@ type Model struct {
 	Paused    bool
 	Width     int
 	Height    int
+
+	// Toast: mensagem temporária no statusbar (ex: "snapshot salvo em /tmp/xxx").
+	// Vazio quando não há toast ativo. clearToastMsg apaga após 2s.
+	toast string
+
+	// Export contínuo (tecla 'e' ou flag --export):
+	// quando exportFile != nil, exportTickMsg agenda a próxima escrita JSONL.
+	exportFile *os.File
 
 	// Collectors
 	fdCollector      *collector.FDCollector
@@ -188,6 +202,17 @@ func NewModel(cfg Config) Model {
 		}
 	}
 
+	// --export: abre o arquivo JSONL desde já. Se falhar, apenas avisa
+	// (não bloqueia o launch — usuário ainda usa a TUI normalmente).
+	if cfg.Export {
+		if f, err := openExportFile(); err == nil {
+			m.exportFile = f
+			m.toast = fmt.Sprintf("✓ export: %s", f.Name())
+		} else {
+			fmt.Fprintf(os.Stderr, "aviso: --export falhou: %v\n", err)
+		}
+	}
+
 	return m
 }
 
@@ -212,6 +237,12 @@ func (m Model) Init() tea.Cmd {
 	}
 	if m.ioThroughputCollector != nil {
 		cmds = append(cmds, waitForIOThroughput(m.ioThroughputCollector))
+	}
+	if m.exportFile != nil {
+		cmds = append(cmds, exportTick())
+	}
+	if m.toast != "" {
+		cmds = append(cmds, clearToastAfter(toastTTL))
 	}
 	return tea.Batch(cmds...)
 }
@@ -281,6 +312,24 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.IOStats.IOWaitPct = collector.IOWaitSample(v).Pct
 		m.usingMockIOWait = false
 		return m, waitForIOWait(m.iowaitCollector)
+
+	case clearToastMsg:
+		m.toast = ""
+		return m, nil
+
+	case exportTickMsg:
+		// Export contínuo: escreve uma linha JSONL por tick. Se a escrita falhar,
+		// fecha o arquivo e mostra toast de erro — não trava a TUI.
+		if m.exportFile != nil {
+			if err := writeSnapshotLine(m.exportFile, m); err != nil {
+				_ = m.exportFile.Close()
+				m.exportFile = nil
+				m.toast = fmt.Sprintf("⚠ export: %v", err)
+				return m, clearToastAfter(toastTTL)
+			}
+			return m, exportTick()
+		}
+		return m, nil
 
 	case IOThroughputMsg:
 		s := collector.IOThroughputSample(v)
@@ -804,6 +853,30 @@ func tick(fps int) tea.Cmd {
 	}
 	d := time.Second / time.Duration(fps)
 	return tea.Tick(d, func(t time.Time) tea.Msg { return TickMsg(t) })
+}
+
+// exportInterval define quão frequentemente o export contínuo grava uma
+// linha JSONL. simInterval (700ms) seria muito barulhento — 2s é um
+// compromise entre granularidade e tamanho do arquivo gerado.
+const exportInterval = 2 * time.Second
+
+func exportTick() tea.Cmd {
+	return tea.Tick(exportInterval, func(t time.Time) tea.Msg { return exportTickMsg(t) })
+}
+
+// toastTTL é quanto tempo a mensagem temporária no statusbar fica visível.
+const toastTTL = 2 * time.Second
+
+func clearToastAfter(d time.Duration) tea.Cmd {
+	return tea.Tick(d, func(time.Time) tea.Msg { return clearToastMsg{} })
+}
+
+// Close libera recursos abertos pelo model — atualmente o arquivo de export.
+// main.go chama isso após p.Run() retornar pra garantir flush.
+func (m Model) Close() {
+	if m.exportFile != nil {
+		_ = m.exportFile.Close()
+	}
 }
 
 // waitForFD bloqueia até receber uma mensagem do FD collector e a entrega ao Update.

--- a/internal/tui/snapshot.go
+++ b/internal/tui/snapshot.go
@@ -1,0 +1,115 @@
+package tui
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/trentas/xray/internal/collector"
+)
+
+// snapshotSchemaVersion bate semver no formato JSON. Bumping requer
+// migração no consumidor; campos adicionados em backward-compat não bumpam.
+const snapshotSchemaVersion = 1
+
+// Snapshot é o formato canônico de export — usado tanto pelo `s` (one-shot)
+// quanto pelo `e` (continuous JSONL). Apenas dados do model, não estado de UI.
+type Snapshot struct {
+	Version    int          `json:"version"`
+	CapturedAt time.Time    `json:"captured_at"`
+	PID        int          `json:"pid"`
+	Process    string       `json:"process"`
+	UptimeMs   int64        `json:"uptime_ms"`
+	Data       SnapshotData `json:"data"`
+}
+
+// SnapshotData é toda a telemetria capturada — apenas campos com fonte real
+// ou simulada que reflete dados a serem analisados off-line.
+type SnapshotData struct {
+	CPUHistory     []float64                 `json:"cpu_history"`
+	SyscallCounts  map[string]uint64         `json:"syscall_counts"`
+	NetConns       []collector.NetConn       `json:"network_connections"`
+	MemStats       collector.MemStats        `json:"memory"`
+	Threads        []collector.ThreadInfo    `json:"threads"`
+	IOStats        collector.IOStats         `json:"io"`
+	IOReadHist     []float64                 `json:"io_read_history"`
+	IOWriteHist    []float64                 `json:"io_write_history"`
+	FDs            []collector.FDEntry       `json:"fds"`
+	FDCountHistory []float64                 `json:"fd_count_history"`
+	FDEvents       []collector.FDEvent       `json:"fd_events"`
+	Timeline       []collector.TimelineEvent `json:"timeline"`
+}
+
+// buildSnapshot extrai um Snapshot a partir do estado atual do model.
+func buildSnapshot(m Model) Snapshot {
+	return Snapshot{
+		Version:    snapshotSchemaVersion,
+		CapturedAt: time.Now(),
+		PID:        m.cfg.PID,
+		Process:    m.ProcessName,
+		UptimeMs:   time.Since(m.StartedAt).Milliseconds(),
+		Data: SnapshotData{
+			CPUHistory:     append([]float64(nil), m.CPUHistory...),
+			SyscallCounts:  copyUintMap(m.SyscallCounts),
+			NetConns:       append([]collector.NetConn(nil), m.NetConns...),
+			MemStats:       m.MemStats,
+			Threads:        append([]collector.ThreadInfo(nil), m.Threads...),
+			IOStats:        m.IOStats,
+			IOReadHist:     append([]float64(nil), m.IOReadHist...),
+			IOWriteHist:    append([]float64(nil), m.IOWriteHist...),
+			FDs:            append([]collector.FDEntry(nil), m.FDs...),
+			FDCountHistory: append([]float64(nil), m.FDCountHistory...),
+			FDEvents:       append([]collector.FDEvent(nil), m.FDEvents...),
+			Timeline:       append([]collector.TimelineEvent(nil), m.Timeline...),
+		},
+	}
+}
+
+// SaveSnapshot serializa um snapshot em JSON formatado num arquivo
+// xray-snapshot-<timestamp>.json no cwd. Retorna o path criado.
+//
+// Exposto pra o main.go usar no fluxo de --export-on-quit.
+func SaveSnapshot(m Model) (string, error) {
+	snap := buildSnapshot(m)
+	path := fmt.Sprintf("xray-snapshot-%s.json", snap.CapturedAt.Format("20060102-150405"))
+	data, err := json.MarshalIndent(snap, "", "  ")
+	if err != nil {
+		return "", err
+	}
+	if err := os.WriteFile(path, data, 0644); err != nil {
+		return "", err
+	}
+	return path, nil
+}
+
+// openExportFile cria/trunca xray-export-<timestamp>.jsonl pra modo contínuo.
+func openExportFile() (*os.File, error) {
+	path := fmt.Sprintf("xray-export-%s.jsonl", time.Now().Format("20060102-150405"))
+	return os.OpenFile(path, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0644)
+}
+
+// writeSnapshotLine grava uma linha JSONL (snapshot serializado + \n).
+// Usa Marshal (não Indent) pra economizar espaço — JSONL espera uma linha por entrada.
+func writeSnapshotLine(f *os.File, m Model) error {
+	if f == nil {
+		return nil
+	}
+	snap := buildSnapshot(m)
+	data, err := json.Marshal(snap)
+	if err != nil {
+		return err
+	}
+	if _, err := f.Write(append(data, '\n')); err != nil {
+		return err
+	}
+	return nil
+}
+
+func copyUintMap(in map[string]uint64) map[string]uint64 {
+	out := make(map[string]uint64, len(in))
+	for k, v := range in {
+		out[k] = v
+	}
+	return out
+}

--- a/internal/tui/snapshot_test.go
+++ b/internal/tui/snapshot_test.go
@@ -1,0 +1,119 @@
+package tui
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestBuildSnapshot_includesAllFields(t *testing.T) {
+	m := NewModel(Config{PID: 1, FPS: 5, NoEBPF: true})
+	m.Width = 120
+	m.Height = 40
+
+	snap := buildSnapshot(m)
+
+	if snap.Version != snapshotSchemaVersion {
+		t.Errorf("version=%d, esperado %d", snap.Version, snapshotSchemaVersion)
+	}
+	if snap.PID != 1 {
+		t.Errorf("PID=%d", snap.PID)
+	}
+	if snap.Process == "" {
+		t.Error("Process vazio")
+	}
+	// Critério da issue: deve incluir CPU, syscalls, FDs, threads, mem, IO, timeline
+	if len(snap.Data.CPUHistory) == 0 {
+		t.Error("CPUHistory vazio")
+	}
+	if len(snap.Data.SyscallCounts) == 0 {
+		t.Error("SyscallCounts vazio")
+	}
+	if len(snap.Data.FDs) == 0 {
+		t.Error("FDs vazio")
+	}
+	if len(snap.Data.Threads) == 0 {
+		t.Error("Threads vazio")
+	}
+	if snap.Data.MemStats.RSSBytes == 0 {
+		t.Error("MemStats.RSSBytes zerado")
+	}
+}
+
+func TestSaveSnapshot_roundtrip(t *testing.T) {
+	m := NewModel(Config{PID: 1, FPS: 5, NoEBPF: true})
+	m.Width = 120
+	m.Height = 40
+
+	// SaveSnapshot cria no cwd; isolamos via TempDir
+	dir := t.TempDir()
+	wd, _ := os.Getwd()
+	defer os.Chdir(wd) //nolint:errcheck
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+
+	path, err := SaveSnapshot(m)
+	if err != nil {
+		t.Fatalf("save: %v", err)
+	}
+	if !strings.HasPrefix(path, "xray-snapshot-") {
+		t.Errorf("path inesperado: %s", path)
+	}
+	full := filepath.Join(dir, path)
+	data, err := os.ReadFile(full)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+
+	var roundtrip Snapshot
+	if err := json.Unmarshal(data, &roundtrip); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if roundtrip.Version != snapshotSchemaVersion {
+		t.Errorf("version round-trip=%d", roundtrip.Version)
+	}
+	if len(roundtrip.Data.FDs) != len(m.FDs) {
+		t.Errorf("FDs round-trip: %d vs %d", len(roundtrip.Data.FDs), len(m.FDs))
+	}
+}
+
+func TestExportFile_jsonlLine(t *testing.T) {
+	m := NewModel(Config{PID: 1, FPS: 5, NoEBPF: true})
+	m.Width = 120
+	m.Height = 40
+
+	dir := t.TempDir()
+	wd, _ := os.Getwd()
+	defer os.Chdir(wd) //nolint:errcheck
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+
+	f, err := openExportFile()
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer f.Close()
+
+	if err := writeSnapshotLine(f, m); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if err := writeSnapshotLine(f, m); err != nil {
+		t.Fatalf("write 2: %v", err)
+	}
+
+	data, _ := os.ReadFile(f.Name())
+	lines := strings.Split(strings.TrimRight(string(data), "\n"), "\n")
+	if len(lines) != 2 {
+		t.Fatalf("esperava 2 linhas, got %d", len(lines))
+	}
+	for i, line := range lines {
+		var s Snapshot
+		if err := json.Unmarshal([]byte(line), &s); err != nil {
+			t.Errorf("linha %d não é JSON válido: %v", i, err)
+		}
+	}
+}

--- a/internal/tui/statusbar.go
+++ b/internal/tui/statusbar.go
@@ -40,22 +40,40 @@ func renderStatusBar(m Model) string {
 	left := strings.Join(longParts, lblStyle.Render("  ·  "))
 
 	rightParts := []string{}
-	if m.Paused {
-		rightParts = append(rightParts, lipgloss.NewStyle().
-			Foreground(ColorAmber).
+	// Toast tem prioridade — substitui o info da direita por 2s
+	if m.toast != "" {
+		toastStyle := lipgloss.NewStyle().
+			Foreground(ColorTeal).
 			Background(barBg).
-			Bold(true).
-			Render("⏸ PAUSED"))
+			Bold(true)
+		// Se toast começa com ⚠, troca pra cor de aviso
+		if strings.HasPrefix(m.toast, "⚠") {
+			toastStyle = toastStyle.Foreground(ColorAmber)
+		}
+		rightParts = append(rightParts, toastStyle.Render(m.toast))
+	} else {
+		if m.Paused {
+			rightParts = append(rightParts, lipgloss.NewStyle().
+				Foreground(ColorAmber).
+				Background(barBg).
+				Bold(true).
+				Render("⏸ PAUSED"))
+		}
+		if m.cfg.NoEBPF {
+			rightParts = append(rightParts, lipgloss.NewStyle().
+				Foreground(ColorOrange).
+				Background(barBg).
+				Render("[--no-ebpf]"))
+		}
+		if m.exportFile != nil {
+			rightParts = append(rightParts, lipgloss.NewStyle().
+				Foreground(ColorTeal).
+				Background(barBg).
+				Render("● REC"))
+		}
+		rightParts = append(rightParts, lblStyle.Render("eBPF kernel 6.8 · sampling 100Hz · overhead <0.5%"))
 	}
-	if m.cfg.NoEBPF {
-		rightParts = append(rightParts, lipgloss.NewStyle().
-			Foreground(ColorOrange).
-			Background(barBg).
-			Render("[--no-ebpf]"))
-	}
-	rightFull := append([]string{}, rightParts...)
-	rightFull = append(rightFull, lblStyle.Render("eBPF kernel 6.8 · sampling 100Hz · overhead <0.5%"))
-	right := strings.Join(rightFull, lblStyle.Render("  "))
+	right := strings.Join(rightParts, lblStyle.Render("  "))
 
 	// degrada progressivamente: drop info → keybindings curtos → drop right inteiro
 	if lipgloss.Width(left)+lipgloss.Width(right)+3 > m.Width {


### PR DESCRIPTION
Closes #15.

## Implementação

| Trigger | Comportamento |
|---|---|
| `s` | One-shot: `xray-snapshot-<ts>.json` (indented JSON) |
| `e` | Toggle: `xray-export-<ts>.jsonl` (1 linha a cada 2s) |
| `--export` flag | Abre JSONL desde o launch + grava snapshot final ao sair |

Schema versionado (`v1`). `SnapshotData` cobre acceptance criteria #15: CPUHistory, SyscallCounts, NetConns, MemStats, Threads, IOStats + histórico, FDs, FDEvents, Timeline.

Toast no statusbar por 2s ao executar `s`/`e` mostra path ou erro (cor teal/amber). Indicador `● REC` quando export contínuo está ON.

## Cobertura nova
- `TestBuildSnapshot_includesAllFields`
- `TestSaveSnapshot_roundtrip` (Marshal/Unmarshal preserva)
- `TestExportFile_jsonlLine` (cada linha é JSON válido)