### PR TITLE
tui: input filter (/) + help overlay (?)

### DIFF
--- a/internal/tui/help.go
+++ b/internal/tui/help.go
@@ -1,0 +1,91 @@
+package tui
+
+import (
+	"strings"
+
+	"github.com/charmbracelet/lipgloss"
+)
+
+// renderHelpOverlay desenha um modal centralizado com todos os keybindings.
+// Recebe as dimensões totais do content area; lipgloss.Place centraliza o card.
+func renderHelpOverlay(w, h int) string {
+	sectionTitle := lipgloss.NewStyle().Foreground(ColorCyan).Bold(true)
+	keyStyle := lipgloss.NewStyle().Foreground(ColorTeal).Bold(true)
+	descStyle := lipgloss.NewStyle().Foreground(ColorText)
+	dimDesc := lipgloss.NewStyle().Foreground(ColorMuted)
+
+	row := func(key, desc string) string {
+		return keyStyle.Render(padRight(key, 14)) + " " + descStyle.Render(desc)
+	}
+	dimRow := func(key, desc string) string {
+		return keyStyle.Render(padRight(key, 14)) + " " + dimDesc.Render(desc)
+	}
+
+	lines := []string{
+		sectionTitle.Render("Navegação"),
+		row("F1-F7", "Trocar aba"),
+		row("1-7", "Atalho da aba (alternativa ao F1-F7)"),
+		row("Tab", "Próxima aba"),
+		row("Shift+Tab", "Aba anterior"),
+		"",
+		sectionTitle.Render("Filtro"),
+		row("/", "Abre filtro substring (ou cicla tipos em F6 quando vazio)"),
+		row("Enter", "Confirma filtro"),
+		row("Esc", "Cancela input · ou limpa filtro · ou fecha help"),
+		row("Ctrl+U", "Limpa o que está sendo digitado"),
+		"",
+		sectionTitle.Render("Estado"),
+		row("p, Space", "Pausar / retomar simulação"),
+		row("?", "Abre / fecha esta tela"),
+		row("q, Ctrl+C", "Sair"),
+		"",
+		sectionTitle.Render("Snapshot / Export"),
+		row("s", "Snapshot one-shot (xray-snapshot-<ts>.json)"),
+		row("e", "Toggle export contínuo (xray-export-<ts>.jsonl)"),
+		dimRow("--export", "Flag CLI: export desde o launch + snapshot final ao sair"),
+	}
+
+	body := strings.Join(lines, "\n")
+
+	card := lipgloss.NewStyle().
+		Border(lipgloss.RoundedBorder()).
+		BorderForeground(ColorCyan).
+		Background(ColorPanel).
+		Padding(1, 3).
+		Render(body)
+
+	// Centraliza o card sobre fundo escurecido. lipgloss.Place pinta a área
+	// total com a cor base e posiciona o card no centro.
+	return lipgloss.Place(w, h,
+		lipgloss.Center, lipgloss.Center,
+		card,
+		lipgloss.WithWhitespaceBackground(ColorBG),
+	)
+}
+
+// renderFilterInput desenha o widget de input ativo em vez do statusbar.
+// Mostra o cursor como bloco ▏ no fim do buffer. width = m.Width.
+func renderFilterInput(m Model, w int) string {
+	barBg := lipgloss.Color("#0a0d11")
+	prompt := lipgloss.NewStyle().
+		Foreground(ColorTeal).
+		Background(barBg).
+		Bold(true).
+		Render(" / ")
+	hint := lipgloss.NewStyle().
+		Foreground(ColorDim).
+		Background(barBg).
+		Render(" Enter confirma · Esc cancela · Ctrl+U limpa")
+
+	cursor := lipgloss.NewStyle().Foreground(ColorBright).Background(barBg).Render("▏")
+	value := lipgloss.NewStyle().Foreground(ColorBright).Background(barBg).Render(m.inputBuf)
+
+	used := lipgloss.Width(prompt) + lipgloss.Width(value) + lipgloss.Width(cursor) + lipgloss.Width(hint)
+	gap := w - used - 2
+	if gap < 1 {
+		gap = 1
+	}
+	pad := lipgloss.NewStyle().Background(barBg).Render(strings.Repeat(" ", gap))
+	edge := lipgloss.NewStyle().Background(barBg).Render(" ")
+	return edge + prompt + value + cursor + pad + hint + edge
+}

--- a/internal/tui/help_test.go
+++ b/internal/tui/help_test.go
@@ -1,0 +1,147 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+// TestHelpOverlayToggle confirma que `?` abre/fecha o help.
+func TestHelpOverlayToggle(t *testing.T) {
+	m := NewModel(Config{PID: 1, FPS: 5, NoEBPF: true})
+	m.Width = 140
+	m.Height = 40
+
+	if m.showHelp {
+		t.Fatal("showHelp deveria começar false")
+	}
+
+	nm, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'?'}})
+	m = nm.(Model)
+	if !m.showHelp {
+		t.Error("? não abriu help")
+	}
+
+	// View() deve renderizar o overlay quando showHelp
+	out := m.View()
+	if !strings.Contains(out, "Navegação") {
+		t.Error("overlay não renderizou seção Navegação")
+	}
+	if !strings.Contains(out, "Filtro") {
+		t.Error("overlay não renderizou seção Filtro")
+	}
+
+	// Qualquer tecla fecha
+	nm, _ = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'a'}})
+	m = nm.(Model)
+	if m.showHelp {
+		t.Error("tecla não fechou o help")
+	}
+}
+
+// TestFilterInputFlow exercita / → tipa → Enter → confirma filtro
+func TestFilterInputFlow(t *testing.T) {
+	m := NewModel(Config{PID: 1, FPS: 5, NoEBPF: true})
+	m.Width = 140
+	m.Height = 40
+	m.ActiveTab = TabSyscalls // F6 tem o cycle dos types — uso outra view
+
+	// Inicialmente sem filtro
+	if m.filter != "" || m.inputMode != InputModeNone {
+		t.Fatal("estado inicial inesperado")
+	}
+
+	// Press /
+	nm, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'/'}})
+	m = nm.(Model)
+	if m.inputMode != InputModeFilter {
+		t.Errorf("após '/', inputMode=%d (esperado %d)", m.inputMode, InputModeFilter)
+	}
+
+	// Type "tcp"
+	for _, r := range "tcp" {
+		nm, _ = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{r}})
+		m = nm.(Model)
+	}
+	if m.inputBuf != "tcp" {
+		t.Errorf("inputBuf=%q", m.inputBuf)
+	}
+	if m.filter != "" {
+		t.Error("filter não deveria ter mudado antes de Enter")
+	}
+
+	// Press Enter
+	nm, _ = m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m = nm.(Model)
+	if m.filter != "tcp" {
+		t.Errorf("após Enter, filter=%q (esperado tcp)", m.filter)
+	}
+	if m.inputMode != InputModeNone {
+		t.Error("inputMode deveria ter saído")
+	}
+	if m.inputBuf != "" {
+		t.Error("inputBuf deveria estar vazio após Enter")
+	}
+
+	// Esc fora de input mode com filter ativo limpa o filtro
+	nm, _ = m.Update(tea.KeyMsg{Type: tea.KeyEsc})
+	m = nm.(Model)
+	if m.filter != "" {
+		t.Errorf("Esc não limpou filter, ainda %q", m.filter)
+	}
+}
+
+// TestFilterEscCancelsKeepsPreviousFilter — Esc dentro de input mode mantém o filtro anterior
+func TestFilterEscCancelsKeepsPreviousFilter(t *testing.T) {
+	m := NewModel(Config{PID: 1, FPS: 5, NoEBPF: true})
+	m.Width = 140
+	m.Height = 40
+	m.ActiveTab = TabSyscalls
+	m.filter = "old"
+
+	// Press / — inputBuf pré-popula com filter atual
+	nm, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'/'}})
+	m = nm.(Model)
+	if m.inputBuf != "old" {
+		t.Errorf("inputBuf não pré-populou: %q", m.inputBuf)
+	}
+
+	// Type "X" para descaracterizar
+	nm, _ = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'X'}})
+	m = nm.(Model)
+
+	// Press Esc — deve cancelar e MANTER filter anterior
+	nm, _ = m.Update(tea.KeyMsg{Type: tea.KeyEsc})
+	m = nm.(Model)
+	if m.filter != "old" {
+		t.Errorf("após Esc cancelando input, filter=%q (esperado 'old')", m.filter)
+	}
+	if m.inputMode != InputModeNone {
+		t.Error("inputMode não saiu")
+	}
+}
+
+// TestFilterFDView_substring confirma que m.filter restringe FDs em F6
+func TestFilterFDView_substring(t *testing.T) {
+	m := NewModel(Config{PID: 1, FPS: 5, NoEBPF: true})
+	m.Width = 180
+	m.Height = 40
+	m.ActiveTab = TabFD
+
+	// Sem filtro: todas as FDs aparecem
+	out := m.View()
+	if !strings.Contains(out, "stdin") || !strings.Contains(out, "TCP") {
+		t.Error("baseline deveria ter stdin e TCP")
+	}
+
+	// Aplica filtro "TCP"
+	m.filter = "TCP"
+	out = m.View()
+	if !strings.Contains(out, "TCP") {
+		t.Error("após filter=TCP, esperava ver TCP")
+	}
+	if strings.Contains(out, "stdin") {
+		t.Error("após filter=TCP, stdin não deveria aparecer")
+	}
+}

--- a/internal/tui/keys.go
+++ b/internal/tui/keys.go
@@ -2,17 +2,37 @@ package tui
 
 import (
 	"fmt"
+	"unicode"
 
 	tea "github.com/charmbracelet/bubbletea"
 )
 
-// fdFilters define a ordem de ciclagem ao apertar '/' na FD view.
+// fdFilters define a ordem de ciclagem ao apertar '/' na FD view (modo legado
+// quando o filtro substring está vazio — `/` apertar de novo entra em input mode).
 var fdFilters = []string{"all", "file", "socket", "pipe", "epoll", "timer"}
 
 // handleKey processa entrada do teclado.
-// Retorna o model atualizado (cópia mutada) e qualquer Cmd subsequente.
+//
+// Ordem de prioridade:
+//  1. Help overlay aberto: qualquer tecla fecha
+//  2. Input mode (filtro) ativo: forwarding pra inputBuf, com Enter/Esc/Backspace especiais
+//  3. Comandos globais (F1-F7, q, p, etc)
 func (m Model) handleKey(msg tea.KeyMsg) (Model, tea.Cmd) {
-	switch msg.String() {
+	key := msg.String()
+
+	// 1. Help overlay
+	if m.showHelp {
+		m.showHelp = false
+		return m, nil
+	}
+
+	// 2. Input mode (filtro substring)
+	if m.inputMode == InputModeFilter {
+		return m.handleFilterInput(msg, key)
+	}
+
+	// 3. Comandos globais
+	switch key {
 	case "q", "ctrl+c":
 		return m, tea.Quit
 
@@ -39,10 +59,22 @@ func (m Model) handleKey(msg tea.KeyMsg) (Model, tea.Cmd) {
 	case "shift+tab", "left", "h":
 		m.ActiveTab = (m.ActiveTab - 1 + TabCount) % TabCount
 
+	case "?":
+		m.showHelp = true
+		return m, nil
+
+	case "esc":
+		// Esc fora de input/help limpa filtro ativo (se houver)
+		if m.filter != "" {
+			m.filter = ""
+		}
+		return m, nil
+
 	case "/":
-		// Cicla o filtro do FD view. Implementação simplificada — substituir
-		// por input field quando o módulo de input estiver pronto.
-		if m.ActiveTab == TabFD {
+		// Em F6, se o filtro substring está vazio, primeiro `/` cicla os tipos
+		// (comportamento legado pra ergonomia rápida). Quando há filtro ativo
+		// ou em outras views, abre input mode.
+		if m.ActiveTab == TabFD && m.filter == "" {
 			for i, f := range fdFilters {
 				if f == m.FDFilter {
 					m.FDFilter = fdFilters[(i+1)%len(fdFilters)]
@@ -50,10 +82,14 @@ func (m Model) handleKey(msg tea.KeyMsg) (Model, tea.Cmd) {
 				}
 			}
 			m.FDFilter = fdFilters[0]
+			return m, nil
 		}
+		// Entra em modo de input com o valor atual pré-preenchido
+		m.inputMode = InputModeFilter
+		m.inputBuf = m.filter
+		return m, nil
 
 	case "s":
-		// One-shot snapshot: grava xray-snapshot-<timestamp>.json em cwd.
 		path, err := SaveSnapshot(m)
 		if err != nil {
 			m.toast = fmtToast("⚠ snapshot: %v", err)
@@ -63,7 +99,6 @@ func (m Model) handleKey(msg tea.KeyMsg) (Model, tea.Cmd) {
 		return m, clearToastAfter(toastTTL)
 
 	case "e":
-		// Toggle export contínuo: liga/desliga o JSONL.
 		if m.exportFile != nil {
 			_ = m.exportFile.Close()
 			m.exportFile = nil
@@ -77,14 +112,58 @@ func (m Model) handleKey(msg tea.KeyMsg) (Model, tea.Cmd) {
 		}
 		m.exportFile = f
 		m.toast = fmtToast("✓ export: %s", f.Name())
-		// Dispara o primeiro tick + clear-toast em paralelo
 		return m, tea.Batch(exportTick(), clearToastAfter(toastTTL))
 	}
 	return m, nil
 }
 
-// fmtToast é um wrapper de fmt.Sprintf isolado pra deixar a chamada legível
-// no switch acima.
+// handleFilterInput processa teclas em modo de input. Enter confirma, Esc
+// cancela mantendo o filtro anterior, Backspace apaga, runas printáveis são
+// concatenadas.
+func (m Model) handleFilterInput(msg tea.KeyMsg, key string) (Model, tea.Cmd) {
+	switch msg.Type {
+	case tea.KeyEnter:
+		m.filter = m.inputBuf
+		m.inputMode = InputModeNone
+		m.inputBuf = ""
+		return m, nil
+
+	case tea.KeyEsc, tea.KeyCtrlC:
+		// Cancela: fecha input sem alterar o filtro vigente
+		m.inputMode = InputModeNone
+		m.inputBuf = ""
+		return m, nil
+
+	case tea.KeyBackspace:
+		if len(m.inputBuf) > 0 {
+			r := []rune(m.inputBuf)
+			m.inputBuf = string(r[:len(r)-1])
+		}
+		return m, nil
+
+	case tea.KeyCtrlU:
+		m.inputBuf = ""
+		return m, nil
+
+	case tea.KeyRunes:
+		// Concatena os runas do evento — geralmente 1 rune por keystroke,
+		// mas paste pode entregar vários de uma vez
+		m.inputBuf += string(msg.Runes)
+		return m, nil
+
+	case tea.KeySpace:
+		m.inputBuf += " "
+		return m, nil
+	}
+
+	// Fallback: alguns terminais entregam printáveis como string única
+	if len(key) == 1 && unicode.IsPrint(rune(key[0])) {
+		m.inputBuf += key
+	}
+	return m, nil
+}
+
+// fmtToast wrapper de fmt.Sprintf — deixa o switch acima legível.
 func fmtToast(format string, args ...interface{}) string {
 	return fmt.Sprintf(format, args...)
 }

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -38,6 +38,14 @@ const (
 	TabCount
 )
 
+// InputMode descreve qual input modal está ativo (se algum).
+type InputMode int
+
+const (
+	InputModeNone InputMode = iota
+	InputModeFilter
+)
+
 var tabNames = []string{
 	"F1 Overview",
 	"F2 Syscalls",
@@ -115,6 +123,17 @@ type Model struct {
 	// Export contínuo (tecla 'e' ou flag --export):
 	// quando exportFile != nil, exportTickMsg agenda a próxima escrita JSONL.
 	exportFile *os.File
+
+	// Filter: substring aplicada às listas das views (FD/threads/syscalls).
+	// inputMode é InputModeFilter quando o usuário está digitando — inputBuf
+	// é o que está sendo composto. Após Enter, vira filter; após Esc, descartado.
+	filter    string
+	inputMode InputMode
+	inputBuf  string
+
+	// showHelp: quando true, View() renderiza overlay com keybindings sobre
+	// o conteúdo. Fechado por qualquer tecla (incluindo `?` e `esc`).
+	showHelp bool
 
 	// Collectors
 	fdCollector      *collector.FDCollector
@@ -360,7 +379,14 @@ func (m Model) View() string {
 
 	header := renderHeader(m)
 	tabbar := renderTabBar(m)
-	statusbar := renderStatusBar(m)
+
+	// Statusbar é substituído pelo input box quando inputMode == filter
+	var statusbar string
+	if m.inputMode == InputModeFilter {
+		statusbar = renderFilterInput(m, m.Width)
+	} else {
+		statusbar = renderStatusBar(m)
+	}
 
 	chromeH := lipgloss.Height(header) + lipgloss.Height(tabbar) + lipgloss.Height(statusbar)
 	contentH := m.Height - chromeH
@@ -368,6 +394,12 @@ func (m Model) View() string {
 		contentH = 4
 	}
 	contentW := m.Width
+
+	// Help overlay tem prioridade sobre o conteúdo da view
+	if m.showHelp {
+		overlay := renderHelpOverlay(contentW, contentH)
+		return header + "\n" + tabbar + "\n" + overlay + "\n" + statusbar
+	}
 
 	var content string
 	switch m.ActiveTab {

--- a/internal/tui/view_fd.go
+++ b/internal/tui/view_fd.go
@@ -153,15 +153,26 @@ func renderFDTable(m Model, w, h int) string {
 			lipgloss.NewStyle().Width(dotW).Render(""),
 	)
 
-	// filtra
+	// filtra: primeiro por tipo (FDFilter cíclico), depois por substring
+	// (m.filter, vindo do input mode `/`).
 	filtered := m.FDs
 	if m.FDFilter != "all" && m.FDFilter != "" {
-		filtered = make([]collector.FDEntry, 0, len(m.FDs))
+		next := make([]collector.FDEntry, 0, len(m.FDs))
 		for _, f := range m.FDs {
 			if f.Type == m.FDFilter {
-				filtered = append(filtered, f)
+				next = append(next, f)
 			}
 		}
+		filtered = next
+	}
+	if m.filter != "" {
+		next := make([]collector.FDEntry, 0, len(filtered))
+		for _, f := range filtered {
+			if strings.Contains(strings.ToLower(f.Desc), strings.ToLower(m.filter)) {
+				next = append(next, f)
+			}
+		}
+		filtered = next
 	}
 	sort.Slice(filtered, func(i, j int) bool { return filtered[i].FD < filtered[j].FD })
 


### PR DESCRIPTION
Closes #16.

## Filter substring

Tecla `/` abre input mode renderizando widget no statusbar:
```
 / TCP_                        Enter confirma · Esc cancela · Ctrl+U limpa
```

- Em F6 com filter vazio, primeiro `/` cicla tipos (`all`/`file`/`socket`/...) — comportamento legado mantido pra ergonomia rápida
- Em outras views ou com filter já ativo, abre input com pré-fill
- Enter confirma · Esc cancela (mantém filter anterior) · Ctrl+U limpa input · Backspace UTF-8 safe
- Esc fora de input com filter ativo → limpa filter
- Aplicado em F6 combinando type filter + substring (case-insensitive em DESCRIPTION)

## Help overlay

Tecla `?` abre modal centralizado via `lipgloss.Place` com keybindings agrupadas (Navegação / Filtro / Estado / Snapshot). Border rounded ciano sobre fundo escurecido. Qualquer tecla fecha.

## Cobertura nova
- `TestHelpOverlayToggle`
- `TestFilterInputFlow` (open → type → Enter → confirms)
- `TestFilterEscCancelsKeepsPreviousFilter` (Esc semantics)
- `TestFilterFDView_substring` (F6 filtra por DESCRIPTION)

Tudo verde local: `go test -race ./...`