### PR TITLE
infra: capabilities UX + collector status in help overlay

### DIFF
--- a/cmd/xray/main.go
+++ b/cmd/xray/main.go
@@ -6,6 +6,7 @@ import (
 	"os"
 
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/trentas/xray/internal/bpf"
 	"github.com/trentas/xray/internal/tui"
 )
 
@@ -22,10 +23,14 @@ func main() {
 		os.Exit(1)
 	}
 
-	if !*noEBPF && os.Geteuid() != 0 {
-		fmt.Fprintln(os.Stderr, "erro: eBPF requer root ou CAP_BPF")
-		fmt.Fprintln(os.Stderr, "dica: use --no-ebpf para modo degradado sem root, ou execute com sudo")
-		os.Exit(1)
+	if !*noEBPF {
+		caps := bpf.GetCapStatus()
+		if diag := caps.Diagnose(); diag != "" {
+			fmt.Fprintln(os.Stderr, "erro: eBPF não disponível")
+			fmt.Fprintln(os.Stderr, "")
+			fmt.Fprint(os.Stderr, diag)
+			os.Exit(1)
+		}
 	}
 
 	cfg := tui.Config{

--- a/internal/bpf/caps.go
+++ b/internal/bpf/caps.go
@@ -1,0 +1,168 @@
+//go:build linux
+
+package bpf
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+)
+
+// Capability bits do uapi/linux/capability.h relevantes pro xray.
+const (
+	capBPF       = 39
+	capPerfmon   = 38
+	capSysAdmin  = 21
+	capSysPtrace = 19
+)
+
+// CapStatus descreve quais privilégios o processo atual tem em runtime,
+// mais info de kernel/sysctl que afetam disponibilidade de eBPF.
+type CapStatus struct {
+	IsRoot       bool
+	HasBPF       bool
+	HasPerfmon   bool
+	HasSysAdmin  bool
+	HasSysPtrace bool
+
+	// KernelMajor e KernelMinor são parseados de uname.release.
+	// Vazios (=0) se a leitura falhou.
+	KernelMajor int
+	KernelMinor int
+
+	// UnprivBPFDisabled é o valor de /proc/sys/kernel/unprivileged_bpf_disabled.
+	// 0 = unprivileged eBPF permitido; 1/2 = bloqueado (default em distros modernas).
+	// -1 = sysctl não pôde ser lido.
+	UnprivBPFDisabled int
+}
+
+// GetCapStatus retorna o snapshot de privilégios do processo. Não falha:
+// campos não-determináveis ficam zerados.
+func GetCapStatus() CapStatus {
+	s := CapStatus{
+		IsRoot:            os.Geteuid() == 0,
+		UnprivBPFDisabled: -1,
+	}
+	s.HasBPF = hasCapability(capBPF)
+	s.HasPerfmon = hasCapability(capPerfmon)
+	s.HasSysAdmin = hasCapability(capSysAdmin)
+	s.HasSysPtrace = hasCapability(capSysPtrace)
+	s.KernelMajor, s.KernelMinor = readKernelVersion()
+	if data, err := os.ReadFile("/proc/sys/kernel/unprivileged_bpf_disabled"); err == nil {
+		if v, err := strconv.Atoi(strings.TrimSpace(string(data))); err == nil {
+			s.UnprivBPFDisabled = v
+		}
+	}
+	return s
+}
+
+// CanLoadBPF é true se o processo tem privilégios suficientes pra carregar
+// programas eBPF (root OU CAP_BPF + CAP_PERFMON). Não considera kernel
+// version — só capabilities.
+func (s CapStatus) CanLoadBPF() bool {
+	return s.IsRoot || (s.HasBPF && s.HasPerfmon)
+}
+
+// KernelSupportsBPF é true se kernel >= 5.8 (BTF + ring buffer + CAP_BPF).
+// Versões anteriores funcionam parcialmente mas o xray assume 5.8+.
+func (s CapStatus) KernelSupportsBPF() bool {
+	if s.KernelMajor == 0 {
+		return true // não sabemos; deixa o load falhar com erro mais específico
+	}
+	if s.KernelMajor > 5 {
+		return true
+	}
+	return s.KernelMajor == 5 && s.KernelMinor >= 8
+}
+
+// Diagnose retorna uma mensagem multi-linha explicando o estado do processo
+// e como obter privilégios eBPF (ou cair pra --no-ebpf). Vazio se está OK.
+func (s CapStatus) Diagnose() string {
+	if s.CanLoadBPF() && s.KernelSupportsBPF() {
+		return ""
+	}
+	var b strings.Builder
+
+	// Kernel issue tem prioridade — não adianta sugerir caps se kernel é antigo
+	if !s.KernelSupportsBPF() {
+		fmt.Fprintf(&b, "Kernel %d.%d detectado — xray requer Linux 5.8+ (BTF + CAP_BPF).\n",
+			s.KernelMajor, s.KernelMinor)
+		fmt.Fprintln(&b, "Em kernels antigos, use --no-ebpf (modo /proc-only).")
+		return b.String()
+	}
+
+	fmt.Fprintln(&b, "eBPF não disponível com privilégios atuais.")
+
+	// Quais caps estão faltando?
+	missing := []string{}
+	if !s.HasBPF {
+		missing = append(missing, "CAP_BPF")
+	}
+	if !s.HasPerfmon {
+		missing = append(missing, "CAP_PERFMON")
+	}
+	if len(missing) > 0 && !s.IsRoot {
+		fmt.Fprintf(&b, "Faltando: %s\n", strings.Join(missing, ", "))
+	}
+
+	if s.UnprivBPFDisabled > 0 && !s.IsRoot {
+		fmt.Fprintln(&b, "")
+		fmt.Fprintf(&b, "Aviso: kernel.unprivileged_bpf_disabled=%d — eBPF unprivileged bloqueado.\n",
+			s.UnprivBPFDisabled)
+		fmt.Fprintln(&b, "Pra reverter (temporariamente): sudo sysctl kernel.unprivileged_bpf_disabled=0")
+	}
+
+	fmt.Fprintln(&b, "")
+	fmt.Fprintln(&b, "Opções:")
+	fmt.Fprintln(&b, "  1) Execute com sudo:")
+	fmt.Fprintln(&b, "       sudo ./bin/xray --pid <PID>")
+	fmt.Fprintln(&b, "  2) Aplique caps no binário (uma vez):")
+	fmt.Fprintln(&b, "       sudo setcap cap_bpf,cap_perfmon+ep ./bin/xray")
+	fmt.Fprintln(&b, "  3) Modo /proc-only (sem eBPF, sem privilégios):")
+	fmt.Fprintln(&b, "       ./bin/xray --pid <PID> --no-ebpf")
+
+	return b.String()
+}
+
+// hasCapability lê /proc/self/status (campo CapEff) e testa o bit do cap.
+// Retorna false em qualquer erro.
+func hasCapability(capBit int) bool {
+	f, err := os.Open("/proc/self/status")
+	if err != nil {
+		return false
+	}
+	defer f.Close()
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if !strings.HasPrefix(line, "CapEff:") {
+			continue
+		}
+		hexStr := strings.TrimSpace(strings.TrimPrefix(line, "CapEff:"))
+		eff, err := strconv.ParseUint(hexStr, 16, 64)
+		if err != nil {
+			return false
+		}
+		return eff&(uint64(1)<<uint(capBit)) != 0
+	}
+	return false
+}
+
+// readKernelVersion parseia "X.Y" do começo de /proc/sys/kernel/osrelease.
+func readKernelVersion() (major, minor int) {
+	data, err := os.ReadFile("/proc/sys/kernel/osrelease")
+	if err != nil {
+		return 0, 0
+	}
+	s := strings.TrimSpace(string(data))
+	// Formato: "5.15.0-91-generic" → major=5, minor=15
+	parts := strings.SplitN(s, ".", 3)
+	if len(parts) < 2 {
+		return 0, 0
+	}
+	major, _ = strconv.Atoi(parts[0])
+	minor, _ = strconv.Atoi(parts[1])
+	return major, minor
+}

--- a/internal/bpf/caps_stub.go
+++ b/internal/bpf/caps_stub.go
@@ -1,0 +1,32 @@
+//go:build !linux
+
+package bpf
+
+// CapStatus em OSes não-Linux: sempre indica que eBPF não pode rodar.
+// Mantemos a mesma shape pra que main.go não precise de build tag.
+type CapStatus struct {
+	IsRoot       bool
+	HasBPF       bool
+	HasPerfmon   bool
+	HasSysAdmin  bool
+	HasSysPtrace bool
+
+	KernelMajor       int
+	KernelMinor       int
+	UnprivBPFDisabled int
+}
+
+func GetCapStatus() CapStatus {
+	return CapStatus{UnprivBPFDisabled: -1}
+}
+
+func (CapStatus) CanLoadBPF() bool         { return false }
+func (CapStatus) KernelSupportsBPF() bool  { return false }
+
+func (CapStatus) Diagnose() string {
+	return "" +
+		"eBPF requer Linux 5.8+. Você está rodando em OS não suportado.\n" +
+		"\n" +
+		"Use --no-ebpf pra rodar a TUI em modo simulado/dev:\n" +
+		"  ./bin/xray --pid <PID> --no-ebpf\n"
+}

--- a/internal/bpf/caps_test.go
+++ b/internal/bpf/caps_test.go
@@ -1,0 +1,110 @@
+//go:build linux
+
+package bpf
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestDiagnose_emptyWhenOK: quando processo é root + kernel suportado, Diagnose vazio.
+func TestDiagnose_emptyWhenOK(t *testing.T) {
+	s := CapStatus{
+		IsRoot:      true,
+		KernelMajor: 6,
+		KernelMinor: 0,
+	}
+	if got := s.Diagnose(); got != "" {
+		t.Errorf("esperava vazio, got %q", got)
+	}
+}
+
+func TestDiagnose_kernelTooOld(t *testing.T) {
+	s := CapStatus{
+		IsRoot:      true,
+		KernelMajor: 5,
+		KernelMinor: 4,
+	}
+	out := s.Diagnose()
+	if !strings.Contains(out, "5.4") {
+		t.Errorf("mensagem deveria citar versão do kernel: %q", out)
+	}
+	if !strings.Contains(out, "5.8") {
+		t.Errorf("mensagem deveria citar mínimo 5.8: %q", out)
+	}
+	if !strings.Contains(out, "--no-ebpf") {
+		t.Errorf("mensagem deveria sugerir --no-ebpf: %q", out)
+	}
+}
+
+func TestDiagnose_missingCaps(t *testing.T) {
+	s := CapStatus{
+		IsRoot:      false,
+		HasBPF:      false,
+		HasPerfmon:  false,
+		KernelMajor: 6, KernelMinor: 1,
+	}
+	out := s.Diagnose()
+	for _, want := range []string{"CAP_BPF", "CAP_PERFMON", "sudo", "setcap", "--no-ebpf"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("mensagem não contém %q: %s", want, out)
+		}
+	}
+}
+
+func TestDiagnose_unprivilegedDisabled(t *testing.T) {
+	s := CapStatus{
+		IsRoot:            false,
+		HasBPF:            false,
+		HasPerfmon:        false,
+		KernelMajor:       6,
+		KernelMinor:       1,
+		UnprivBPFDisabled: 2,
+	}
+	out := s.Diagnose()
+	if !strings.Contains(out, "unprivileged_bpf_disabled") {
+		t.Errorf("mensagem deveria explicar unprivileged_bpf_disabled: %s", out)
+	}
+	if !strings.Contains(out, "sysctl") {
+		t.Errorf("mensagem deveria sugerir sysctl: %s", out)
+	}
+}
+
+func TestKernelSupportsBPF(t *testing.T) {
+	cases := []struct {
+		major, minor int
+		want         bool
+	}{
+		{0, 0, true}, // desconhecido — assume ok, deixa load falhar
+		{4, 19, false},
+		{5, 4, false},
+		{5, 8, true},
+		{5, 15, true},
+		{6, 0, true},
+		{6, 5, true},
+	}
+	for _, c := range cases {
+		s := CapStatus{KernelMajor: c.major, KernelMinor: c.minor}
+		if got := s.KernelSupportsBPF(); got != c.want {
+			t.Errorf("kernel %d.%d: got %v, esperado %v", c.major, c.minor, got, c.want)
+		}
+	}
+}
+
+func TestCanLoadBPF(t *testing.T) {
+	cases := []struct {
+		s    CapStatus
+		want bool
+	}{
+		{CapStatus{IsRoot: true}, true},
+		{CapStatus{IsRoot: false, HasBPF: true, HasPerfmon: true}, true},
+		{CapStatus{IsRoot: false, HasBPF: true, HasPerfmon: false}, false},
+		{CapStatus{IsRoot: false, HasBPF: false, HasPerfmon: true}, false},
+		{CapStatus{IsRoot: false}, false},
+	}
+	for _, c := range cases {
+		if got := c.s.CanLoadBPF(); got != c.want {
+			t.Errorf("status %+v: got %v, esperado %v", c.s, got, c.want)
+		}
+	}
+}

--- a/internal/tui/help.go
+++ b/internal/tui/help.go
@@ -8,7 +8,11 @@ import (
 
 // renderHelpOverlay desenha um modal centralizado com todos os keybindings.
 // Recebe as dimensões totais do content area; lipgloss.Place centraliza o card.
-func renderHelpOverlay(w, h int) string {
+//
+// O model é passado pra que possamos mostrar status dos collectors em runtime
+// (real vs mock) — issue #19 acceptance: "Tecla ou flag pra ver o status de
+// cada collector em runtime".
+func renderHelpOverlayWithStatus(m Model, w, h int) string {
 	sectionTitle := lipgloss.NewStyle().Foreground(ColorCyan).Bold(true)
 	keyStyle := lipgloss.NewStyle().Foreground(ColorTeal).Bold(true)
 	descStyle := lipgloss.NewStyle().Foreground(ColorText)
@@ -19,6 +23,16 @@ func renderHelpOverlay(w, h int) string {
 	}
 	dimRow := func(key, desc string) string {
 		return keyStyle.Render(padRight(key, 14)) + " " + dimDesc.Render(desc)
+	}
+
+	statusReal := lipgloss.NewStyle().Foreground(ColorGreen).Render("● real")
+	statusMock := lipgloss.NewStyle().Foreground(ColorAmber).Render("○ mock")
+	statusRow := func(name string, isMock bool) string {
+		s := statusReal
+		if isMock {
+			s = statusMock
+		}
+		return keyStyle.Render(padRight(name, 14)) + " " + s
 	}
 
 	lines := []string{
@@ -43,6 +57,14 @@ func renderHelpOverlay(w, h int) string {
 		row("s", "Snapshot one-shot (xray-snapshot-<ts>.json)"),
 		row("e", "Toggle export contínuo (xray-export-<ts>.jsonl)"),
 		dimRow("--export", "Flag CLI: export desde o launch + snapshot final ao sair"),
+		"",
+		sectionTitle.Render("Collectors"),
+		statusRow("cpu", m.usingMockCPU),
+		statusRow("memory", m.usingMockMem),
+		statusRow("threads", m.usingMockThreads),
+		statusRow("io-wait", m.usingMockIOWait),
+		statusRow("io-throughput", m.usingMockIOThrough),
+		statusRow("fds", m.usingMockFDs),
 	}
 
 	body := strings.Join(lines, "\n")

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -397,7 +397,7 @@ func (m Model) View() string {
 
 	// Help overlay tem prioridade sobre o conteúdo da view
 	if m.showHelp {
-		overlay := renderHelpOverlay(contentW, contentH)
+		overlay := renderHelpOverlayWithStatus(m, contentW, contentH)
 		return header + "\n" + tabbar + "\n" + overlay + "\n" + statusbar
 	}
 


### PR DESCRIPTION
Closes #19.

## main.go: erro acionável em vez de "eBPF requer root"

Antes:
```
erro: eBPF requer root ou CAP_BPF
dica: use --no-ebpf para modo degradado sem root, ou execute com sudo
```

Agora detecta cenário e dá próximo passo certo:

- Kernel < 5.8 → cita versão + sugere `--no-ebpf`
- Faltando caps → lista quais + 3 opções (sudo / setcap / --no-ebpf)
- `unprivileged_bpf_disabled` > 0 → explica sysctl pra reverter
- macOS/Windows → "eBPF requer Linux 5.8+"

## Help overlay (`?`) ganha seção "Collectors"

```
cpu              ● real
memory           ○ mock
threads          ● real
io-wait          ● real
io-throughput    ● real
fds              ● real
```

Atende acceptance criteria "ver status de cada collector em runtime".

## Implementação

`internal/bpf/caps.go` parseia `/proc/self/status` campo CapEff (hex bitmask), `/proc/sys/kernel/osrelease` (major.minor) e `/proc/sys/kernel/unprivileged_bpf_disabled`. Stub não-Linux retorna mesma shape.

## Cobertura nova
- TestDiagnose_emptyWhenOK / kernelTooOld / missingCaps / unprivilegedDisabled
- TestKernelSupportsBPF (matrix 4.19 → 6.5)
- TestCanLoadBPF (matrix root × caps)