### PR TITLE
infra: release tooling (goreleaser + GitHub Actions)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,30 @@
+name: release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+
+jobs:
+  goreleaser:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # goreleaser usa o histórico pra changelog
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.22'
+          cache: true
+
+      - uses: goreleaser/goreleaser-action@v6
+        with:
+          distribution: goreleaser
+          version: '~> v2'
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,108 @@
+version: 2
+
+project_name: xray
+
+before:
+  hooks:
+    - go mod tidy
+
+builds:
+  # Build default — sem eBPF, roda em qualquer OS suportado.
+  # Quando os collectors eBPF (#9-#14) entrarem, a release vai ganhar uma
+  # segunda variante com -tags=ebpf só para linux/amd64 e linux/arm64.
+  - id: xray
+    main: ./cmd/xray
+    binary: xray
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - darwin
+    goarch:
+      - amd64
+      - arm64
+    flags:
+      - -trimpath
+    ldflags:
+      - -s -w
+      - -X main.version={{ .Version }}
+      - -X main.commit={{ .Commit }}
+      - -X main.buildDate={{ .Date }}
+
+archives:
+  - id: xray
+    ids: [xray]
+    formats: [tar.gz]
+    name_template: >-
+      {{ .ProjectName }}-{{ .Version }}-{{ .Os }}-{{ .Arch }}
+    files:
+      - LICENSE
+      - README.md
+      - CLAUDE.md
+
+checksum:
+  name_template: "SHA256SUMS"
+  algorithm: sha256
+
+snapshot:
+  version_template: "{{ .Tag }}-next"
+
+changelog:
+  sort: asc
+  use: github
+  filters:
+    exclude:
+      - "^docs:"
+      - "^test:"
+      - "^chore:"
+      - "^ci:"
+  groups:
+    - title: "Features"
+      regexp: "^.*feat[(\\w)]*:.*$"
+      order: 0
+    - title: "Bug fixes"
+      regexp: "^.*fix[(\\w)]*:.*$"
+      order: 1
+    - title: "Collectors"
+      regexp: "^.*collector[(\\w)]*:.*$"
+      order: 2
+    - title: "TUI"
+      regexp: "^.*tui[(\\w)]*:.*$"
+      order: 3
+    - title: "Infra"
+      regexp: "^.*infra[(\\w)]*:.*$"
+      order: 4
+    - title: "Outros"
+      order: 99
+
+release:
+  github:
+    owner: trentas
+    name: xray
+  name_template: "xray {{ .Version }}"
+  draft: false
+  prerelease: auto
+  mode: replace
+  header: |
+    ## xray {{ .Version }}
+
+    Binários cross-compiled para Linux (amd64/arm64) e macOS (amd64/arm64).
+
+    ### Verificação de integridade
+
+    ```bash
+    sha256sum -c SHA256SUMS
+    ```
+
+    ### Instalação
+
+    ```bash
+    curl -L https://github.com/trentas/xray/releases/download/{{ .Tag }}/xray-{{ .Version }}-linux-amd64.tar.gz | tar xz
+    sudo install xray /usr/local/bin/
+    xray --pid <PID> --no-ebpf
+    ```
+  footer: |
+    ---
+
+    Esta é uma release **sem eBPF embarcado** (modo `--no-ebpf` apenas).
+    Coletores eBPF estão sendo entregues nas issues #9-#14.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Fabio Trentini
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/cmd/xray/main.go
+++ b/cmd/xray/main.go
@@ -10,16 +10,31 @@ import (
 	"github.com/trentas/xray/internal/tui"
 )
 
+// Variáveis injetadas via -ldflags no build de release (goreleaser).
+// Em dev (`go build`/`go run`), ficam com "dev"/"none"/"unknown".
+var (
+	version   = "dev"
+	commit    = "none"
+	buildDate = "unknown"
+)
+
 func main() {
-	pid     := flag.Int("pid", 0, "PID do processo a inspecionar (obrigatório)")
-	fps     := flag.Int("fps", 5, "Taxa de atualização da TUI (frames por segundo)")
+	pid := flag.Int("pid", 0, "PID do processo a inspecionar (obrigatório)")
+	fps := flag.Int("fps", 5, "Taxa de atualização da TUI (frames por segundo)")
 	noEBPF := flag.Bool("no-ebpf", false, "Modo degradado: usa apenas /proc, sem eBPF (útil para desenvolvimento)")
-	export  := flag.Bool("export", false, "Salvar snapshot JSON ao sair (equivalente à tecla 'e')")
+	export := flag.Bool("export", false, "Salvar snapshot JSON ao sair (equivalente à tecla 'e')")
+	showVer := flag.Bool("version", false, "Imprime versão e sai")
 	flag.Parse()
+
+	if *showVer {
+		fmt.Printf("xray %s (commit %s, built %s)\n", version, commit, buildDate)
+		os.Exit(0)
+	}
 
 	if *pid == 0 {
 		fmt.Fprintln(os.Stderr, "erro: --pid é obrigatório")
-		fmt.Fprintln(os.Stderr, "uso:  xray --pid <PID> [--fps 5] [--no-ebpf]")
+		fmt.Fprintln(os.Stderr, "uso:  xray --pid <PID> [--fps 5] [--no-ebpf] [--export]")
+		fmt.Fprintln(os.Stderr, "      xray --version")
 		os.Exit(1)
 	}
 


### PR DESCRIPTION
Closes #20.

## Pipeline

`git tag v0.1.0 && git push origin v0.1.0`
→ workflow `release.yml` dispara
→ `goreleaser` builda 4 binários
→ release abre em `github.com/trentas/xray/releases` com changelog + SHA256SUMS

## Build matrix

- linux/amd64, linux/arm64, darwin/amd64, darwin/arm64
- CGO_ENABLED=0, -trimpath, -s -w (binários menores)
- ldflags injeta `version` / `commit` / `buildDate` em `main.go`
- Archive: `xray-<ver>-<os>-<arch>.tar.gz` com binary + LICENSE + README + CLAUDE.md

## Mudanças

- `.goreleaser.yaml` v2 com changelog agrupado por tipo (feat/fix/collector/tui/infra)
- `.github/workflows/release.yml`: trigger em `v*`, usa goreleaser-action@v6
- `cmd/xray/main.go`: flag `--version` + vars package-level pra ldflags
- `LICENSE` MIT

## Verificação local

```bash
go build -ldflags="-X main.version=v0.0.1-test ..." -o /tmp/xray ./cmd/xray
/tmp/xray --version
# xray v0.0.1-test (commit abc123, built 2026-05-05)
```

## Defer pra futuro

eBPF release variants (linux + tags=ebpf + libbpf-dev no runner) virão quando #9-#14 entregarem o código real. A release atual ainda é pura modo `--no-ebpf`.