### PR TITLE
collector+infra: dynamic clkTck + lima.yaml for ARM Linux dev VM

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,4 +200,26 @@ make clean           # rm -rf bin/
 make lint            # golangci-lint (precisa instalar)
 ```
 
+### Ambiente Linux para testar eBPF (Mac Apple Silicon)
+
+`lima.yaml` na raiz do repo provisiona Ubuntu 24.04 ARM64 com Go 1.22 +
+clang + libbpf-dev + bpftool já instalados, com o `~` do Mac montado
+read-write dentro do VM. Edita no Mac, roda dentro do VM.
+
+```bash
+brew install lima
+limactl start --name=xray-dev ./lima.yaml
+
+# entra no VM
+limactl shell xray-dev
+cd /Users/<você>/src/github.com/trentas/xray
+make test
+sudo ./bin/xray --pid 1 --no-ebpf
+
+# limpa quando terminar
+limactl stop xray-dev && limactl delete xray-dev
+```
+
+Em Macs Intel, troque `vmType: vz` por `vmType: qemu` no `lima.yaml`.
+
 Ver [CLAUDE.md](CLAUDE.md) para guia de implementação e contratos dos collectors.

--- a/internal/collector/clktck_test.go
+++ b/internal/collector/clktck_test.go
@@ -1,0 +1,17 @@
+package collector
+
+import "testing"
+
+// TestDetectClkTck — em qualquer sistema POSIX (Linux/macOS) `getconf CLK_TCK`
+// retorna um valor sensato. Em sistemas onde o comando não existe, o fallback
+// é 100. Verificamos que retorna >0 e está num range razoável.
+func TestDetectClkTck(t *testing.T) {
+	v := detectClkTck()
+	if v <= 0 {
+		t.Fatalf("clkTck deve ser positivo, got %v", v)
+	}
+	// Valores conhecidos: 100 (x86 Ubuntu), 250 (ARM Ubuntu/RHEL), 1000 (Fedora ARM)
+	if v < 50 || v > 10000 {
+		t.Errorf("clkTck %v fora de range razoável (50..10000)", v)
+	}
+}

--- a/internal/collector/cpu_proc.go
+++ b/internal/collector/cpu_proc.go
@@ -3,6 +3,7 @@ package collector
 import (
 	"fmt"
 	"os"
+	"os/exec"
 	"strconv"
 	"strings"
 	"sync"
@@ -61,9 +62,25 @@ func (c *CPUCollector) loop() {
 	}
 }
 
-// clkTck assume CONFIG_HZ=100, default em x86/x86_64 Linux há ~20 anos.
-// Em ARM pode ser 250 — corrigir via sysconf(_SC_CLK_TCK) quando virar problema.
-const clkTck = 100
+// clkTck é a frequência do relógio do kernel (CONFIG_HZ), em ticks/segundo.
+// Varia por arquitetura/distro:
+//   - x86/x86_64: tipicamente 100 (Ubuntu) ou 250 (RHEL family)
+//   - ARM/ARM64:  tipicamente 250 (Ubuntu/Debian) ou 1000 (Fedora ARM)
+//
+// Detecção via `getconf CLK_TCK` (POSIX, disponível em Linux e Darwin) —
+// uma única invocação no startup, custo desprezível. Antes era hardcoded em
+// 100, o que dava CPU% 2.5x errado em ARM (issue #18 follow-up).
+var clkTck float64 = detectClkTck()
+
+func detectClkTck() float64 {
+	out, err := exec.Command("getconf", "CLK_TCK").Output()
+	if err == nil {
+		if v, err := strconv.ParseFloat(strings.TrimSpace(string(out)), 64); err == nil && v > 0 {
+			return v
+		}
+	}
+	return 100 // fallback razoável
+}
 
 func (c *CPUCollector) sample() (CpuSample, error) {
 	data, err := os.ReadFile(fmt.Sprintf("/proc/%d/stat", c.pid))

--- a/lima.yaml
+++ b/lima.yaml
@@ -1,0 +1,103 @@
+# lima.yaml — VM de desenvolvimento Linux ARM64 para testar xray com eBPF.
+#
+# Uso:
+#   limactl start --name=xray-dev ./lima.yaml
+#   limactl shell xray-dev
+#   cd /Users/<você>/src/github.com/trentas/xray
+#   make build-ebpf       # quando os .bpf.c entrarem (issues #9-#14)
+#   sudo ./bin/xray --pid 1
+#
+# Limpeza:
+#   limactl stop xray-dev && limactl delete xray-dev
+
+# Apple Virtualization Framework — performance quase nativa em Apple Silicon.
+# Em Macs Intel, troque para "qemu" (Lima detecta automaticamente também).
+vmType: vz
+
+# Ubuntu 24.04 LTS Server cloudimg arm64.
+# Kernel 6.8 vem com BTF, ring buffer, CAP_BPF — tudo que precisamos.
+images:
+  - location: "https://cloud-images.ubuntu.com/releases/24.04/release/ubuntu-24.04-server-cloudimg-arm64.img"
+    arch: aarch64
+
+cpus: 4
+memory: "4GiB"
+disk: "20GiB"
+
+# Compartilha o home do Mac com o VM. Edita no Mac, roda dentro do VM.
+# `writable: true` permite que builds dentro do VM (bin/, *.o) apareçam no Mac.
+mounts:
+  - location: "~"
+    writable: true
+mountType: virtiofs
+
+# Provisioning: roda uma vez no primeiro start.
+provision:
+  - mode: system
+    description: "Instala toolchain Go + eBPF (clang, libbpf, bpftool)"
+    script: |
+      #!/bin/bash
+      set -eux
+      export DEBIAN_FRONTEND=noninteractive
+      apt-get update
+      apt-get install -y \
+        build-essential \
+        clang \
+        llvm \
+        libbpf-dev \
+        linux-tools-common \
+        linux-tools-generic \
+        bpftool \
+        git \
+        curl \
+        ca-certificates \
+        pkg-config
+
+      # Go 1.22+ — apt do Ubuntu 24.04 ainda traz 1.22 mas em path estranho.
+      # Baixar diretamente do go.dev é mais determinístico.
+      GOVER=1.22.10
+      if ! command -v go >/dev/null 2>&1 || ! go version | grep -q "go1.2[2-9]"; then
+        curl -sL "https://go.dev/dl/go${GOVER}.linux-arm64.tar.gz" | tar -C /usr/local -xz
+        ln -sf /usr/local/go/bin/go /usr/local/bin/go
+        ln -sf /usr/local/go/bin/gofmt /usr/local/bin/gofmt
+      fi
+
+  - mode: user
+    description: "PATH + variáveis convenientes para o usuário default (lima)"
+    script: |
+      #!/bin/bash
+      set -eux
+      grep -q 'GOPATH' ~/.bashrc 2>/dev/null || cat >>~/.bashrc <<'EOF'
+
+      # xray dev env
+      export GOPATH=$HOME/go
+      export PATH=$PATH:/usr/local/go/bin:$GOPATH/bin
+      EOF
+
+# Probes: validam que o setup terminou. lima espera todos passarem antes de
+# devolver controle ao terminal.
+probes:
+  - description: "Go instalado"
+    script: |
+      #!/bin/bash
+      command -v go >/dev/null 2>&1
+      go version | grep -q "go1.2[2-9]"
+  - description: "libbpf-dev instalado"
+    script: |
+      #!/bin/bash
+      pkg-config --exists libbpf
+  - description: "clang disponível"
+    script: |
+      #!/bin/bash
+      command -v clang >/dev/null 2>&1
+
+# Ao terminar provisioning, imprime hints úteis no log (`limactl logs xray-dev`).
+message: |
+  ✓ VM xray-dev pronta.
+
+  Próximos passos:
+    limactl shell xray-dev
+    cd /Users/$(whoami)/src/github.com/trentas/xray   # ajuste pro seu user
+    make test                                          # roda os testes Linux
+    make build-ebpf                                    # quando .bpf.c entrarem (#9+)
+    sudo ./bin/xray --pid 1 --no-ebpf                  # já funciona com a MVP atual


### PR DESCRIPTION
Dois fixes pré-eBPF:

## clkTck dinâmico (corrige bug ARM)

`internal/collector/cpu_proc.go` tinha `const clkTck = 100` hardcoded. Em ARM Linux (Ubuntu/Debian = CONFIG_HZ=250, Fedora ARM = 1000), o CPU% reportava **2.5x ou 10x menor** que o real.

Agora detectado via `getconf CLK_TCK` no startup (POSIX, funciona em Linux e macOS, custo desprezível de 1 fork). Fallback 100 se falhar.

Verificado: macOS local retorna 100; Ubuntu ARM retornará 250.

## lima.yaml para dev VM

VM Ubuntu 24.04 ARM64 reproduzível pra testar eBPF em Mac Apple Silicon. Provisiona Go 1.22, clang, libbpf-dev, bpftool, com `~` do Mac montado read-write dentro do VM.

```bash
brew install lima
limactl start --name=xray-dev ./lima.yaml
limactl shell xray-dev
cd /Users/<u>/src/github.com/trentas/xray
make test && sudo ./bin/xray --pid 1 --no-ebpf
```

README atualizado com seção dev VM.

Pré-requisito agora satisfeito pras issues #9-#14 começarem.