### PR TITLE
tui: standardize ColorPanel as background across panels (fix bg leak)

### DIFF
--- a/internal/tui/help.go
+++ b/internal/tui/help.go
@@ -13,26 +13,29 @@ import (
 // (real vs mock) — issue #19 acceptance: "Tecla ou flag pra ver o status de
 // cada collector em runtime".
 func renderHelpOverlayWithStatus(m Model, w, h int) string {
-	sectionTitle := lipgloss.NewStyle().Foreground(ColorCyan).Bold(true)
-	keyStyle := lipgloss.NewStyle().Foreground(ColorTeal).Bold(true)
-	descStyle := lipgloss.NewStyle().Foreground(ColorText)
-	dimDesc := lipgloss.NewStyle().Foreground(ColorMuted)
+	// Help overlay vive sobre o ColorPanel do card. Todos os estilos abaixo
+	// setam ColorPanel como bg pra que segmentos não vazem o background do
+	// terminal entre as palavras.
+	sectionTitle := lipgloss.NewStyle().Foreground(ColorCyan).Background(ColorPanel).Bold(true)
+	keyStyle := lipgloss.NewStyle().Foreground(ColorTeal).Background(ColorPanel).Bold(true)
+	descStyle := lipgloss.NewStyle().Foreground(ColorText).Background(ColorPanel)
+	dimDesc := lipgloss.NewStyle().Foreground(ColorMuted).Background(ColorPanel)
 
 	row := func(key, desc string) string {
-		return keyStyle.Render(padRight(key, 14)) + " " + descStyle.Render(desc)
+		return keyStyle.Render(padRight(key, 14)) + descStyle.Render(" "+desc)
 	}
 	dimRow := func(key, desc string) string {
-		return keyStyle.Render(padRight(key, 14)) + " " + dimDesc.Render(desc)
+		return keyStyle.Render(padRight(key, 14)) + dimDesc.Render(" "+desc)
 	}
 
-	statusReal := lipgloss.NewStyle().Foreground(ColorGreen).Render("● real")
-	statusMock := lipgloss.NewStyle().Foreground(ColorAmber).Render("○ mock")
+	statusReal := lipgloss.NewStyle().Foreground(ColorGreen).Background(ColorPanel).Render("● real")
+	statusMock := lipgloss.NewStyle().Foreground(ColorAmber).Background(ColorPanel).Render("○ mock")
 	statusRow := func(name string, isMock bool) string {
 		s := statusReal
 		if isMock {
 			s = statusMock
 		}
-		return keyStyle.Render(padRight(name, 14)) + " " + s
+		return keyStyle.Render(padRight(name, 14)) + descStyle.Render(" ") + s
 	}
 
 	lines := []string{

--- a/internal/tui/panel.go
+++ b/internal/tui/panel.go
@@ -103,13 +103,25 @@ func minInt(a, b int) int {
 }
 
 // padRight retorna s padded com espaços até `w` colunas (largura visível).
-// Se s já for >= w, é truncado.
+// O padding sai com Background(ColorPanel) — caso contrário, células
+// rendered ficariam com bg default do terminal e vazariam pelo gap.
 func padRight(s string, w int) string {
 	vw := lipgloss.Width(s)
 	if vw >= w {
 		return s
 	}
-	return s + strings.Repeat(" ", w-vw)
+	pad := lipgloss.NewStyle().Background(ColorPanel).Render(strings.Repeat(" ", w-vw))
+	return s + pad
+}
+
+// panelRow concatena segments com um separador de 1 espaço PINTADO com
+// ColorPanel — usar pra montar linhas dentro de panel bodies sem deixar
+// gaps com bg default do terminal vazando entre as palavras.
+//
+// Substitui o padrão antigo `name + " " + bar + " " + count`.
+func panelRow(parts ...string) string {
+	sep := lipgloss.NewStyle().Background(ColorPanel).Render(" ")
+	return strings.Join(parts, sep)
 }
 
 // truncate corta s para caber em `w` colunas visíveis, adicionando "…" se necessário.

--- a/internal/tui/panels.go
+++ b/internal/tui/panels.go
@@ -31,7 +31,7 @@ func renderCPU(history []float64, w int) string {
 		color = ColorAmber
 	}
 
-	val := lipgloss.NewStyle().Foreground(color).Bold(true).Render(fmt.Sprintf("%.0f%%", cur))
+	val := lipgloss.NewStyle().Foreground(color).Background(ColorPanel).Bold(true).Render(fmt.Sprintf("%.0f%%", cur))
 	lbl := MutedStyle.Render("cpu usage")
 
 	rightW := maxInt(lipgloss.Width(val), lipgloss.Width(lbl))
@@ -105,12 +105,13 @@ func renderSyscallBars(counts map[string]uint64, names []string, w, h int) strin
 	lines := make([]string, 0, len(entries))
 	for i, s := range entries {
 		c := syscallBarColors[i%len(syscallBarColors)]
-		name := lipgloss.NewStyle().Foreground(c).Width(nameW).Render(truncate(s.name, nameW))
+		name := lipgloss.NewStyle().Foreground(c).Background(ColorPanel).Width(nameW).Render(truncate(s.name, nameW))
 		bar := HorizontalBar(float64(s.count), float64(maxCount), barW, c)
 		count := lipgloss.NewStyle().
-			Foreground(c).Width(countW).Align(lipgloss.Right).
+			Foreground(c).Background(ColorPanel).Width(countW).Align(lipgloss.Right).
 			Render(fmt.Sprintf("%d", s.count))
-		lines = append(lines, name+" "+bar+" "+count)
+		lines = append(lines, panelRow(name, bar, count))
+
 	}
 	return strings.Join(lines, "\n")
 }
@@ -176,19 +177,20 @@ func renderSyscallTable(counts map[string]uint64, w, h int) string {
 
 	for i, s := range all {
 		c := syscallBarColors[i%len(syscallBarColors)]
-		name := lipgloss.NewStyle().Foreground(c).Width(nameW).Render(truncate(s.name, nameW))
+		name := lipgloss.NewStyle().Foreground(c).Background(ColorPanel).Width(nameW).Render(truncate(s.name, nameW))
 		bar := HorizontalBar(float64(s.count), float64(maxCount), barW, c)
 		count := lipgloss.NewStyle().
-			Foreground(ColorText).Width(countW).Align(lipgloss.Right).
+			Foreground(ColorText).Background(ColorPanel).Width(countW).Align(lipgloss.Right).
 			Render(fmt.Sprintf("%d", s.count))
 		pct := 0.0
 		if total > 0 {
 			pct = float64(s.count) / float64(total) * 100
 		}
 		pctStr := lipgloss.NewStyle().
-			Foreground(ColorMuted).Width(pctW).Align(lipgloss.Right).
+			Foreground(ColorMuted).Background(ColorPanel).Width(pctW).Align(lipgloss.Right).
 			Render(fmt.Sprintf("%.1f%%", pct))
-		lines = append(lines, name+" "+bar+" "+count+" "+pctStr)
+		lines = append(lines, panelRow(name, bar, count, pctStr))
+
 	}
 
 	footer := DimStyle.Render(strings.Repeat("─", w)) + "\n" +
@@ -227,21 +229,21 @@ func renderThreadList(threads []collector.ThreadInfo, w, h int) string {
 			break
 		}
 		glyph, color := threadStateGlyph(t.State)
-		gly := lipgloss.NewStyle().Foreground(color).Render(glyph)
-		name := lipgloss.NewStyle().Foreground(ColorBright).Width(nameW).Render(truncate(t.Name, nameW))
+		gly := lipgloss.NewStyle().Foreground(color).Background(ColorPanel).Render(glyph)
+		name := lipgloss.NewStyle().Foreground(ColorBright).Background(ColorPanel).Width(nameW).Render(truncate(t.Name, nameW))
 
 		var bar string
 		if t.State == "running" {
 			bar = HorizontalBar(t.CPUPct, 100, barW, color)
 		} else {
-			bar = lipgloss.NewStyle().Foreground(ColorDim).Render(strings.Repeat("░", barW))
+			bar = lipgloss.NewStyle().Foreground(ColorDim).Background(ColorPanel).Render(strings.Repeat("░", barW))
 		}
 
 		cpuLabel := "--"
 		if t.CPUPct > 0 {
 			cpuLabel = fmt.Sprintf("%.0f%%", t.CPUPct)
 		}
-		cpuStr := lipgloss.NewStyle().Foreground(ColorMuted).Width(cpuW).Align(lipgloss.Right).Render(cpuLabel)
+		cpuStr := lipgloss.NewStyle().Foreground(ColorMuted).Background(ColorPanel).Width(cpuW).Align(lipgloss.Right).Render(cpuLabel)
 
 		wait := ""
 		if t.Waiting != "" {
@@ -249,7 +251,8 @@ func renderThreadList(threads []collector.ThreadInfo, w, h int) string {
 		}
 		waitCol := lipgloss.NewStyle().Width(waitW).Render(wait)
 
-		lines = append(lines, gly+" "+name+" "+bar+" "+cpuStr+" "+waitCol)
+		lines = append(lines, panelRow(gly, name, bar, cpuStr, waitCol))
+
 	}
 	return strings.Join(lines, "\n")
 }
@@ -279,21 +282,21 @@ func renderThreadTable(threads []collector.ThreadInfo, w, h int) string {
 			break
 		}
 		glyph, color := threadStateGlyph(t.State)
-		gly := lipgloss.NewStyle().Foreground(color).Width(2).Render(glyph)
-		name := lipgloss.NewStyle().Foreground(ColorBright).Width(nameW).Render(truncate(t.Name, nameW))
-		state := lipgloss.NewStyle().Foreground(color).Width(stateW).Render(strings.ToUpper(t.State))
+		gly := lipgloss.NewStyle().Foreground(color).Background(ColorPanel).Width(2).Render(glyph)
+		name := lipgloss.NewStyle().Foreground(ColorBright).Background(ColorPanel).Width(nameW).Render(truncate(t.Name, nameW))
+		state := lipgloss.NewStyle().Foreground(color).Background(ColorPanel).Width(stateW).Render(strings.ToUpper(t.State))
 
 		var bar string
 		if t.State == "running" {
 			bar = HorizontalBar(t.CPUPct, 100, barW, color)
 		} else {
-			bar = lipgloss.NewStyle().Foreground(ColorDim).Render(strings.Repeat("░", barW))
+			bar = lipgloss.NewStyle().Foreground(ColorDim).Background(ColorPanel).Render(strings.Repeat("░", barW))
 		}
 		cpuLabel := "--"
 		if t.CPUPct > 0 {
 			cpuLabel = fmt.Sprintf("%.0f%%", t.CPUPct)
 		}
-		cpuStr := lipgloss.NewStyle().Foreground(ColorMuted).Width(cpuW).Align(lipgloss.Right).Render(cpuLabel)
+		cpuStr := lipgloss.NewStyle().Foreground(ColorMuted).Background(ColorPanel).Width(cpuW).Align(lipgloss.Right).Render(cpuLabel)
 
 		wait := "–"
 		waitColor := ColorDim
@@ -301,9 +304,10 @@ func renderThreadTable(threads []collector.ThreadInfo, w, h int) string {
 			wait = t.Waiting
 			waitColor = ColorAmber
 		}
-		waitStr := lipgloss.NewStyle().Foreground(waitColor).Width(waitW).Render(truncate(wait, waitW))
+		waitStr := lipgloss.NewStyle().Foreground(waitColor).Background(ColorPanel).Width(waitW).Render(truncate(wait, waitW))
 
-		lines = append(lines, gly+name+" "+state+" "+bar+" "+cpuStr+" "+waitStr)
+		lines = append(lines, panelRow(gly+name, state, bar, cpuStr, waitStr))
+
 	}
 	return strings.Join(lines, "\n")
 }
@@ -336,9 +340,9 @@ func renderIOMini(io collector.IOStats, readH, writeH []float64, maxRead, maxWri
 	wSpark := SparklineWithMax(writeH, sparkW, maxWrite, ColorOrange)
 
 	rLabel := MutedStyle.Render("read/s ") +
-		lipgloss.NewStyle().Foreground(ColorCyan).Bold(true).Render(fmtBytesPerSec(curR))
+		lipgloss.NewStyle().Foreground(ColorCyan).Background(ColorPanel).Bold(true).Render(fmtBytesPerSec(curR))
 	wLabel := MutedStyle.Render("write/s ") +
-		lipgloss.NewStyle().Foreground(ColorOrange).Bold(true).Render(fmtBytesPerSec(curW))
+		lipgloss.NewStyle().Foreground(ColorOrange).Background(ColorPanel).Bold(true).Render(fmtBytesPerSec(curW))
 	right := lipgloss.NewStyle().Width(rightW).Align(lipgloss.Left).Render(rLabel) +
 		"\n" +
 		lipgloss.NewStyle().Width(rightW).Align(lipgloss.Left).Render(wLabel)
@@ -381,9 +385,9 @@ func renderIOLargeThroughput(io collector.IOStats, readH, writeH []float64, maxR
 	wSpark := SparklineWithMax(writeH, sparkW, maxWrite, ColorOrange)
 
 	rRight := MutedStyle.Render("read/s\n") +
-		lipgloss.NewStyle().Foreground(ColorCyan).Bold(true).Render(fmtBytesPerSec(curR))
+		lipgloss.NewStyle().Foreground(ColorCyan).Background(ColorPanel).Bold(true).Render(fmtBytesPerSec(curR))
 	wRight := MutedStyle.Render("write/s\n") +
-		lipgloss.NewStyle().Foreground(ColorOrange).Bold(true).Render(fmtBytesPerSec(curW))
+		lipgloss.NewStyle().Foreground(ColorOrange).Background(ColorPanel).Bold(true).Render(fmtBytesPerSec(curW))
 
 	first := lipgloss.JoinHorizontal(lipgloss.Top,
 		rSpark, "  ",
@@ -427,16 +431,17 @@ func renderFDMini(fds []collector.FDEntry, w int) string {
 	}
 
 	headerLine := MutedStyle.Render(padRight("open fds", w-6)) +
-		lipgloss.NewStyle().Foreground(ColorBright).Bold(true).Render(fmt.Sprintf("%4d", len(fds)))
+		lipgloss.NewStyle().Foreground(ColorBright).Background(ColorPanel).Bold(true).Render(fmt.Sprintf("%4d", len(fds)))
 
 	lines := []string{headerLine}
 	for _, t := range fdTypeOrder {
 		c := counts[t]
 		color := FDTypeColor(t)
-		name := lipgloss.NewStyle().Foreground(ColorMuted).Width(nameW).Render(t)
+		name := lipgloss.NewStyle().Foreground(ColorMuted).Background(ColorPanel).Width(nameW).Render(t)
 		bar := HorizontalBar(float64(c), float64(maxC), barW, color)
-		count := lipgloss.NewStyle().Foreground(color).Width(countW).Align(lipgloss.Right).Render(fmt.Sprintf("%d", c))
-		lines = append(lines, name+" "+bar+" "+count)
+		count := lipgloss.NewStyle().Foreground(color).Background(ColorPanel).Width(countW).Align(lipgloss.Right).Render(fmt.Sprintf("%d", c))
+		lines = append(lines, panelRow(name, bar, count))
+
 	}
 	return strings.Join(lines, "\n")
 }
@@ -477,13 +482,13 @@ func renderNetMini(conns []collector.NetConn, w, h int) string {
 		if h > 0 && len(lines) >= h {
 			break
 		}
-		t := lipgloss.NewStyle().Foreground(ColorBlue).Width(typeW).Render(c.Type)
+		t := lipgloss.NewStyle().Foreground(ColorBlue).Background(ColorPanel).Width(typeW).Render(c.Type)
 		dir := c.Dir
 		if dir == "" {
 			dir = "↔"
 		}
-		remote := lipgloss.NewStyle().Foreground(ColorBright).Width(remoteW).Render(truncate(dir+" "+c.Remote, remoteW))
-		state := lipgloss.NewStyle().Foreground(netStateColor(c.State)).Width(stateW).Render(c.State)
+		remote := lipgloss.NewStyle().Foreground(ColorBright).Background(ColorPanel).Width(remoteW).Render(truncate(dir+" "+c.Remote, remoteW))
+		state := lipgloss.NewStyle().Foreground(netStateColor(c.State)).Background(ColorPanel).Width(stateW).Render(c.State)
 		latColor := ColorGreen
 		if c.LatencyMs > 30 {
 			latColor = ColorAmber
@@ -491,9 +496,10 @@ func renderNetMini(conns []collector.NetConn, w, h int) string {
 		if c.LatencyMs > 100 {
 			latColor = ColorRed
 		}
-		lat := lipgloss.NewStyle().Foreground(latColor).Width(latW).Align(lipgloss.Right).
+		lat := lipgloss.NewStyle().Foreground(latColor).Background(ColorPanel).Width(latW).Align(lipgloss.Right).
 			Render(fmt.Sprintf("%.0fms", c.LatencyMs))
-		lines = append(lines, t+" "+remote+" "+state+" "+lat)
+		lines = append(lines, panelRow(t, remote, state, lat))
+
 	}
 	return strings.Join(lines, "\n")
 }
@@ -514,7 +520,7 @@ func renderMemMini(s collector.MemStats, w int) string {
 	lines := make([]string, 0, len(rows))
 	for _, r := range rows {
 		left := MutedStyle.Render(r.label)
-		right := lipgloss.NewStyle().Foreground(r.color).Render(r.value)
+		right := lipgloss.NewStyle().Foreground(r.color).Background(ColorPanel).Render(r.value)
 		gap := w - lipgloss.Width(left) - lipgloss.Width(right)
 		if gap < 1 {
 			gap = 1
@@ -543,15 +549,16 @@ func renderTimelineCompact(events []collector.TimelineEvent, w, h int) string {
 
 	lines := make([]string, 0, len(visible))
 	for _, e := range visible {
-		ts := lipgloss.NewStyle().Foreground(ColorDim).Width(tsW).
+		ts := lipgloss.NewStyle().Foreground(ColorDim).Background(ColorPanel).Width(tsW).
 			Render(e.Timestamp.Format("15:04:05.000"))
 		c := CategoryColor(e.Category)
 		cat := lipgloss.NewStyle().
-			Foreground(c).Width(catW).Align(lipgloss.Center).
+			Foreground(c).Background(ColorPanel).Width(catW).Align(lipgloss.Center).
 			Render(strings.TrimSpace(CategoryLabel(e.Category)))
-		msg := lipgloss.NewStyle().Foreground(ColorText).Width(msgW).
+		msg := lipgloss.NewStyle().Foreground(ColorText).Background(ColorPanel).Width(msgW).
 			Render(truncate(e.Message, msgW))
-		lines = append(lines, ts+" "+cat+" "+msg)
+		lines = append(lines, panelRow(ts, cat, msg))
+
 	}
 	return strings.Join(lines, "\n")
 }

--- a/internal/tui/sparkline.go
+++ b/internal/tui/sparkline.go
@@ -42,8 +42,8 @@ func SparklineWithMax(data []float64, width int, maxScale float64, color lipglos
 		points = points[len(points)-width:]
 	}
 
-	style := lipgloss.NewStyle().Foreground(color)
-	dimStyle := lipgloss.NewStyle().Foreground(ColorDim)
+	style := lipgloss.NewStyle().Foreground(color).Background(ColorPanel)
+	dimStyle := lipgloss.NewStyle().Foreground(ColorDim).Background(ColorPanel)
 
 	var sb strings.Builder
 
@@ -90,7 +90,7 @@ func HorizontalBar(value, max float64, width int, color lipgloss.Color) string {
 		return ""
 	}
 	if max <= 0 {
-		return lipgloss.NewStyle().Foreground(ColorDim).Render(strings.Repeat("░", width))
+		return lipgloss.NewStyle().Foreground(ColorDim).Background(ColorPanel).Render(strings.Repeat("░", width))
 	}
 	if value < 0 {
 		value = 0
@@ -104,6 +104,6 @@ func HorizontalBar(value, max float64, width int, color lipgloss.Color) string {
 	}
 	full := strings.Repeat("█", filled)
 	empty := strings.Repeat("░", width-filled)
-	return lipgloss.NewStyle().Foreground(color).Render(full) +
-		lipgloss.NewStyle().Foreground(ColorDim).Render(empty)
+	return lipgloss.NewStyle().Foreground(color).Background(ColorPanel).Render(full) +
+		lipgloss.NewStyle().Foreground(ColorDim).Background(ColorPanel).Render(empty)
 }

--- a/internal/tui/styles.go
+++ b/internal/tui/styles.go
@@ -46,20 +46,39 @@ var (
 			PaddingLeft(1).PaddingRight(1)
 )
 
-// Estilos de texto semânticos
+// Estilos de texto semânticos.
+//
+// IMPORTANTE: todos têm Background(ColorPanel) explícito. Sem isso, células
+// renderizadas inside panels ficam com o background default do terminal
+// (que é o mauve do Ubuntu, ou qualquer cor do tema do user) — vazando
+// pelos espaços entre segmentos coloridos.
+//
+// Header/tabbar/statusbar usam estilos inline com seus próprios backgrounds
+// e NÃO consomem estes; ver header.go, tabbar.go, statusbar.go.
 var (
-	BrightStyle = lipgloss.NewStyle().Foreground(ColorBright)
-	MutedStyle  = lipgloss.NewStyle().Foreground(ColorMuted)
-	DimStyle    = lipgloss.NewStyle().Foreground(ColorDim)
-	GreenStyle  = lipgloss.NewStyle().Foreground(ColorGreen)
-	CyanStyle   = lipgloss.NewStyle().Foreground(ColorCyan)
-	AmberStyle  = lipgloss.NewStyle().Foreground(ColorAmber)
-	RedStyle    = lipgloss.NewStyle().Foreground(ColorRed)
-	BlueStyle   = lipgloss.NewStyle().Foreground(ColorBlue)
-	PurpleStyle = lipgloss.NewStyle().Foreground(ColorPurple)
-	OrangeStyle = lipgloss.NewStyle().Foreground(ColorOrange)
-	TealStyle   = lipgloss.NewStyle().Foreground(ColorTeal)
+	BrightStyle = lipgloss.NewStyle().Foreground(ColorBright).Background(ColorPanel)
+	MutedStyle  = lipgloss.NewStyle().Foreground(ColorMuted).Background(ColorPanel)
+	DimStyle    = lipgloss.NewStyle().Foreground(ColorDim).Background(ColorPanel)
+	GreenStyle  = lipgloss.NewStyle().Foreground(ColorGreen).Background(ColorPanel)
+	CyanStyle   = lipgloss.NewStyle().Foreground(ColorCyan).Background(ColorPanel)
+	AmberStyle  = lipgloss.NewStyle().Foreground(ColorAmber).Background(ColorPanel)
+	RedStyle    = lipgloss.NewStyle().Foreground(ColorRed).Background(ColorPanel)
+	BlueStyle   = lipgloss.NewStyle().Foreground(ColorBlue).Background(ColorPanel)
+	PurpleStyle = lipgloss.NewStyle().Foreground(ColorPurple).Background(ColorPanel)
+	OrangeStyle = lipgloss.NewStyle().Foreground(ColorOrange).Background(ColorPanel)
+	TealStyle   = lipgloss.NewStyle().Foreground(ColorTeal).Background(ColorPanel)
 )
+
+// PanelStyleBase devolve um base style com ColorPanel como background.
+// Use pra construir estilos inline dentro de panels:
+//
+//	name := PanelStyleBase().Foreground(c).Width(nameW).Render(s)
+//
+// É só açúcar pra `lipgloss.NewStyle().Background(ColorPanel)` mas torna
+// claro a intenção.
+func PanelStyleBase() lipgloss.Style {
+	return lipgloss.NewStyle().Background(ColorPanel)
+}
 
 // Badge: pequeno label colorido inline (ex: "PID 18423", "RUNNING").
 // Single-line por design — usado em headers e tabs onde altura > 1 quebra layout.

--- a/internal/tui/view_fd.go
+++ b/internal/tui/view_fd.go
@@ -92,8 +92,8 @@ func renderFDCountSparkline(m Model, w int) string {
 		sparkW = 5
 	}
 	spark := Sparkline(m.FDCountHistory, sparkW, ColorTeal)
-	val := lipgloss.NewStyle().Foreground(ColorTeal).Bold(true).Width(rightW).Align(lipgloss.Right).Render(fmt.Sprintf("%d", cur))
-	lbl := lipgloss.NewStyle().Foreground(ColorMuted).Width(rightW).Align(lipgloss.Right).Render("open fds")
+	val := lipgloss.NewStyle().Foreground(ColorTeal).Background(ColorPanel).Bold(true).Width(rightW).Align(lipgloss.Right).Render(fmt.Sprintf("%d", cur))
+	lbl := lipgloss.NewStyle().Foreground(ColorMuted).Background(ColorPanel).Width(rightW).Align(lipgloss.Right).Render("open fds")
 	right := val + "\n" + lbl
 	return lipgloss.JoinHorizontal(lipgloss.Top, spark, "  ", right)
 }
@@ -185,32 +185,32 @@ func renderFDTable(m Model, w, h int) string {
 		isOld := f.AgeMs > 3600*1000
 		isSuspect := f.Type == "file" && strings.Contains(f.Desc, "/tmp") && f.AgeMs > 600*1000
 
-		fdNum := lipgloss.NewStyle().Foreground(ColorMuted).Bold(true).Width(fdW).Render(fmt.Sprintf("%d", f.FD))
-		typeStr := lipgloss.NewStyle().Foreground(FDTypeColor(f.Type)).Width(typeW).Render(FDTypeIcon(f.Type) + " " + f.Type)
+		fdNum := lipgloss.NewStyle().Foreground(ColorMuted).Background(ColorPanel).Bold(true).Width(fdW).Render(fmt.Sprintf("%d", f.FD))
+		typeStr := lipgloss.NewStyle().Foreground(FDTypeColor(f.Type)).Background(ColorPanel).Width(typeW).Render(FDTypeIcon(f.Type) + " " + f.Type)
 
 		descColor := ColorText
 		if f.Active {
 			descColor = ColorBright
 		}
-		descStr := lipgloss.NewStyle().Foreground(descColor).Width(descW).Render(truncate(f.Desc, descW))
+		descStr := lipgloss.NewStyle().Foreground(descColor).Background(ColorPanel).Width(descW).Render(truncate(f.Desc, descW))
 
-		flagsStr := lipgloss.NewStyle().Foreground(ColorDim).Width(flagsW).Render(f.Flags)
-		bytesStr := lipgloss.NewStyle().Foreground(ColorMuted).Width(bytesW).Align(lipgloss.Right).Render(fmtBytes(f.Bytes))
+		flagsStr := lipgloss.NewStyle().Foreground(ColorDim).Background(ColorPanel).Width(flagsW).Render(f.Flags)
+		bytesStr := lipgloss.NewStyle().Foreground(ColorMuted).Background(ColorPanel).Width(bytesW).Align(lipgloss.Right).Render(fmtBytes(f.Bytes))
 
 		ageColor := ColorDim
 		if isOld {
 			ageColor = ColorAmber
 		}
-		ageStr := lipgloss.NewStyle().Foreground(ageColor).Width(ageW).Align(lipgloss.Right).Render(fmtAgeMs(f.AgeMs))
+		ageStr := lipgloss.NewStyle().Foreground(ageColor).Background(ColorPanel).Width(ageW).Align(lipgloss.Right).Render(fmtAgeMs(f.AgeMs))
 
 		var dot string
 		if f.Active {
-			dot = lipgloss.NewStyle().Foreground(ColorGreen).Render("●")
+			dot = lipgloss.NewStyle().Foreground(ColorGreen).Background(ColorPanel).Render("●")
 		} else {
-			dot = lipgloss.NewStyle().Foreground(ColorDim).Render("○")
+			dot = lipgloss.NewStyle().Foreground(ColorDim).Background(ColorPanel).Render("○")
 		}
 
-		row := fdNum + " " + typeStr + " " + descStr + " " + flagsStr + " " + bytesStr + " " + ageStr + " " + dot
+		row := panelRow(fdNum, typeStr, descStr, flagsStr, bytesStr, ageStr, dot)
 		if isSuspect {
 			row = lipgloss.NewStyle().Background(lipgloss.Color("#1f1a08")).Render(row)
 		}
@@ -271,7 +271,7 @@ func renderFDStats(m Model, w int) string {
 	lines := []string{}
 	for _, r := range rows {
 		left := MutedStyle.Render(r.label)
-		right := lipgloss.NewStyle().Foreground(r.color).Render(r.value)
+		right := lipgloss.NewStyle().Foreground(r.color).Background(ColorPanel).Render(r.value)
 		gap := w - lipgloss.Width(left) - lipgloss.Width(right)
 		if gap < 1 {
 			gap = 1
@@ -296,9 +296,10 @@ func renderFDEvents(events []collector.FDEvent, w, h int) string {
 	}
 	lines := make([]string, 0, len(visible))
 	for _, e := range visible {
-		ts := lipgloss.NewStyle().Foreground(ColorDim).Width(tsW).Render(e.Timestamp.Format("15:04:05.000"))
-		msg := lipgloss.NewStyle().Foreground(ColorText).Width(msgW).Render(truncate(e.Message, msgW))
-		lines = append(lines, ts+" "+msg)
+		ts := lipgloss.NewStyle().Foreground(ColorDim).Background(ColorPanel).Width(tsW).Render(e.Timestamp.Format("15:04:05.000"))
+		msg := lipgloss.NewStyle().Foreground(ColorText).Background(ColorPanel).Width(msgW).Render(truncate(e.Message, msgW))
+		lines = append(lines, panelRow(ts, msg))
+
 	}
 	return strings.Join(lines, "\n")
 }

--- a/internal/tui/view_io.go
+++ b/internal/tui/view_io.go
@@ -142,10 +142,10 @@ func renderIOTopFiles(files []collector.IOFileStats, displayPaths []string, w, h
 		ops := f.Reads + f.Writes
 		typeColor := ioFileTypeColor(f.Type)
 
-		typeStr := lipgloss.NewStyle().Foreground(typeColor).Width(typeW).Render(f.Type)
-		path := lipgloss.NewStyle().Foreground(ColorText).Width(pathW).Render(truncate(f.Path, pathW))
-		opsStr := lipgloss.NewStyle().Foreground(ColorBright).Width(opsW).Align(lipgloss.Right).Render(fmt.Sprintf("%d", ops))
-		bytesStr := lipgloss.NewStyle().Foreground(ColorMuted).Width(bytesW).Align(lipgloss.Right).Render(fmtBytes(f.Bytes))
+		typeStr := lipgloss.NewStyle().Foreground(typeColor).Background(ColorPanel).Width(typeW).Render(f.Type)
+		path := lipgloss.NewStyle().Foreground(ColorText).Background(ColorPanel).Width(pathW).Render(truncate(f.Path, pathW))
+		opsStr := lipgloss.NewStyle().Foreground(ColorBright).Background(ColorPanel).Width(opsW).Align(lipgloss.Right).Render(fmt.Sprintf("%d", ops))
+		bytesStr := lipgloss.NewStyle().Foreground(ColorMuted).Background(ColorPanel).Width(bytesW).Align(lipgloss.Right).Render(fmtBytes(f.Bytes))
 
 		latColor := ColorGreen
 		if f.LatencyMs > 1 {
@@ -154,7 +154,7 @@ func renderIOTopFiles(files []collector.IOFileStats, displayPaths []string, w, h
 		if f.LatencyMs > 5 {
 			latColor = ColorRed
 		}
-		latStr := lipgloss.NewStyle().Foreground(latColor).Width(latW).Align(lipgloss.Right).Render(fmt.Sprintf("%.1fms", f.LatencyMs))
+		latStr := lipgloss.NewStyle().Foreground(latColor).Background(ColorPanel).Width(latW).Align(lipgloss.Right).Render(fmt.Sprintf("%.1fms", f.LatencyMs))
 
 		fsyncColor := ColorDim
 		fsyncLabel := "–"
@@ -165,9 +165,10 @@ func renderIOTopFiles(files []collector.IOFileStats, displayPaths []string, w, h
 		if f.Fsyncs > 10 {
 			fsyncColor = ColorRed
 		}
-		fsyncStr := lipgloss.NewStyle().Foreground(fsyncColor).Width(fsyncW).Align(lipgloss.Right).Render(fsyncLabel)
+		fsyncStr := lipgloss.NewStyle().Foreground(fsyncColor).Background(ColorPanel).Width(fsyncW).Align(lipgloss.Right).Render(fsyncLabel)
 
-		lines = append(lines, typeStr+" "+path+" "+opsStr+" "+bytesStr+" "+latStr+" "+fsyncStr)
+		lines = append(lines, panelRow(typeStr, path, opsStr, bytesStr, latStr, fsyncStr))
+
 	}
 	return strings.Join(lines, "\n")
 }
@@ -196,11 +197,11 @@ func renderIOLatencyDist(buckets []collector.LatencyBucket, w, h int) string {
 		if h > 0 && len(lines) >= h {
 			break
 		}
-		label := lipgloss.NewStyle().Foreground(ColorMuted).Width(labelW).Render(b.Label)
+		label := lipgloss.NewStyle().Foreground(ColorMuted).Background(ColorPanel).Width(labelW).Render(b.Label)
 		readBar := HorizontalBar(b.Read, maxV, barW, ColorCyan)
 		writeBar := HorizontalBar(b.Write, maxV, barW, ColorOrange)
-		readNum := lipgloss.NewStyle().Foreground(ColorCyan).Width(numW).Align(lipgloss.Right).Render(fmt.Sprintf("%.0f", b.Read))
-		writeNum := lipgloss.NewStyle().Foreground(ColorOrange).Width(numW).Align(lipgloss.Right).Render(fmt.Sprintf("%.0f", b.Write))
+		readNum := lipgloss.NewStyle().Foreground(ColorCyan).Background(ColorPanel).Width(numW).Align(lipgloss.Right).Render(fmt.Sprintf("%.0f", b.Read))
+		writeNum := lipgloss.NewStyle().Foreground(ColorOrange).Background(ColorPanel).Width(numW).Align(lipgloss.Right).Render(fmt.Sprintf("%.0f", b.Write))
 
 		stack := lipgloss.JoinVertical(lipgloss.Left,
 			lipgloss.JoinHorizontal(lipgloss.Top, label, " ", readBar, " ", readNum),
@@ -228,7 +229,7 @@ func renderIOStats(s collector.IOStats, w int) string {
 	lines := []string{}
 	for _, r := range rows {
 		left := MutedStyle.Render(r.label)
-		right := lipgloss.NewStyle().Foreground(r.color).Render(r.value)
+		right := lipgloss.NewStyle().Foreground(r.color).Background(ColorPanel).Render(r.value)
 		gap := w - lipgloss.Width(left) - lipgloss.Width(right)
 		if gap < 1 {
 			gap = 1

--- a/internal/tui/view_network.go
+++ b/internal/tui/view_network.go
@@ -58,11 +58,12 @@ func renderNetLatencyTrend(m Model, w int) string {
 		if c.LatencyMs > 100 {
 			latColor = ColorRed
 		}
-		left := lipgloss.NewStyle().Foreground(ColorMuted).Width(labelW).Render(truncate(c.Remote, labelW))
+		left := lipgloss.NewStyle().Foreground(ColorMuted).Background(ColorPanel).Width(labelW).Render(truncate(c.Remote, labelW))
 		bar := HorizontalBar(c.LatencyMs, 100, barW, latColor)
-		val := lipgloss.NewStyle().Foreground(latColor).Width(8).Align(lipgloss.Right).
+		val := lipgloss.NewStyle().Foreground(latColor).Background(ColorPanel).Width(8).Align(lipgloss.Right).
 			Render(fmt.Sprintf("%.1fms", c.LatencyMs))
-		lines = append(lines, left+" "+bar+" "+val)
+		lines = append(lines, panelRow(left, bar, val))
+
 	}
 	return strings.Join(lines, "\n\n") // espaçamento entre linhas
 }

--- a/internal/tui/view_threads.go
+++ b/internal/tui/view_threads.go
@@ -29,7 +29,7 @@ func renderThreadsView(m Model, w, h int) string {
 // Versão MVP — quando vier um collector real, substituir por análise de hold/wait.
 func renderLockGraph(m Model, w int) string {
 	title := MutedStyle.Render("lock graph")
-	body := lipgloss.NewStyle().Foreground(ColorAmber).Render("mutex-A") +
+	body := lipgloss.NewStyle().Foreground(ColorAmber).Background(ColorPanel).Render("mutex-A") +
 		MutedStyle.Render(" held by ") +
 		GreenStyle.Render("main(1)") +
 		MutedStyle.Render(" ← blocked: ") +

--- a/internal/tui/view_timeline.go
+++ b/internal/tui/view_timeline.go
@@ -35,17 +35,19 @@ func renderTimelineFull(events []collector.TimelineEvent, w, h int) string {
 
 	lines := make([]string, 0, len(visible))
 	for _, e := range visible {
-		ts := lipgloss.NewStyle().Foreground(ColorDim).Width(tsW).
+		ts := lipgloss.NewStyle().Foreground(ColorDim).Background(ColorPanel).Width(tsW).
 			Render(e.Timestamp.Format("15:04:05.000"))
 		c := CategoryColor(e.Category)
 		cat := lipgloss.NewStyle().
 			Foreground(c).
+			Background(ColorPanel).
 			Width(catW).
 			Align(lipgloss.Center).
 			Render(strings.TrimSpace(CategoryLabel(e.Category)))
-		msg := lipgloss.NewStyle().Foreground(ColorText).Width(msgW).
+		msg := lipgloss.NewStyle().Foreground(ColorText).Background(ColorPanel).Width(msgW).
 			Render(truncate(e.Message, msgW))
-		lines = append(lines, ts+" "+cat+" "+msg)
+		lines = append(lines, panelRow(ts, cat, msg))
+
 	}
 	return strings.Join(lines, "\n")
 }


### PR DESCRIPTION
Bug visual reportado: linhas dentro de panels apareciam metade com background do terminal (mauve no Ubuntu) e metade com ColorPanel — inconsistente.

## Causa

Lipgloss não propaga Background do estilo pai pros segmentos filhos. Cada inline `lipgloss.NewStyle().Foreground(c).Render(s)` emite ANSI sem bg, deixando o terminal default vazar entre as palavras.

## Fix

3 frentes:

1. **Named styles em styles.go** ganharam `Background(ColorPanel)`: BrightStyle, MutedStyle, DimStyle, *Style etc.
2. **Inline calls** em panels.go + view_*.go (60+ lugares) tiveram `.Background(ColorPanel)` adicionado via patch automatizado (sed + python com lookahead negativo pra não duplicar)
3. **Separadores entre segmentos**: introduzido `panelRow(parts...)` que faz `strings.Join` com " " pintado com ColorPanel. Substitui o padrão `A+" "+B` que deixava cells vazadas. Também `padRight()` agora pinta padding.

## Verificação

Dump truecolor de F1:
- 724 sequências `\x1b[48;2;...m` aplicadas (era ~0)
- ColorPanel (`#13161c`) é dominante; outras bgs intencionais (chrome, badges, suspect rows)
- `go test -race ./...` verde

## Pra você ver

```bash
cd ~/xray   # ou shared folder
git pull
make build
sudo ./bin/xray --pid 1 --no-ebpf
```

Espero que F1 fique com ColorPanel uniforme em todas as células dentro dos panels — sem mais o mauve do Ubuntu vazando.