### PR TITLE
tui: real process name + fix bg gap residue

### DIFF
--- a/internal/tui/panel.go
+++ b/internal/tui/panel.go
@@ -120,9 +120,26 @@ func padRight(s string, w int) string {
 //
 // Substitui o padrão antigo `name + " " + bar + " " + count`.
 func panelRow(parts ...string) string {
-	sep := lipgloss.NewStyle().Background(ColorPanel).Render(" ")
-	return strings.Join(parts, sep)
+	return strings.Join(parts, panelSp1)
 }
+
+// panelGap retorna `width` espaços pintados com ColorPanel.
+// Usar em lipgloss.JoinHorizontal quando precisa de gap entre elementos:
+//
+//	lipgloss.JoinHorizontal(lipgloss.Top, spark, panelGap(2), right)
+//
+// — em vez do `"  "` cru que vazaria o background do terminal.
+func panelGap(width int) string {
+	if width <= 0 {
+		return ""
+	}
+	return lipgloss.NewStyle().Background(ColorPanel).Render(strings.Repeat(" ", width))
+}
+
+var (
+	panelSp1 = panelGap(1)
+	panelSp2 = panelGap(2)
+)
 
 // truncate corta s para caber em `w` colunas visíveis, adicionando "…" se necessário.
 func truncate(s string, w int) string {

--- a/internal/tui/panels.go
+++ b/internal/tui/panels.go
@@ -42,11 +42,11 @@ func renderCPU(history []float64, w int) string {
 	spark := SparklineWithMax(history, sparkW, 100, color)
 
 	right := lipgloss.JoinVertical(lipgloss.Right,
-		lipgloss.NewStyle().Width(rightW).Align(lipgloss.Right).Render(val),
-		lipgloss.NewStyle().Width(rightW).Align(lipgloss.Right).Render(lbl),
+		lipgloss.NewStyle().Width(rightW).Background(ColorPanel).Align(lipgloss.Right).Render(val),
+		lipgloss.NewStyle().Width(rightW).Background(ColorPanel).Align(lipgloss.Right).Render(lbl),
 	)
 
-	return lipgloss.JoinHorizontal(lipgloss.Top, spark, "  ", right)
+	return lipgloss.JoinHorizontal(lipgloss.Top, spark, panelSp2, right)
 }
 
 // ─── Syscall bars ────────────────────────────────────────────────────────────
@@ -162,8 +162,8 @@ func renderSyscallTable(counts map[string]uint64, w, h int) string {
 	header := MutedStyle.Render(
 		padRight("SYSCALL", nameW) + " " +
 			padRight("FREQUENCY", barW) + " " +
-			lipgloss.NewStyle().Width(countW).Align(lipgloss.Right).Render("COUNT") + " " +
-			lipgloss.NewStyle().Width(pctW).Align(lipgloss.Right).Render("%"),
+			lipgloss.NewStyle().Width(countW).Background(ColorPanel).Align(lipgloss.Right).Render("COUNT") + " " +
+			lipgloss.NewStyle().Width(pctW).Background(ColorPanel).Align(lipgloss.Right).Render("%"),
 	)
 
 	lines := []string{header}
@@ -249,7 +249,7 @@ func renderThreadList(threads []collector.ThreadInfo, w, h int) string {
 		if t.Waiting != "" {
 			wait = AmberStyle.Render(truncate("⏳ "+t.Waiting, waitW))
 		}
-		waitCol := lipgloss.NewStyle().Width(waitW).Render(wait)
+		waitCol := lipgloss.NewStyle().Width(waitW).Background(ColorPanel).Render(wait)
 
 		lines = append(lines, panelRow(gly, name, bar, cpuStr, waitCol))
 
@@ -272,7 +272,7 @@ func renderThreadTable(threads []collector.ThreadInfo, w, h int) string {
 		padRight("  NAME", 2+nameW) + " " +
 			padRight("STATE", stateW) + " " +
 			padRight("CPU", barW) + " " +
-			lipgloss.NewStyle().Width(cpuW).Align(lipgloss.Right).Render("%") + " " +
+			lipgloss.NewStyle().Width(cpuW).Background(ColorPanel).Align(lipgloss.Right).Render("%") + " " +
 			padRight("WAITING ON", waitW),
 	)
 
@@ -343,12 +343,12 @@ func renderIOMini(io collector.IOStats, readH, writeH []float64, maxRead, maxWri
 		lipgloss.NewStyle().Foreground(ColorCyan).Background(ColorPanel).Bold(true).Render(fmtBytesPerSec(curR))
 	wLabel := MutedStyle.Render("write/s ") +
 		lipgloss.NewStyle().Foreground(ColorOrange).Background(ColorPanel).Bold(true).Render(fmtBytesPerSec(curW))
-	right := lipgloss.NewStyle().Width(rightW).Align(lipgloss.Left).Render(rLabel) +
+	right := lipgloss.NewStyle().Width(rightW).Background(ColorPanel).Align(lipgloss.Left).Render(rLabel) +
 		"\n" +
-		lipgloss.NewStyle().Width(rightW).Align(lipgloss.Left).Render(wLabel)
+		lipgloss.NewStyle().Width(rightW).Background(ColorPanel).Align(lipgloss.Left).Render(wLabel)
 
 	sparks := rSpark + "\n" + wSpark
-	header := lipgloss.JoinHorizontal(lipgloss.Top, sparks, "  ", right)
+	header := lipgloss.JoinHorizontal(lipgloss.Top, sparks, panelSp2, right)
 
 	stats := []string{
 		MutedStyle.Render("read ops ") + CyanStyle.Render(fmt.Sprintf("%d", io.ReadOps)),
@@ -390,12 +390,12 @@ func renderIOLargeThroughput(io collector.IOStats, readH, writeH []float64, maxR
 		lipgloss.NewStyle().Foreground(ColorOrange).Background(ColorPanel).Bold(true).Render(fmtBytesPerSec(curW))
 
 	first := lipgloss.JoinHorizontal(lipgloss.Top,
-		rSpark, "  ",
-		lipgloss.NewStyle().Width(rightW).Render(rRight),
+		rSpark, panelSp2,
+		lipgloss.NewStyle().Width(rightW).Background(ColorPanel).Render(rRight),
 	)
 	second := lipgloss.JoinHorizontal(lipgloss.Top,
-		wSpark, "  ",
-		lipgloss.NewStyle().Width(rightW).Render(wRight),
+		wSpark, panelSp2,
+		lipgloss.NewStyle().Width(rightW).Background(ColorPanel).Render(wRight),
 	)
 	return first + "\n" + second
 }
@@ -474,7 +474,7 @@ func renderNetMini(conns []collector.NetConn, w, h int) string {
 		padRight("TYPE", typeW) + " " +
 			padRight("REMOTE", remoteW) + " " +
 			padRight("STATE", stateW) + " " +
-			lipgloss.NewStyle().Width(latW).Align(lipgloss.Right).Render("LAT"),
+			lipgloss.NewStyle().Width(latW).Background(ColorPanel).Align(lipgloss.Right).Render("LAT"),
 	)
 
 	lines := []string{header}

--- a/internal/tui/view_fd.go
+++ b/internal/tui/view_fd.go
@@ -95,7 +95,7 @@ func renderFDCountSparkline(m Model, w int) string {
 	val := lipgloss.NewStyle().Foreground(ColorTeal).Background(ColorPanel).Bold(true).Width(rightW).Align(lipgloss.Right).Render(fmt.Sprintf("%d", cur))
 	lbl := lipgloss.NewStyle().Foreground(ColorMuted).Background(ColorPanel).Width(rightW).Align(lipgloss.Right).Render("open fds")
 	right := val + "\n" + lbl
-	return lipgloss.JoinHorizontal(lipgloss.Top, spark, "  ", right)
+	return lipgloss.JoinHorizontal(lipgloss.Top, spark, panelSp2, right)
 }
 
 func renderFDFilterRow(m Model, w int) string {
@@ -144,13 +144,13 @@ func renderFDTable(m Model, w, h int) string {
 	}
 
 	header := MutedStyle.Render(
-		lipgloss.NewStyle().Width(fdW).Render("FD") + " " +
+		lipgloss.NewStyle().Width(fdW).Background(ColorPanel).Render("FD") + " " +
 			padRight("TYPE", typeW) + " " +
 			padRight("DESCRIPTION", descW) + " " +
 			padRight("FLAGS", flagsW) + " " +
-			lipgloss.NewStyle().Width(bytesW).Align(lipgloss.Right).Render("BYTES") + " " +
-			lipgloss.NewStyle().Width(ageW).Align(lipgloss.Right).Render("AGE") + " " +
-			lipgloss.NewStyle().Width(dotW).Render(""),
+			lipgloss.NewStyle().Width(bytesW).Background(ColorPanel).Align(lipgloss.Right).Render("BYTES") + " " +
+			lipgloss.NewStyle().Width(ageW).Background(ColorPanel).Align(lipgloss.Right).Render("AGE") + " " +
+			lipgloss.NewStyle().Width(dotW).Background(ColorPanel).Render(""),
 	)
 
 	// filtra: primeiro por tipo (FDFilter cíclico), depois por substring

--- a/internal/tui/view_io.go
+++ b/internal/tui/view_io.go
@@ -121,10 +121,10 @@ func renderIOTopFiles(files []collector.IOFileStats, displayPaths []string, w, h
 	header := MutedStyle.Render(
 		padRight("TYPE", typeW) + " " +
 			padRight("PATH", pathW) + " " +
-			lipgloss.NewStyle().Width(opsW).Align(lipgloss.Right).Render("OPS") + " " +
-			lipgloss.NewStyle().Width(bytesW).Align(lipgloss.Right).Render("BYTES") + " " +
-			lipgloss.NewStyle().Width(latW).Align(lipgloss.Right).Render("LAT") + " " +
-			lipgloss.NewStyle().Width(fsyncW).Align(lipgloss.Right).Render("FSYNC"),
+			lipgloss.NewStyle().Width(opsW).Background(ColorPanel).Align(lipgloss.Right).Render("OPS") + " " +
+			lipgloss.NewStyle().Width(bytesW).Background(ColorPanel).Align(lipgloss.Right).Render("BYTES") + " " +
+			lipgloss.NewStyle().Width(latW).Background(ColorPanel).Align(lipgloss.Right).Render("LAT") + " " +
+			lipgloss.NewStyle().Width(fsyncW).Background(ColorPanel).Align(lipgloss.Right).Render("FSYNC"),
 	)
 
 	maxOps := uint64(1)
@@ -204,8 +204,8 @@ func renderIOLatencyDist(buckets []collector.LatencyBucket, w, h int) string {
 		writeNum := lipgloss.NewStyle().Foreground(ColorOrange).Background(ColorPanel).Width(numW).Align(lipgloss.Right).Render(fmt.Sprintf("%.0f", b.Write))
 
 		stack := lipgloss.JoinVertical(lipgloss.Left,
-			lipgloss.JoinHorizontal(lipgloss.Top, label, " ", readBar, " ", readNum),
-			lipgloss.JoinHorizontal(lipgloss.Top, padRight("", labelW), " ", writeBar, " ", writeNum),
+			lipgloss.JoinHorizontal(lipgloss.Top, label, panelSp1, readBar, panelSp1, readNum),
+			lipgloss.JoinHorizontal(lipgloss.Top, padRight("", labelW), panelSp1, writeBar, panelSp1, writeNum),
 		)
 		lines = append(lines, stack)
 	}


### PR DESCRIPTION
1. ProcessName lê `/proc/<pid>/comm` em vez do hardcoded `api-server`. Em macOS sem /proc, fallback `(?)`.
2. Bg gap residual: 3 lugares com `left + strings.Repeat(" ", gap) + right` trocados por `panelGap(gap)` (panels.go renderMemMini, view_fd.go renderFDStats, view_io.go renderIOStats).
3. `bottom := strings.Join(stats, "  ")` → `panelSp2` em renderIOMini.

`go test -race ./...` verde.