### PR TITLE
tui: real process name (/proc/<pid>/comm) + fix bg gap residue in panels

### DIFF
--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -6,6 +6,7 @@ import (
 	"math/rand"
 	"os"
 	"sort"
+	"strings"
 	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
@@ -174,7 +175,7 @@ type Model struct {
 func NewModel(cfg Config) Model {
 	m := Model{
 		cfg:              cfg,
-		ProcessName:      "api-server",
+		ProcessName:      detectProcessName(cfg.PID),
 		Runtime:          "Go 1.22",
 		State:            "RUNNING",
 		StartedAt:        time.Now(),
@@ -1056,5 +1057,23 @@ func clamp(v, lo, hi float64) float64 {
 		return hi
 	}
 	return v
+}
+
+// detectProcessName lê /proc/<pid>/comm pra obter o nome curto do processo
+// (kernel TASK_COMM_LEN = 16 chars). Em macOS/Windows, fallback pra "(?)" —
+// indica claramente que estamos em modo simulado.
+func detectProcessName(pid int) string {
+	if pid <= 0 {
+		return "(?)"
+	}
+	data, err := os.ReadFile(fmt.Sprintf("/proc/%d/comm", pid))
+	if err != nil {
+		return "(?)"
+	}
+	name := strings.TrimSpace(string(data))
+	if name == "" {
+		return "(?)"
+	}
+	return name
 }
 

--- a/internal/tui/panels.go
+++ b/internal/tui/panels.go
@@ -356,7 +356,7 @@ func renderIOMini(io collector.IOStats, readH, writeH []float64, maxRead, maxWri
 		MutedStyle.Render("fsyncs ") + colorByThreshold(io.Fsyncs, 20).Render(fmt.Sprintf("%d", io.Fsyncs)),
 		MutedStyle.Render("io-wait ") + colorByPctThreshold(io.IOWaitPct, 15).Render(fmt.Sprintf("%.1f%%", io.IOWaitPct)),
 	}
-	bottom := strings.Join(stats, "  ")
+	bottom := strings.Join(stats, panelSp2)
 
 	return header + "\n" + bottom
 }
@@ -525,7 +525,7 @@ func renderMemMini(s collector.MemStats, w int) string {
 		if gap < 1 {
 			gap = 1
 		}
-		lines = append(lines, left+strings.Repeat(" ", gap)+right)
+		lines = append(lines, left+panelGap(gap)+right)
 	}
 	return strings.Join(lines, "\n")
 }

--- a/internal/tui/view_fd.go
+++ b/internal/tui/view_fd.go
@@ -276,7 +276,7 @@ func renderFDStats(m Model, w int) string {
 		if gap < 1 {
 			gap = 1
 		}
-		lines = append(lines, left+strings.Repeat(" ", gap)+right)
+		lines = append(lines, left+panelGap(gap)+right)
 	}
 	return strings.Join(lines, "\n")
 }

--- a/internal/tui/view_io.go
+++ b/internal/tui/view_io.go
@@ -234,7 +234,7 @@ func renderIOStats(s collector.IOStats, w int) string {
 		if gap < 1 {
 			gap = 1
 		}
-		lines = append(lines, left+strings.Repeat(" ", gap)+right)
+		lines = append(lines, left+panelGap(gap)+right)
 	}
 	return strings.Join(lines, "\n")
 }


### PR DESCRIPTION
Recuperando commit que ficou órfão no merge anterior do #40 (deu push errado, branch estava em estado antigo).

## Mudanças reais

1. **`detectProcessName(pid)`** lê `/proc/<pid>/comm` em vez do hardcoded `api-server`. `--pid 1` em Linux passa a mostrar `systemd`. macOS sem /proc → `(?)`.
2. **`panelGap(gap)`** substitui `strings.Repeat(" ", gap)` em 3 lugares: `renderMemMini`, `renderFDStats`, `renderIOStats`. Era o gap entre label e value à direita que vazava bg do terminal.
3. **`panelSp2`** substitui `"  "` no `strings.Join` do bottom stats em `renderIOMini`.

## Verificação

`go test -race ./...` verde.