### PR TITLE
ebpf: CPU sampling via perf_event @ 100Hz/CPU

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,17 +19,21 @@ else
   GNU_TRIPLE := $(shell gcc -print-multiarch 2>/dev/null)
 endif
 
-BPF_C  := internal/bpf/programs/syscalls.bpf.c
-BPF_O  := $(BPF_C:.c=.o)
+# Lista de programas eBPF a compilar. Adicionar novos .bpf.c aqui.
+BPF_SRCS := \
+	internal/bpf/programs/syscalls.bpf.c \
+	internal/bpf/programs/cpu.bpf.c
+
+BPF_OBJS := $(BPF_SRCS:.c=.o)
 
 CLANG  ?= clang
 
-# Regra implícita: .bpf.c → .bpf.o via clang -target bpf.
+# Regra padrão: .bpf.c → .bpf.o via clang -target bpf.
 # `-target bpf`: emite bytecode BPF em vez de nativo
 # `-O2 -g`: otimização + dwarf info (verificador BPF aproveita os DWARF)
 # `-D__TARGET_ARCH_*`: define usado por bpf_tracing.h pra pt_regs offsets
 # `-I/usr/include/$GNU_TRIPLE`: necessário pra encontrar `asm/types.h` etc.
-$(BPF_O): $(BPF_C)
+%.bpf.o: %.bpf.c
 	$(CLANG) -O2 -g -target bpf \
 		-D__TARGET_ARCH_$(BPF_ARCH) \
 		-I/usr/include \
@@ -37,7 +41,7 @@ $(BPF_O): $(BPF_C)
 		-c $< -o $@
 
 # `make gen` produz todos os .o de programs/. Roda só em Linux com libbpf-dev.
-gen: $(BPF_O)
+gen: $(BPF_OBJS)
 
 # ─── builds ──────────────────────────────────────────────────────────────────
 
@@ -73,7 +77,7 @@ test-all: test
 
 vet:
 	go vet ./...
-	@if [ -f $(BPF_O) ]; then \
+	@if ls $(BPF_OBJS) >/dev/null 2>&1; then \
 		go vet -tags=ebpf ./...; \
 	else \
 		echo "(go vet -tags=ebpf pulado: rode 'make gen' primeiro)"; \

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/charmbracelet/bubbletea v0.27.0
 	github.com/charmbracelet/lipgloss v0.12.1
 	github.com/cilium/ebpf v0.13.0
+	golang.org/x/sys v0.24.0
 )
 
 require (
@@ -26,6 +27,5 @@ require (
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect
 	golang.org/x/exp v0.0.0-20230224173230-c95f2b4c22f2 // indirect
 	golang.org/x/sync v0.8.0 // indirect
-	golang.org/x/sys v0.24.0 // indirect
 	golang.org/x/text v0.3.8 // indirect
 )

--- a/internal/bpf/cpu.go
+++ b/internal/bpf/cpu.go
@@ -1,0 +1,153 @@
+//go:build linux && ebpf
+
+package bpf
+
+import (
+	"bytes"
+	_ "embed"
+	"errors"
+	"fmt"
+	"runtime"
+	"unsafe"
+
+	"github.com/cilium/ebpf"
+	"github.com/cilium/ebpf/rlimit"
+	"golang.org/x/sys/unix"
+)
+
+//go:embed programs/cpu.bpf.o
+var cpuBPFObj []byte
+
+// CPUTracer faz sampling do PID alvo via perf_event PERF_COUNT_SW_CPU_CLOCK
+// em SAMPLE_FREQ Hz por CPU. Quando o kernel dispara um sample e o tgid
+// atual é o alvo, o BPF program incrementa um contador. O collector lê o
+// contador a cada N segundos e calcula % de CPU.
+type CPUTracer struct {
+	coll       *ebpf.Collection
+	samplesMap *ebpf.Map
+	perfFDs    []int // 1 fd por CPU online
+}
+
+// SampleFreq é a frequência de sampling em Hz por CPU. 100Hz é o que o
+// `perf record` usa por default e o que Instruments do macOS chama de
+// "Sampler" — granularidade suficiente pra detectar CPU spikes >10ms.
+const SampleFreq = 100
+
+func OpenCPUTracer(pid int) (*CPUTracer, error) {
+	if pid <= 0 {
+		return nil, errors.New("pid inválido")
+	}
+	if err := rlimit.RemoveMemlock(); err != nil {
+		return nil, fmt.Errorf("rlimit.RemoveMemlock: %w", err)
+	}
+
+	spec, err := ebpf.LoadCollectionSpecFromReader(bytes.NewReader(cpuBPFObj))
+	if err != nil {
+		return nil, fmt.Errorf("parse cpu BPF object: %w", err)
+	}
+	coll, err := ebpf.NewCollection(spec)
+	if err != nil {
+		return nil, fmt.Errorf("load cpu BPF collection: %w", err)
+	}
+
+	t := &CPUTracer{coll: coll}
+
+	targetMap := coll.Maps["cpu_target_pid"]
+	if targetMap == nil {
+		t.Close()
+		return nil, errors.New("cpu_target_pid map não encontrado")
+	}
+	var key uint32 = 0
+	val := uint32(pid)
+	if err := targetMap.Update(&key, &val, ebpf.UpdateAny); err != nil {
+		t.Close()
+		return nil, fmt.Errorf("set cpu_target_pid: %w", err)
+	}
+
+	t.samplesMap = coll.Maps["cpu_target_samples"]
+	if t.samplesMap == nil {
+		t.Close()
+		return nil, errors.New("cpu_target_samples map não encontrado")
+	}
+
+	prog := coll.Programs["handle_perf_event"]
+	if prog == nil {
+		t.Close()
+		return nil, errors.New("handle_perf_event program não encontrado")
+	}
+
+	// perf_event_open + ioctl(PERF_EVENT_IOC_SET_BPF) por CPU.
+	// PERF_TYPE_SOFTWARE/PERF_COUNT_SW_CPU_CLOCK dispara amostras em
+	// SAMPLE_FREQ Hz por CPU (kernel garante uniformidade).
+	ncpu := runtime.NumCPU()
+	for cpu := 0; cpu < ncpu; cpu++ {
+		attr := unix.PerfEventAttr{
+			Type:        unix.PERF_TYPE_SOFTWARE,
+			Config:      unix.PERF_COUNT_SW_CPU_CLOCK,
+			Sample:      SampleFreq,
+			Sample_type: unix.PERF_SAMPLE_RAW,
+			Bits:        unix.PerfBitFreq, // Sample é taxa (Hz), não período em ns
+		}
+		attr.Size = uint32(unsafe.Sizeof(attr))
+		// pid=-1 (qualquer task), cpu=cpu, group_fd=-1
+		fd, err := unix.PerfEventOpen(&attr, -1, cpu, -1, 0)
+		if err != nil {
+			t.Close()
+			return nil, fmt.Errorf("perf_event_open cpu=%d: %w", cpu, err)
+		}
+		// Anexa programa BPF a esse fd
+		if err := unix.IoctlSetInt(fd, unix.PERF_EVENT_IOC_SET_BPF, prog.FD()); err != nil {
+			unix.Close(fd)
+			t.Close()
+			return nil, fmt.Errorf("ioctl SET_BPF cpu=%d: %w", cpu, err)
+		}
+		// Habilita sampling
+		if err := unix.IoctlSetInt(fd, unix.PERF_EVENT_IOC_ENABLE, 0); err != nil {
+			unix.Close(fd)
+			t.Close()
+			return nil, fmt.Errorf("ioctl ENABLE cpu=%d: %w", cpu, err)
+		}
+		t.perfFDs = append(t.perfFDs, fd)
+	}
+
+	return t, nil
+}
+
+// SampleCount retorna o contador atual de samples on-CPU acumulados.
+// O collector usa o delta entre chamadas pra calcular %.
+func (t *CPUTracer) SampleCount() (uint64, error) {
+	if t == nil || t.samplesMap == nil {
+		return 0, errors.New("tracer não inicializado")
+	}
+	var key uint32 = 0
+	var val uint64
+	if err := t.samplesMap.Lookup(&key, &val); err != nil {
+		return 0, err
+	}
+	return val, nil
+}
+
+// NumCPU retorna o número de CPUs nas quais o tracer está sampling.
+// Usado pro cálculo de % no collector.
+func (t *CPUTracer) NumCPU() int {
+	return len(t.perfFDs)
+}
+
+func (t *CPUTracer) Close() error {
+	if t == nil {
+		return nil
+	}
+	for _, fd := range t.perfFDs {
+		// Disable then close
+		_ = unix.IoctlSetInt(fd, unix.PERF_EVENT_IOC_DISABLE, 0)
+		_ = unix.Close(fd)
+	}
+	t.perfFDs = nil
+	if t.coll != nil {
+		t.coll.Close()
+		t.coll = nil
+		t.samplesMap = nil
+	}
+	return nil
+}
+

--- a/internal/bpf/cpu_stub.go
+++ b/internal/bpf/cpu_stub.go
@@ -1,0 +1,16 @@
+//go:build !linux || !ebpf
+
+package bpf
+
+import "errors"
+
+var errCPUStub = errors.New("eBPF cpu sampler não disponível neste build (precisa Linux + -tags=ebpf)")
+
+type CPUTracer struct{}
+
+const SampleFreq = 100
+
+func OpenCPUTracer(int) (*CPUTracer, error) { return nil, errCPUStub }
+func (*CPUTracer) SampleCount() (uint64, error) { return 0, errCPUStub }
+func (*CPUTracer) NumCPU() int                  { return 0 }
+func (*CPUTracer) Close() error                 { return nil }

--- a/internal/bpf/programs/cpu.bpf.c
+++ b/internal/bpf/programs/cpu.bpf.c
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: GPL-2.0
+//
+// cpu.bpf.c — sampling de CPU do PID alvo via perf_event a 100Hz por CPU.
+//
+// Maps:
+//   cpu_target_pid       ARRAY[1]  pid alvo (escrito pelo loader Go)
+//   cpu_target_samples   ARRAY[1]  contador acumulado de samples onde o
+//                                   target estava on-CPU
+//
+// Loader Go abre um perf_event PERF_TYPE_SOFTWARE/PERF_COUNT_SW_CPU_CLOCK
+// com sample_freq=100 em cada CPU. Cada vez que o kernel dispara um sample,
+// se o tgid atual == target_pid, incrementa o contador.
+//
+// Cálculo do % no Go side:
+//   delta_samples / (sample_freq × elapsed_seconds × NCPU) × 100 = % do
+//   sistema. Multiplica por NCPU pra ter % em escala "single-core" (top-style).
+
+#include <linux/bpf.h>
+#include <bpf/bpf_helpers.h>
+
+char LICENSE[] SEC("license") = "GPL";
+
+struct {
+    __uint(type, BPF_MAP_TYPE_ARRAY);
+    __type(key, __u32);
+    __type(value, __u32);
+    __uint(max_entries, 1);
+} cpu_target_pid SEC(".maps");
+
+struct {
+    __uint(type, BPF_MAP_TYPE_ARRAY);
+    __type(key, __u32);
+    __type(value, __u64);
+    __uint(max_entries, 1);
+} cpu_target_samples SEC(".maps");
+
+SEC("perf_event")
+int handle_perf_event(void *ctx)
+{
+    __u32 key = 0;
+    __u32 *target = bpf_map_lookup_elem(&cpu_target_pid, &key);
+    if (!target || *target == 0)
+        return 0;
+
+    __u64 pid_tgid = bpf_get_current_pid_tgid();
+    __u32 tgid = (__u32)(pid_tgid >> 32);
+    if (tgid != *target)
+        return 0;
+
+    __u64 *count = bpf_map_lookup_elem(&cpu_target_samples, &key);
+    if (count)
+        __sync_fetch_and_add(count, 1);
+    return 0;
+}

--- a/internal/collector/cpu_ebpf.go
+++ b/internal/collector/cpu_ebpf.go
@@ -1,0 +1,116 @@
+//go:build linux && ebpf
+
+package collector
+
+import (
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/trentas/xray/internal/bpf"
+)
+
+// CPUEBPFCollector consome o contador de samples on-CPU do tracer perf_event
+// (internal/bpf/cpu.go) e publica CpuSample{UsagePct} a cada 1s.
+//
+// Cálculo:
+//   delta_samples / (SampleFreq × NCPU × elapsed_seconds) × 100 × NCPU
+//   = delta_samples / (SampleFreq × elapsed_seconds) × 100
+//   = % single-core (top-style; pode passar 100% em multi-thread)
+//
+// Em build sem -tags=ebpf ou OS não-Linux, o stub paralelo sempre falha
+// em Start, levando o model a usar /proc collector ou simulação.
+type CPUEBPFCollector struct {
+	tracer *bpf.CPUTracer
+	ch     chan interface{}
+	stop   chan struct{}
+
+	mu       sync.Mutex
+	lastSamp uint64
+	lastAt   time.Time
+}
+
+func NewCPUEBPFCollector() *CPUEBPFCollector {
+	return &CPUEBPFCollector{
+		ch:   make(chan interface{}, 16),
+		stop: make(chan struct{}),
+	}
+}
+
+func (c *CPUEBPFCollector) Start(pid int) error {
+	tracer, err := bpf.OpenCPUTracer(pid)
+	if err != nil {
+		return fmt.Errorf("cpu eBPF: %w", err)
+	}
+	c.tracer = tracer
+	go c.loop()
+	return nil
+}
+
+func (c *CPUEBPFCollector) Stop() {
+	close(c.stop)
+	if c.tracer != nil {
+		_ = c.tracer.Close()
+		c.tracer = nil
+	}
+}
+
+func (c *CPUEBPFCollector) Subscribe() <-chan interface{} {
+	return c.ch
+}
+
+func (c *CPUEBPFCollector) loop() {
+	t := time.NewTicker(1 * time.Second)
+	defer t.Stop()
+	for {
+		select {
+		case <-c.stop:
+			return
+		case <-t.C:
+			if s, err := c.sample(); err == nil {
+				select {
+				case c.ch <- s:
+				default:
+				}
+			}
+		}
+	}
+}
+
+func (c *CPUEBPFCollector) sample() (CpuSample, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if c.tracer == nil {
+		return CpuSample{}, fmt.Errorf("tracer não aberto")
+	}
+	count, err := c.tracer.SampleCount()
+	if err != nil {
+		return CpuSample{}, err
+	}
+
+	now := time.Now()
+	var pct float64
+	if !c.lastAt.IsZero() {
+		elapsed := now.Sub(c.lastAt).Seconds()
+		if elapsed > 0 && count >= c.lastSamp {
+			delta := float64(count - c.lastSamp)
+			// pct = % of single-core. SampleFreq amostras por segundo por CPU
+			// dão NCPU × SampleFreq amostras/s no total. delta nesse intervalo
+			// representa frações da CPU usada pelo target.
+			//
+			// pct = (delta / (SampleFreq × elapsed)) × 100
+			pct = (delta / (float64(bpf.SampleFreq) * elapsed)) * 100
+			if pct > float64(c.tracer.NumCPU()*100) {
+				pct = float64(c.tracer.NumCPU() * 100) // saturação
+			}
+		}
+	}
+	c.lastSamp = count
+	c.lastAt = now
+
+	return CpuSample{
+		UsagePct:  pct,
+		Timestamp: now,
+	}, nil
+}

--- a/internal/collector/cpu_ebpf_stub.go
+++ b/internal/collector/cpu_ebpf_stub.go
@@ -1,0 +1,14 @@
+//go:build !linux || !ebpf
+
+package collector
+
+import "errors"
+
+type CPUEBPFCollector struct{}
+
+func NewCPUEBPFCollector() *CPUEBPFCollector { return &CPUEBPFCollector{} }
+func (*CPUEBPFCollector) Start(int) error {
+	return errors.New("eBPF cpu sampler não disponível neste build")
+}
+func (*CPUEBPFCollector) Stop()                          {}
+func (*CPUEBPFCollector) Subscribe() <-chan interface{}  { return nil }

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -140,6 +140,7 @@ type Model struct {
 	// Collectors
 	fdCollector           *collector.FDCollector
 	cpuCollector          *collector.CPUCollector
+	cpuEBPF               *collector.CPUEBPFCollector
 	threadsCollector      *collector.ThreadsCollector
 	memCollector          *collector.MemCollector
 	iowaitCollector       *collector.IOWaitCollector
@@ -204,9 +205,20 @@ func NewModel(cfg Config) Model {
 		} else if !cfg.NoEBPF {
 			fmt.Fprintf(os.Stderr, "aviso: FD collector indisponível\n")
 		}
-		if c := collector.NewCPUCollector(); c.Start(cfg.PID) == nil {
-			m.cpuCollector = c
-			m.usingMockCPU = false
+		// CPU: tenta eBPF perf_event primeiro (granularidade 100Hz/CPU);
+		// se falhar (sem -tags=ebpf, sem caps, etc.), cai pra /proc polling.
+		if !cfg.NoEBPF {
+			c := collector.NewCPUEBPFCollector()
+			if err := c.Start(cfg.PID); err == nil {
+				m.cpuEBPF = c
+				m.usingMockCPU = false
+			}
+		}
+		if m.cpuEBPF == nil {
+			if c := collector.NewCPUCollector(); c.Start(cfg.PID) == nil {
+				m.cpuCollector = c
+				m.usingMockCPU = false
+			}
 		}
 		if c := collector.NewThreadsCollector(); c.Start(cfg.PID) == nil {
 			m.threadsCollector = c
@@ -259,6 +271,9 @@ func (m Model) Init() tea.Cmd {
 	}
 	if m.cpuCollector != nil {
 		cmds = append(cmds, waitForCPU(m.cpuCollector))
+	}
+	if m.cpuEBPF != nil {
+		cmds = append(cmds, waitForCPUEBPF(m.cpuEBPF))
 	}
 	if m.threadsCollector != nil {
 		cmds = append(cmds, waitForThreads(m.threadsCollector))
@@ -333,6 +348,10 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		s := collector.CpuSample(v)
 		m.CPUHistory = appendCapped(m.CPUHistory, s.UsagePct, 60)
 		m.usingMockCPU = false
+		// Reagenda na source ativa: eBPF tem prioridade quando disponível.
+		if m.cpuEBPF != nil {
+			return m, waitForCPUEBPF(m.cpuEBPF)
+		}
 		return m, waitForCPU(m.cpuCollector)
 
 	case ThreadsMsg:
@@ -965,6 +984,23 @@ func waitForCPU(c *collector.CPUCollector) tea.Cmd {
 	}
 	return func() tea.Msg {
 		v := <-c.Subscribe()
+		if s, ok := v.(collector.CpuSample); ok {
+			return CpuMsg(s)
+		}
+		return TickMsg(time.Now())
+	}
+}
+
+func waitForCPUEBPF(c *collector.CPUEBPFCollector) tea.Cmd {
+	if c == nil {
+		return nil
+	}
+	return func() tea.Msg {
+		ch := c.Subscribe()
+		if ch == nil {
+			return TickMsg(time.Now())
+		}
+		v := <-ch
 		if s, ok := v.(collector.CpuSample); ok {
 			return CpuMsg(s)
 		}


### PR DESCRIPTION
Closes #10. Segundo programa eBPF.

## Como funciona

`unix.PerfEventOpen` em cada CPU com `PERF_TYPE_SOFTWARE / PERF_COUNT_SW_CPU_CLOCK` em 100Hz. Kernel dispara um sample em cada CPU em 100Hz; programa eBPF checa se `tgid == target_pid` e incrementa um contador.

Cálculo no Go: `pct = (delta_samples / (SampleFreq × elapsed_s)) × 100` = % single-core (top-style, pode passar 100% em multi-thread).

## Files

- `internal/bpf/programs/cpu.bpf.c` — perf_event handler + 2 maps
- `internal/bpf/cpu.go` — `CPUTracer` com perf_event_open + ioctl SET_BPF/ENABLE por CPU
- `internal/collector/cpu_ebpf.go` — polling 1s, computa %
- `internal/tui/model.go` — eBPF tem prioridade sobre /proc CPU collector

## Verificação

`go vet` + `go test -race` verdes em macOS. Não testado em Linux ainda.

## Pra testar na VM ARM

```bash
cd ~/xray && git pull
make build-ebpf
sudo ./bin/xray --pid $(pgrep firefox) 
```

CPU sparkline da F1 deve passar a vir do eBPF (granularidade 100Hz/CPU vs polling 500ms do /proc). Help overlay (`?`) deve mostrar `cpu ● real` e o valor deve ficar coerente com `top` ±5%.

## Caveats

- Sample.Type=PERF_SAMPLE_RAW + perfBitFreq usados, mas não emitimos buffer (apenas counter); kernel ignora sample_type sem ring buffer.
- ARM64 + Ubuntu 24.04 + kernel 6.8 confirma support; kernels < 4.4 (sem perf BPF) falham em ioctl SET_BPF — fallback pra /proc continua funcionando.