### PR TITLE
tui: collector source visibility (eBPF vs /proc vs mock)

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,8 +88,31 @@ sudo ./bin/xray --pid 1234 --export
 | `p`, `Space` | Pausar / retomar simulação |
 | `/` | Filtrar (cicla tipos na F6) |
 | `q`, `Ctrl+C` | Sair |
-| `s` | Snapshot JSON (planejado #15) |
-| `e` | Toggle export contínuo (planejado #15) |
+| `?` | Help overlay (status dos collectors com source eBPF/proc/mock) |
+| `s` | Snapshot JSON one-shot |
+| `e` | Toggle export contínuo (JSONL) |
+
+### Verificando se eBPF carregou
+
+O help overlay (`?`) mostra cada collector com sua origem: `cpu ● real via eBPF`, `cpu ● real via /proc`, ou `cpu ○ mock`.
+
+Se um collector eBPF falhou ao iniciar, o erro aparece em **stderr** antes da TUI subir:
+
+```
+$ sudo ./bin/xray --pid 1234
+aviso: eBPF cpu collector indisponível: perf_event_open: operation not permitted
+```
+
+Comum: `operation not permitted` = falta `CAP_BPF` + `CAP_PERFMON` ou kernel com `unprivileged_bpf_disabled=1`.
+
+Verificação extra do kernel-side (Linux):
+
+```bash
+# Lista programas eBPF carregados pelo kernel
+sudo bpftool prog list | grep -E 'tracepoint|perf_event' | tail
+```
+
+Quando xray está rodando com eBPF ativo, deve aparecer `handle_sys_enter` / `handle_sys_exit` (#9) e `handle_perf_event` (#10).
 
 ---
 

--- a/internal/tui/help.go
+++ b/internal/tui/help.go
@@ -6,6 +6,15 @@ import (
 	"github.com/charmbracelet/lipgloss"
 )
 
+// sourceProcOrEmpty retorna "/proc" quando o collector está rodando real,
+// "" caso contrário. Usado pra anotar a source no help overlay.
+func sourceProcOrEmpty(real bool) string {
+	if real {
+		return "/proc"
+	}
+	return ""
+}
+
 // renderHelpOverlay desenha um modal centralizado com todos os keybindings.
 // Recebe as dimensões totais do content area; lipgloss.Place centraliza o card.
 //
@@ -30,12 +39,18 @@ func renderHelpOverlayWithStatus(m Model, w, h int) string {
 
 	statusReal := lipgloss.NewStyle().Foreground(ColorGreen).Background(ColorPanel).Render("● real")
 	statusMock := lipgloss.NewStyle().Foreground(ColorAmber).Background(ColorPanel).Render("○ mock")
-	statusRow := func(name string, isMock bool) string {
+	sourceStyle := lipgloss.NewStyle().Foreground(ColorMuted).Background(ColorPanel).Italic(true)
+
+	statusRow := func(name string, isMock bool, source string) string {
 		s := statusReal
 		if isMock {
 			s = statusMock
 		}
-		return keyStyle.Render(padRight(name, 14)) + descStyle.Render(" ") + s
+		row := keyStyle.Render(padRight(name, 14)) + descStyle.Render(" ") + s
+		if source != "" {
+			row += sourceStyle.Render(" via " + source)
+		}
+		return row
 	}
 
 	lines := []string{
@@ -62,13 +77,13 @@ func renderHelpOverlayWithStatus(m Model, w, h int) string {
 		dimRow("--export", "Flag CLI: export desde o launch + snapshot final ao sair"),
 		"",
 		sectionTitle.Render("Collectors"),
-		statusRow("syscalls", m.usingMockSyscalls),
-		statusRow("cpu", m.usingMockCPU),
-		statusRow("memory", m.usingMockMem),
-		statusRow("threads", m.usingMockThreads),
-		statusRow("io-wait", m.usingMockIOWait),
-		statusRow("io-throughput", m.usingMockIOThrough),
-		statusRow("fds", m.usingMockFDs),
+		statusRow("syscalls", m.usingMockSyscalls, m.syscallsSource),
+		statusRow("cpu", m.usingMockCPU, m.cpuSource),
+		statusRow("memory", m.usingMockMem, sourceProcOrEmpty(!m.usingMockMem)),
+		statusRow("threads", m.usingMockThreads, sourceProcOrEmpty(!m.usingMockThreads)),
+		statusRow("io-wait", m.usingMockIOWait, sourceProcOrEmpty(!m.usingMockIOWait)),
+		statusRow("io-throughput", m.usingMockIOThrough, sourceProcOrEmpty(!m.usingMockIOThrough)),
+		statusRow("fds", m.usingMockFDs, sourceProcOrEmpty(!m.usingMockFDs)),
 	}
 
 	body := strings.Join(lines, "\n")

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -157,7 +157,12 @@ type Model struct {
 	usingMockIOWait      bool
 	usingMockIOThrough   bool
 	usingMockSyscalls    bool
-	lastSimAt           time.Time
+	lastSimAt            time.Time
+
+	// Sources: indicam de onde veio o dado real ("eBPF" | "/proc" | "" pra mock).
+	// Mostrado no help overlay (?) pra debug e visibilidade.
+	cpuSource      string
+	syscallsSource string
 
 	// Caches estáveis para evitar reordenação visual entre ticks.
 	// topSyscallNames é recomputado a cada `topRefreshInterval`; entre refreshes
@@ -207,17 +212,22 @@ func NewModel(cfg Config) Model {
 		}
 		// CPU: tenta eBPF perf_event primeiro (granularidade 100Hz/CPU);
 		// se falhar (sem -tags=ebpf, sem caps, etc.), cai pra /proc polling.
+		// Erro de eBPF é exposto em stderr ANTES do alt-screen pra usuário ver.
 		if !cfg.NoEBPF {
 			c := collector.NewCPUEBPFCollector()
 			if err := c.Start(cfg.PID); err == nil {
 				m.cpuEBPF = c
 				m.usingMockCPU = false
+				m.cpuSource = "eBPF"
+			} else {
+				fmt.Fprintf(os.Stderr, "aviso: eBPF cpu collector indisponível: %v\n", err)
 			}
 		}
 		if m.cpuEBPF == nil {
 			if c := collector.NewCPUCollector(); c.Start(cfg.PID) == nil {
 				m.cpuCollector = c
 				m.usingMockCPU = false
+				m.cpuSource = "/proc"
 			}
 		}
 		if c := collector.NewThreadsCollector(); c.Start(cfg.PID) == nil {
@@ -237,13 +247,15 @@ func NewModel(cfg Config) Model {
 			m.usingMockIOThrough = false
 		}
 		// Coletor eBPF: só funciona em build com -tags=ebpf, kernel >= 5.8
-		// e CAP_BPF/CAP_PERFMON. Em qualquer outra config, Start falha
-		// silenciosamente e mantemos usingMockSyscalls=true.
+		// e CAP_BPF/CAP_PERFMON. Erro vai pra stderr pra usuário ver.
 		if !cfg.NoEBPF {
 			c := collector.NewSyscallsEBPFCollector()
 			if err := c.Start(cfg.PID); err == nil {
 				m.syscallsEBPF = c
 				m.usingMockSyscalls = false
+				m.syscallsSource = "eBPF"
+			} else {
+				fmt.Fprintf(os.Stderr, "aviso: eBPF syscalls collector indisponível: %v\n", err)
 			}
 		}
 	}


### PR DESCRIPTION
Resposta direta à pergunta do usuário: "como eu sei que deu perm denied ou nao do #10?"

## 3 mecanismos de visibilidade

**1. Help overlay (`?`)** mostra source ao lado de cada collector:
```
cpu              ● real via eBPF
syscalls         ● real via eBPF
threads          ● real via /proc
fds              ● real via /proc
io-throughput    ○ mock
```

**2. stderr warning** quando eBPF falha (impresso antes do alt-screen):
```
aviso: eBPF cpu collector indisponível: perf_event_open: operation not permitted
```

**3. README** tem nova seção "Verificando se eBPF carregou" documentando os pontos acima + `sudo bpftool prog list` pra verificação kernel-side.

## Implementação

- `model.go`: campos `cpuSource` / `syscallsSource` (string)
- `help.go`: `statusRow` aceita source e renderiza " via X" em italic muted
- main.go pra outros collectors usa helper `sourceProcOrEmpty(real)`

`go test -race ./...` verde.