### PR TITLE
infra: bpf.Available const + startup diagnostic

### DIFF
--- a/cmd/xray/main.go
+++ b/cmd/xray/main.go
@@ -39,12 +39,25 @@ func main() {
 	}
 
 	if !*noEBPF {
-		caps := bpf.GetCapStatus()
-		if diag := caps.Diagnose(); diag != "" {
-			fmt.Fprintln(os.Stderr, "erro: eBPF não disponível")
+		// Diagnóstico de build vs runtime:
+		//   - Available = false → binário foi compilado SEM `-tags=ebpf`.
+		//     Não é erro de permissão; é build errado. Cai pra /proc.
+		//   - Available = true mas caps insuficientes → erro fatal antes
+		//     do TUI subir, com mensagem detalhada de Diagnose().
+		if !bpf.Available {
+			fmt.Fprintln(os.Stderr, "[xray] eBPF não está embarcado neste binário")
+			fmt.Fprintln(os.Stderr, "       Rode `make build-ebpf` (Linux + libbpf-dev) pra ativar.")
+			fmt.Fprintln(os.Stderr, "       Continuando em modo /proc-only.")
 			fmt.Fprintln(os.Stderr, "")
-			fmt.Fprint(os.Stderr, diag)
-			os.Exit(1)
+		} else {
+			caps := bpf.GetCapStatus()
+			if diag := caps.Diagnose(); diag != "" {
+				fmt.Fprintln(os.Stderr, "erro: eBPF não disponível")
+				fmt.Fprintln(os.Stderr, "")
+				fmt.Fprint(os.Stderr, diag)
+				os.Exit(1)
+			}
+			fmt.Fprintln(os.Stderr, "[xray] eBPF embarcado, kernel suporta. Iniciando tracers...")
 		}
 	}
 

--- a/internal/bpf/available.go
+++ b/internal/bpf/available.go
@@ -1,0 +1,8 @@
+//go:build linux && ebpf
+
+package bpf
+
+// Available é true quando o binário foi compilado com `-tags=ebpf` em Linux.
+// Em qualquer outro build (default ou OS não-Linux) é false. main.go usa
+// pra distinguir "eBPF tentou e falhou" de "binário sem eBPF".
+const Available = true

--- a/internal/bpf/available_stub.go
+++ b/internal/bpf/available_stub.go
@@ -1,0 +1,7 @@
+//go:build !linux || !ebpf
+
+package bpf
+
+// Available é false em builds default (sem -tags=ebpf) ou em OS não-Linux.
+// Quando false, todos os Open*Tracer retornam erro imediatamente.
+const Available = false


### PR DESCRIPTION
Resposta concreta à confusão "bpftool não retornou nada" — provavelmente o binário foi compilado sem `-tags=ebpf`.

Agora o startup diferencia 3 cenários:

1. **Build sem ebpf tag**: `[xray] eBPF não está embarcado neste binário. Rode \`make build-ebpf\` ...`
2. **Build com ebpf, kernel OK**: `[xray] eBPF embarcado, kernel suporta. Iniciando tracers...`
3. **Build com ebpf, caps insuficientes**: erro detalhado com Diagnose() e exit 1

Implementação:
- `internal/bpf/available.go` (linux+ebpf): `const Available = true`
- `internal/bpf/available_stub.go` (other): `const Available = false`
- `main.go` checa `bpf.Available` antes do alt-screen e imprime mensagem apropriada

`go test -race ./...` verde.