### PR TITLE
tui: scrollable help overlay (↑/↓/PgUp/PgDn) for 80x24

### DIFF
--- a/internal/tui/help.go
+++ b/internal/tui/help.go
@@ -86,6 +86,52 @@ func renderHelpOverlayWithStatus(m Model, w, h int) string {
 		statusRow("fds", m.usingMockFDs, sourceProcOrEmpty(!m.usingMockFDs)),
 	}
 
+	// Scroll: card tem border (2 lines) + padding (2 lines) = 4 overhead;
+	// se ainda assim sobrar pra scroll indicators (2 linhas), maxBody fica
+	// h - 4 - 2 = h - 6. Em terminais 80x24 com chrome ocupando ~3 linhas,
+	// contentH ≈ 21, maxBody ≈ 15 — menor que ~30 linhas do help. Scroll é
+	// realmente necessário.
+	maxBody := h - 4
+	if maxBody < 5 {
+		maxBody = 5
+	}
+
+	scroll := m.helpScroll
+	hasMoreAbove := false
+	hasMoreBelow := false
+
+	if len(lines) > maxBody {
+		// reserva 2 linhas pros indicators de scroll
+		bodyH := maxBody - 2
+		if bodyH < 3 {
+			bodyH = 3
+		}
+		// clamp scroll
+		maxScroll := len(lines) - bodyH
+		if scroll > maxScroll {
+			scroll = maxScroll
+		}
+		if scroll < 0 {
+			scroll = 0
+		}
+		hasMoreAbove = scroll > 0
+		hasMoreBelow = scroll+bodyH < len(lines)
+		lines = lines[scroll : scroll+bodyH]
+	}
+
+	scrollIndicator := func(visible bool, glyph, hint string) string {
+		if !visible {
+			return lipgloss.NewStyle().Foreground(ColorPanel).Background(ColorPanel).Render(strings.Repeat(" ", 30))
+		}
+		return lipgloss.NewStyle().Foreground(ColorTeal).Background(ColorPanel).Italic(true).
+			Render(glyph + " " + hint)
+	}
+
+	if hasMoreAbove || hasMoreBelow {
+		lines = append([]string{scrollIndicator(hasMoreAbove, "↑", "mais acima (↑/PgUp)")}, lines...)
+		lines = append(lines, scrollIndicator(hasMoreBelow, "↓", "mais abaixo (↓/PgDn)"))
+	}
+
 	body := strings.Join(lines, "\n")
 
 	card := lipgloss.NewStyle().

--- a/internal/tui/help_test.go
+++ b/internal/tui/help_test.go
@@ -32,11 +32,59 @@ func TestHelpOverlayToggle(t *testing.T) {
 		t.Error("overlay não renderizou seção Filtro")
 	}
 
-	// Qualquer tecla fecha
+	// Tecla 'a' agora não fecha (só ?, esc, q fecham — outras são ignoradas
+	// pra permitir scroll com setas/PgUp/PgDn sem fechar acidentalmente).
 	nm, _ = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'a'}})
 	m = nm.(Model)
+	if !m.showHelp {
+		t.Error("tecla 'a' fechou help — deveria ignorar")
+	}
+
+	// '?' fecha
+	nm, _ = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'?'}})
+	m = nm.(Model)
 	if m.showHelp {
-		t.Error("tecla não fechou o help")
+		t.Error("? não fechou o help")
+	}
+}
+
+func TestHelpScroll(t *testing.T) {
+	m := NewModel(Config{PID: 1, FPS: 5, NoEBPF: true})
+	m.Width = 80
+	m.Height = 24
+	m.showHelp = true
+
+	if m.helpScroll != 0 {
+		t.Fatal("helpScroll inicial != 0")
+	}
+
+	// ↓ aumenta scroll
+	nm, _ := m.Update(tea.KeyMsg{Type: tea.KeyDown})
+	m = nm.(Model)
+	if m.helpScroll != 1 {
+		t.Errorf("após ↓, helpScroll=%d (esperado 1)", m.helpScroll)
+	}
+
+	// ↑ diminui
+	nm, _ = m.Update(tea.KeyMsg{Type: tea.KeyUp})
+	m = nm.(Model)
+	if m.helpScroll != 0 {
+		t.Errorf("após ↑, helpScroll=%d (esperado 0)", m.helpScroll)
+	}
+
+	// ↑ não vai abaixo de 0
+	nm, _ = m.Update(tea.KeyMsg{Type: tea.KeyUp})
+	m = nm.(Model)
+	if m.helpScroll != 0 {
+		t.Errorf("↑ no topo deveria ficar em 0, got %d", m.helpScroll)
+	}
+
+	// Esc fecha e zera scroll
+	m.helpScroll = 5
+	nm, _ = m.Update(tea.KeyMsg{Type: tea.KeyEsc})
+	m = nm.(Model)
+	if m.showHelp || m.helpScroll != 0 {
+		t.Errorf("Esc deveria fechar e zerar scroll: showHelp=%v scroll=%d", m.showHelp, m.helpScroll)
 	}
 }
 

--- a/internal/tui/keys.go
+++ b/internal/tui/keys.go
@@ -22,7 +22,31 @@ func (m Model) handleKey(msg tea.KeyMsg) (Model, tea.Cmd) {
 
 	// 1. Help overlay
 	if m.showHelp {
-		m.showHelp = false
+		switch key {
+		case "up", "k":
+			if m.helpScroll > 0 {
+				m.helpScroll--
+			}
+		case "down", "j":
+			m.helpScroll++ // capado pela view se passar do total
+		case "pgup":
+			m.helpScroll -= 10
+			if m.helpScroll < 0 {
+				m.helpScroll = 0
+			}
+		case "pgdown":
+			m.helpScroll += 10
+		case "home", "g":
+			m.helpScroll = 0
+		case "end", "G":
+			m.helpScroll = 9999 // capado pela view
+		case "?", "esc", "q":
+			m.showHelp = false
+			m.helpScroll = 0
+		default:
+			// outras teclas: ignora (mantém help aberto pro user scrollar
+			// sem fechar acidentalmente). `?` ou esc/q pra sair.
+		}
 		return m, nil
 	}
 

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -134,8 +134,10 @@ type Model struct {
 	inputBuf  string
 
 	// showHelp: quando true, View() renderiza overlay com keybindings sobre
-	// o conteúdo. Fechado por qualquer tecla (incluindo `?` e `esc`).
-	showHelp bool
+	// o conteúdo. Fechado por `?`, `esc` ou `q`. Setas/PgUp/PgDn fazem scroll
+	// quando o overlay não cabe na altura disponível.
+	showHelp   bool
+	helpScroll int
 
 	// Collectors
 	fdCollector           *collector.FDCollector


### PR DESCRIPTION
Reportado pelo user: help não cabe em 80x24. Adiciona scroll.

- ↑/k, ↓/j: scroll 1 linha
- PgUp/PgDn: 10 linhas
- Home/g, End/G: extremos
- ?, esc, q: fecha
- Outras teclas: ignoradas (não fecham mais — antes "qualquer tecla fecha" causava acidentes ao scrollar)

Indicadores "↑ mais acima" / "↓ mais abaixo" aparecem quando há conteúdo cortado.