### PR TITLE
ebpf: I/O syscall tracking → real top files + histogram

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,8 @@ endif
 # Lista de programas eBPF a compilar. Adicionar novos .bpf.c aqui.
 BPF_SRCS := \
 	internal/bpf/programs/syscalls.bpf.c \
-	internal/bpf/programs/cpu.bpf.c
+	internal/bpf/programs/cpu.bpf.c \
+	internal/bpf/programs/io.bpf.c
 
 BPF_OBJS := $(BPF_SRCS:.c=.o)
 

--- a/internal/bpf/io.go
+++ b/internal/bpf/io.go
@@ -1,0 +1,157 @@
+//go:build linux && ebpf
+
+package bpf
+
+import (
+	"bytes"
+	_ "embed"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"io"
+
+	"github.com/cilium/ebpf"
+	"github.com/cilium/ebpf/link"
+	"github.com/cilium/ebpf/ringbuf"
+	"github.com/cilium/ebpf/rlimit"
+)
+
+//go:embed programs/io.bpf.o
+var ioBPFObj []byte
+
+// IOEvent é o layout 1:1 da struct io_event em programs/io.bpf.c.
+// Tamanho fixo 32 bytes; binary.LittleEndian.Read parseia direto da ring buffer.
+type IOEvent struct {
+	TsNs   uint64
+	LatNs  uint64
+	Bytes  uint64
+	FD     uint32
+	Op     uint32 // 0=read, 1=write
+	TGID   uint32
+	_      uint32 // pad
+}
+
+const (
+	IOOpRead  uint32 = 0
+	IOOpWrite uint32 = 1
+)
+
+// IOTracer carrega io.bpf.o, attacha tracepoints sys_enter/exit_read/write,
+// abre ring buffer reader e expõe Next() pra entregar eventos parseados.
+type IOTracer struct {
+	coll  *ebpf.Collection
+	links []link.Link
+	rb    *ringbuf.Reader
+}
+
+func OpenIOTracer(pid int) (*IOTracer, error) {
+	if pid <= 0 {
+		return nil, errors.New("pid inválido")
+	}
+	if err := rlimit.RemoveMemlock(); err != nil {
+		return nil, fmt.Errorf("rlimit: %w", err)
+	}
+
+	spec, err := ebpf.LoadCollectionSpecFromReader(bytes.NewReader(ioBPFObj))
+	if err != nil {
+		return nil, fmt.Errorf("parse io BPF object: %w", err)
+	}
+	coll, err := ebpf.NewCollection(spec)
+	if err != nil {
+		return nil, fmt.Errorf("load io collection: %w", err)
+	}
+	t := &IOTracer{coll: coll}
+
+	// Setar target_pid
+	targetMap := coll.Maps["io_target_pid"]
+	if targetMap == nil {
+		t.Close()
+		return nil, errors.New("io_target_pid map ausente")
+	}
+	var key uint32 = 0
+	val := uint32(pid)
+	if err := targetMap.Update(&key, &val, ebpf.UpdateAny); err != nil {
+		t.Close()
+		return nil, fmt.Errorf("set io_target_pid: %w", err)
+	}
+
+	// Attach 4 tracepoints (enter/exit × read/write)
+	attachments := []struct {
+		group, name, prog string
+	}{
+		{"syscalls", "sys_enter_read", "handle_enter_read"},
+		{"syscalls", "sys_exit_read", "handle_exit_read"},
+		{"syscalls", "sys_enter_write", "handle_enter_write"},
+		{"syscalls", "sys_exit_write", "handle_exit_write"},
+	}
+	for _, a := range attachments {
+		prog := coll.Programs[a.prog]
+		if prog == nil {
+			t.Close()
+			return nil, fmt.Errorf("program %s ausente", a.prog)
+		}
+		l, err := link.Tracepoint(a.group, a.name, prog, nil)
+		if err != nil {
+			t.Close()
+			return nil, fmt.Errorf("attach %s/%s: %w", a.group, a.name, err)
+		}
+		t.links = append(t.links, l)
+	}
+
+	// Abre ring buffer reader. Reads bloqueiam até evento chegar ou Close.
+	eventsMap := coll.Maps["io_events"]
+	if eventsMap == nil {
+		t.Close()
+		return nil, errors.New("io_events ringbuf ausente")
+	}
+	rb, err := ringbuf.NewReader(eventsMap)
+	if err != nil {
+		t.Close()
+		return nil, fmt.Errorf("ringbuf reader: %w", err)
+	}
+	t.rb = rb
+
+	return t, nil
+}
+
+// Next bloqueia até o próximo evento chegar do kernel. Retorna io.EOF se o
+// tracer foi fechado. Erros transientes (sample lost, etc) são contornados.
+func (t *IOTracer) Next() (IOEvent, error) {
+	var ev IOEvent
+	if t == nil || t.rb == nil {
+		return ev, errors.New("tracer não inicializado")
+	}
+	rec, err := t.rb.Read()
+	if err != nil {
+		if errors.Is(err, ringbuf.ErrClosed) {
+			return ev, io.EOF
+		}
+		return ev, err
+	}
+	if len(rec.RawSample) < 32 {
+		return ev, fmt.Errorf("evento curto: %d bytes", len(rec.RawSample))
+	}
+	if err := binary.Read(bytes.NewReader(rec.RawSample), binary.LittleEndian, &ev); err != nil {
+		return ev, fmt.Errorf("decode event: %w", err)
+	}
+	return ev, nil
+}
+
+func (t *IOTracer) Close() error {
+	if t == nil {
+		return nil
+	}
+	if t.rb != nil {
+		_ = t.rb.Close()
+		t.rb = nil
+	}
+	for _, l := range t.links {
+		_ = l.Close()
+	}
+	t.links = nil
+	if t.coll != nil {
+		t.coll.Close()
+		t.coll = nil
+	}
+	return nil
+}

--- a/internal/bpf/io_stub.go
+++ b/internal/bpf/io_stub.go
@@ -1,0 +1,30 @@
+//go:build !linux || !ebpf
+
+package bpf
+
+import (
+	"errors"
+	"io"
+)
+
+var errIOStub = errors.New("eBPF io tracer não disponível neste build")
+
+const (
+	IOOpRead  uint32 = 0
+	IOOpWrite uint32 = 1
+)
+
+type IOEvent struct {
+	TsNs  uint64
+	LatNs uint64
+	Bytes uint64
+	FD    uint32
+	Op    uint32
+	TGID  uint32
+}
+
+type IOTracer struct{}
+
+func OpenIOTracer(int) (*IOTracer, error)       { return nil, errIOStub }
+func (*IOTracer) Next() (IOEvent, error)         { return IOEvent{}, io.EOF }
+func (*IOTracer) Close() error                   { return nil }

--- a/internal/bpf/programs/io.bpf.c
+++ b/internal/bpf/programs/io.bpf.c
@@ -1,0 +1,171 @@
+// SPDX-License-Identifier: GPL-2.0
+//
+// io.bpf.c — rastreia syscalls de I/O síncrono (read/write/pread64/pwrite64)
+// do PID alvo, mede latência por chamada e emite eventos via ring buffer.
+//
+// Maps:
+//   io_target_pid       ARRAY[1]   pid alvo (escrito pelo loader Go)
+//   io_inflight_map     HASH       tgid_pid → {ts_ns, fd, op, count_req}
+//                                  rastreia syscall em flight pra correlacionar
+//                                  enter/exit
+//   io_events           RINGBUF    canal pro user-space — cada evento contém
+//                                  fd, op type, bytes lidos/escritos, latência
+//
+// Por que syscall-level (não block-level)?
+//   block:block_rq_* dá latência REAL de disco (exclui cache). Mas resolver
+//   path do file requer vmlinux.h ou CO-RE. Aqui usamos sys_enter_/sys_exit_
+//   tracepoints que dão fd direto — Go resolve fd→path via /proc/<pid>/fd.
+//   Trade-off: mostramos I/O syscall-level (inclui cache hits), que é o que
+//   o usuário vê em "files acessados" e bate com o mockup de F5.
+//
+// Tracepoints em syscalls/sys_enter_X são arch-independentes (kernel resolve
+// pelo nome, não pelo número) — código compilado em x86_64 funciona em arm64.
+
+#include <linux/bpf.h>
+#include <bpf/bpf_helpers.h>
+
+char LICENSE[] SEC("license") = "GPL";
+
+// Estruturas dos tracepoints. Layout estável de
+// /sys/kernel/debug/tracing/events/syscalls/sys_enter_read/format:
+//
+//   common_type/flags/preempt_count/pid    (8 bytes)
+//   __syscall_nr int + padding              (8 bytes)
+//   fd unsigned long                        (8 bytes)
+//   buf char*                               (8 bytes)
+//   count size_t                            (8 bytes)
+struct sys_enter_rw_args {
+    unsigned long long _pad;
+    long id;
+    unsigned long fd;
+    unsigned long buf;
+    unsigned long count;
+};
+
+struct sys_exit_args {
+    unsigned long long _pad;
+    long id;
+    long ret;
+};
+
+// Op codes — devem bater com o lado Go (collector/io_ebpf.go).
+#define OP_READ  0
+#define OP_WRITE 1
+
+struct io_inflight {
+    __u64 ts_ns;
+    __u32 fd;
+    __u32 op;
+    __u64 count_req;
+};
+
+// Evento publicado pro user-space via ring buffer. Layout fixo, lido com
+// binary.LittleEndian no Go side. Mantenha em sincronia com IOEvent em
+// internal/collector/io_ebpf.go.
+struct io_event {
+    __u64 ts_ns;
+    __u64 lat_ns;
+    __u64 bytes;       // ret value (se positivo)
+    __u32 fd;
+    __u32 op;
+    __u32 tgid;
+    __u32 _pad;
+};
+
+struct {
+    __uint(type, BPF_MAP_TYPE_ARRAY);
+    __type(key, __u32);
+    __type(value, __u32);
+    __uint(max_entries, 1);
+} io_target_pid SEC(".maps");
+
+struct {
+    __uint(type, BPF_MAP_TYPE_HASH);
+    __type(key, __u64);
+    __type(value, struct io_inflight);
+    __uint(max_entries, 10240);
+} io_inflight_map SEC(".maps");
+
+struct {
+    __uint(type, BPF_MAP_TYPE_RINGBUF);
+    __uint(max_entries, 1 << 20); // 1MB
+} io_events SEC(".maps");
+
+static __always_inline int is_io_target(void)
+{
+    __u32 key = 0;
+    __u32 *target = bpf_map_lookup_elem(&io_target_pid, &key);
+    if (!target || *target == 0)
+        return 0;
+    __u64 pid_tgid = bpf_get_current_pid_tgid();
+    __u32 tgid = (__u32)(pid_tgid >> 32);
+    return tgid == *target;
+}
+
+static __always_inline void enter_io(__u32 op, __u32 fd, __u64 count)
+{
+    if (!is_io_target())
+        return;
+    __u64 pid_tgid = bpf_get_current_pid_tgid();
+    struct io_inflight inf = {
+        .ts_ns     = bpf_ktime_get_ns(),
+        .fd        = fd,
+        .op        = op,
+        .count_req = count,
+    };
+    bpf_map_update_elem(&io_inflight_map, &pid_tgid, &inf, BPF_ANY);
+}
+
+static __always_inline void exit_io(long ret)
+{
+    __u64 pid_tgid = bpf_get_current_pid_tgid();
+    struct io_inflight *inf = bpf_map_lookup_elem(&io_inflight_map, &pid_tgid);
+    if (!inf)
+        return;
+
+    struct io_event *e = bpf_ringbuf_reserve(&io_events, sizeof(*e), 0);
+    if (e) {
+        __u64 now = bpf_ktime_get_ns();
+        e->ts_ns  = now;
+        e->lat_ns = now - inf->ts_ns;
+        e->bytes  = ret > 0 ? (__u64)ret : 0;
+        e->fd     = inf->fd;
+        e->op     = inf->op;
+        e->tgid   = (__u32)(pid_tgid >> 32);
+        e->_pad   = 0;
+        bpf_ringbuf_submit(e, 0);
+    }
+    bpf_map_delete_elem(&io_inflight_map, &pid_tgid);
+}
+
+SEC("tracepoint/syscalls/sys_enter_read")
+int handle_enter_read(struct sys_enter_rw_args *ctx)
+{
+    enter_io(OP_READ, (__u32)ctx->fd, ctx->count);
+    return 0;
+}
+
+SEC("tracepoint/syscalls/sys_exit_read")
+int handle_exit_read(struct sys_exit_args *ctx)
+{
+    if (!is_io_target())
+        return 0;
+    exit_io(ctx->ret);
+    return 0;
+}
+
+SEC("tracepoint/syscalls/sys_enter_write")
+int handle_enter_write(struct sys_enter_rw_args *ctx)
+{
+    enter_io(OP_WRITE, (__u32)ctx->fd, ctx->count);
+    return 0;
+}
+
+SEC("tracepoint/syscalls/sys_exit_write")
+int handle_exit_write(struct sys_exit_args *ctx)
+{
+    if (!is_io_target())
+        return 0;
+    exit_io(ctx->ret);
+    return 0;
+}

--- a/internal/collector/io_ebpf.go
+++ b/internal/collector/io_ebpf.go
@@ -1,0 +1,281 @@
+//go:build linux && ebpf
+
+package collector
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/trentas/xray/internal/bpf"
+)
+
+// IOEBPFCollector consome o ring buffer de eventos do tracer eBPF de I/O
+// e agrega por PATH em janelas de 500ms. Output é o IOStats.TopFiles +
+// LatencyBuckets atualizados, publicados via canal.
+//
+// Resolução fd→path: lookup em /proc/<pid>/fd/<fd> readlink, com cache
+// de 2s pra reduzir overhead. FDs novos resolvem na primeira aparição.
+type IOEBPFCollector struct {
+	tracer *bpf.IOTracer
+	ch     chan interface{}
+	stop   chan struct{}
+	pid    int
+
+	mu      sync.Mutex
+	files   map[string]*ioFileAgg     // path → contadores
+	pathFor map[uint32]pathCacheEntry // fd → path (cached)
+	buckets []LatencyBucket           // baseline buckets pré-criados
+}
+
+type ioFileAgg struct {
+	reads     uint64
+	writes    uint64
+	bytes     uint64
+	latSumNs  uint64
+	latCount  uint64
+	latMaxNs  uint64
+	fileType  string
+}
+
+type pathCacheEntry struct {
+	path  string
+	at    time.Time
+}
+
+const ioPathCacheTTL = 2 * time.Second
+
+func NewIOEBPFCollector() *IOEBPFCollector {
+	return &IOEBPFCollector{
+		ch:      make(chan interface{}, 16),
+		stop:    make(chan struct{}),
+		files:   make(map[string]*ioFileAgg),
+		pathFor: make(map[uint32]pathCacheEntry),
+		buckets: []LatencyBucket{
+			{Label: "<0.1ms"},
+			{Label: "0.1-1ms"},
+			{Label: "1-5ms"},
+			{Label: "5-20ms"},
+			{Label: ">20ms"},
+		},
+	}
+}
+
+func (c *IOEBPFCollector) Start(pid int) error {
+	tracer, err := bpf.OpenIOTracer(pid)
+	if err != nil {
+		return fmt.Errorf("io eBPF: %w", err)
+	}
+	c.tracer = tracer
+	c.pid = pid
+	go c.readLoop()    // consome ringbuf, popula c.files
+	go c.publishLoop() // a cada 500ms publica snapshot dos agregados
+	return nil
+}
+
+func (c *IOEBPFCollector) Stop() {
+	close(c.stop)
+	if c.tracer != nil {
+		_ = c.tracer.Close()
+		c.tracer = nil
+	}
+}
+
+func (c *IOEBPFCollector) Subscribe() <-chan interface{} {
+	return c.ch
+}
+
+// readLoop lê eventos da ring buffer indefinidamente, atualiza agregados
+// in-place. Ringbuf.Read bloqueia até evento chegar — quando o tracer
+// fecha, retorna io.EOF e a goroutine termina.
+func (c *IOEBPFCollector) readLoop() {
+	for {
+		ev, err := c.tracer.Next()
+		if err != nil {
+			if err == io.EOF {
+				return
+			}
+			// erro transiente; tenta de novo
+			continue
+		}
+		c.processEvent(ev)
+	}
+}
+
+func (c *IOEBPFCollector) processEvent(ev bpf.IOEvent) {
+	path := c.resolvePath(ev.FD)
+	if path == "" {
+		path = fmt.Sprintf("fd=%d", ev.FD)
+	}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	agg, ok := c.files[path]
+	if !ok {
+		agg = &ioFileAgg{fileType: classifyPath(path)}
+		c.files[path] = agg
+	}
+	if ev.Op == bpf.IOOpRead {
+		agg.reads++
+	} else {
+		agg.writes++
+	}
+	agg.bytes += ev.Bytes
+	agg.latSumNs += ev.LatNs
+	agg.latCount++
+	if ev.LatNs > agg.latMaxNs {
+		agg.latMaxNs = ev.LatNs
+	}
+
+	// Histograma de latência (em ms)
+	latMs := float64(ev.LatNs) / 1e6
+	bIdx := bucketIndexMs(latMs)
+	if bIdx >= 0 && bIdx < len(c.buckets) {
+		if ev.Op == bpf.IOOpRead {
+			c.buckets[bIdx].Read++
+		} else {
+			c.buckets[bIdx].Write++
+		}
+	}
+}
+
+// resolvePath lê /proc/<pid>/fd/<fd> via readlink, com cache de 2s.
+// Sockets e pipes retornam paths como "socket:[N]" — caller deve filtrar
+// se quiser só files de verdade. Aqui mantemos tudo (sockets aparecem
+// como "socket:[12345]" no top files, sinalizando network I/O).
+func (c *IOEBPFCollector) resolvePath(fd uint32) string {
+	c.mu.Lock()
+	if cached, ok := c.pathFor[fd]; ok && time.Since(cached.at) < ioPathCacheTTL {
+		c.mu.Unlock()
+		return cached.path
+	}
+	c.mu.Unlock()
+
+	link, err := os.Readlink(fmt.Sprintf("/proc/%d/fd/%d", c.pid, fd))
+	if err != nil {
+		return ""
+	}
+
+	c.mu.Lock()
+	c.pathFor[fd] = pathCacheEntry{path: link, at: time.Now()}
+	c.mu.Unlock()
+	return link
+}
+
+// publishLoop a cada 500ms snapshota os agregados e publica IOStats parcial.
+// Reset do histograma a cada publish — buckets refletem janela atual,
+// não cumulativo (mais útil pra UI). TopFiles permanecem cumulativos
+// (consistente com /proc/<pid>/io que cumula).
+func (c *IOEBPFCollector) publishLoop() {
+	t := time.NewTicker(500 * time.Millisecond)
+	defer t.Stop()
+	for {
+		select {
+		case <-c.stop:
+			return
+		case <-t.C:
+			snap := c.snapshot()
+			select {
+			case c.ch <- snap:
+			default:
+			}
+		}
+	}
+}
+
+func (c *IOEBPFCollector) snapshot() IOEBPFSnapshot {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	files := make([]IOFileStats, 0, len(c.files))
+	for path, agg := range c.files {
+		latAvgMs := 0.0
+		if agg.latCount > 0 {
+			latAvgMs = float64(agg.latSumNs) / float64(agg.latCount) / 1e6
+		}
+		files = append(files, IOFileStats{
+			Path:      path,
+			Type:      agg.fileType,
+			Reads:     agg.reads,
+			Writes:    agg.writes,
+			Bytes:     agg.bytes,
+			LatencyMs: latAvgMs,
+			Fsyncs:    0, // sem fsync tracking ainda
+		})
+	}
+
+	// Copia buckets e reseta o cumulativo
+	bucketsCopy := append([]LatencyBucket(nil), c.buckets...)
+	for i := range c.buckets {
+		c.buckets[i].Read = 0
+		c.buckets[i].Write = 0
+	}
+
+	return IOEBPFSnapshot{
+		TopFiles: files,
+		Buckets:  bucketsCopy,
+	}
+}
+
+// IOEBPFSnapshot é o payload publicado. Model atualiza IOStats.TopFiles
+// e IOStats.LatencyBuckets a partir disso.
+type IOEBPFSnapshot struct {
+	TopFiles []IOFileStats
+	Buckets  []LatencyBucket
+}
+
+// classifyPath: heurística de tipo pra colorir o tipo na F5.
+// Mantém compatível com mockup: db / log / cfg / tmp / proc / file / sock.
+func classifyPath(p string) string {
+	switch {
+	case strings.HasPrefix(p, "socket:"):
+		return "sock"
+	case strings.HasPrefix(p, "pipe:"):
+		return "pipe"
+	case strings.HasPrefix(p, "anon_inode:"):
+		return "anon"
+	case strings.Contains(p, "/proc/"):
+		return "proc"
+	case strings.Contains(p, "/tmp/"):
+		return "tmp"
+	case strings.HasSuffix(p, ".log") || strings.Contains(p, "/log/"):
+		return "log"
+	case strings.HasSuffix(p, ".db") || strings.HasSuffix(p, ".sqlite") ||
+		strings.Contains(p, "/db/") || strings.HasSuffix(p, ".db-shm") ||
+		strings.HasSuffix(p, ".db-wal"):
+		return "db"
+	case strings.HasSuffix(p, ".json") || strings.HasSuffix(p, ".yaml") ||
+		strings.HasSuffix(p, ".toml") || strings.HasSuffix(p, ".conf") ||
+		strings.HasSuffix(p, ".ini") || strings.HasSuffix(p, ".cfg") ||
+		strings.Contains(p, "/etc/"):
+		return "cfg"
+	default:
+		// Resolve absoluto se path é relativo (caso raro, defesa)
+		if !filepath.IsAbs(p) {
+			return "file"
+		}
+		return "file"
+	}
+}
+
+// bucketIndexMs mapeia latência em ms pro bucket certo do histograma.
+// Buckets: <0.1, 0.1-1, 1-5, 5-20, >20.
+func bucketIndexMs(ms float64) int {
+	switch {
+	case ms < 0.1:
+		return 0
+	case ms < 1:
+		return 1
+	case ms < 5:
+		return 2
+	case ms < 20:
+		return 3
+	default:
+		return 4
+	}
+}

--- a/internal/collector/io_ebpf_stub.go
+++ b/internal/collector/io_ebpf_stub.go
@@ -1,0 +1,18 @@
+//go:build !linux || !ebpf
+
+package collector
+
+import "errors"
+
+type IOEBPFCollector struct{}
+type IOEBPFSnapshot struct {
+	TopFiles []IOFileStats
+	Buckets  []LatencyBucket
+}
+
+func NewIOEBPFCollector() *IOEBPFCollector { return &IOEBPFCollector{} }
+func (*IOEBPFCollector) Start(int) error {
+	return errors.New("eBPF io collector não disponível neste build")
+}
+func (*IOEBPFCollector) Stop()                          {}
+func (*IOEBPFCollector) Subscribe() <-chan interface{}  { return nil }

--- a/internal/tui/help.go
+++ b/internal/tui/help.go
@@ -79,6 +79,7 @@ func renderHelpOverlayWithStatus(m Model, w, h int) string {
 		sectionTitle.Render("Collectors"),
 		statusRow("syscalls", m.usingMockSyscalls, m.syscallsSource),
 		statusRow("cpu", m.usingMockCPU, m.cpuSource),
+		statusRow("io-files", m.usingMockIOFiles, m.ioFilesSource),
 		statusRow("memory", m.usingMockMem, sourceProcOrEmpty(!m.usingMockMem)),
 		statusRow("threads", m.usingMockThreads, sourceProcOrEmpty(!m.usingMockThreads)),
 		statusRow("io-wait", m.usingMockIOWait, sourceProcOrEmpty(!m.usingMockIOWait)),

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -79,6 +79,7 @@ type IOThroughputMsg collector.IOThroughputSample
 type TimelineMsg collector.TimelineEvent
 type FDEventMsg collector.FDEvent
 type SyscallsMsg map[string]uint64
+type IOEBPFMsg collector.IOEBPFSnapshot
 
 // exportTickMsg dispara periodicamente quando export contínuo está ON.
 type exportTickMsg time.Time
@@ -148,6 +149,7 @@ type Model struct {
 	iowaitCollector       *collector.IOWaitCollector
 	ioThroughputCollector *collector.IOThroughputCollector
 	syscallsEBPF          *collector.SyscallsEBPFCollector
+	ioEBPF                *collector.IOEBPFCollector
 
 	// Simulação
 	rng                  *rand.Rand
@@ -159,12 +161,14 @@ type Model struct {
 	usingMockIOWait      bool
 	usingMockIOThrough   bool
 	usingMockSyscalls    bool
+	usingMockIOFiles     bool
 	lastSimAt            time.Time
 
 	// Sources: indicam de onde veio o dado real ("eBPF" | "/proc" | "" pra mock).
 	// Mostrado no help overlay (?) pra debug e visibilidade.
 	cpuSource      string
 	syscallsSource string
+	ioFilesSource  string
 
 	// Caches estáveis para evitar reordenação visual entre ticks.
 	// topSyscallNames é recomputado a cada `topRefreshInterval`; entre refreshes
@@ -198,6 +202,7 @@ func NewModel(cfg Config) Model {
 		usingMockIOWait:    true,
 		usingMockIOThrough: true,
 		usingMockSyscalls:  true,
+		usingMockIOFiles:   true,
 	}
 
 	m.seedMockData()
@@ -259,6 +264,15 @@ func NewModel(cfg Config) Model {
 			} else {
 				fmt.Fprintf(os.Stderr, "aviso: eBPF syscalls collector indisponível: %v\n", err)
 			}
+
+			c2 := collector.NewIOEBPFCollector()
+			if err := c2.Start(cfg.PID); err == nil {
+				m.ioEBPF = c2
+				m.usingMockIOFiles = false
+				m.ioFilesSource = "eBPF"
+			} else {
+				fmt.Fprintf(os.Stderr, "aviso: eBPF io collector indisponível: %v\n", err)
+			}
 		}
 	}
 
@@ -303,6 +317,9 @@ func (m Model) Init() tea.Cmd {
 	}
 	if m.syscallsEBPF != nil {
 		cmds = append(cmds, waitForSyscalls(m.syscallsEBPF))
+	}
+	if m.ioEBPF != nil {
+		cmds = append(cmds, waitForIOEBPF(m.ioEBPF))
 	}
 	if m.exportFile != nil {
 		cmds = append(cmds, exportTick())
@@ -407,6 +424,22 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.SyscallCounts = map[string]uint64(v)
 		m.usingMockSyscalls = false
 		return m, waitForSyscalls(m.syscallsEBPF)
+
+	case IOEBPFMsg:
+		s := collector.IOEBPFSnapshot(v)
+		m.IOStats.TopFiles = s.TopFiles
+		// Buckets agora vêm da janela atual (read+write counts deste intervalo).
+		// Mesclamos com os labels existentes pra preservar a ordem.
+		if len(s.Buckets) == len(m.IOStats.LatencyBuckets) {
+			for i, b := range s.Buckets {
+				m.IOStats.LatencyBuckets[i].Read = b.Read
+				m.IOStats.LatencyBuckets[i].Write = b.Write
+			}
+		} else if len(s.Buckets) > 0 {
+			m.IOStats.LatencyBuckets = s.Buckets
+		}
+		m.usingMockIOFiles = false
+		return m, waitForIOEBPF(m.ioEBPF)
 
 	case IOThroughputMsg:
 		s := collector.IOThroughputSample(v)
@@ -804,28 +837,32 @@ func (m *Model) tick() {
 		m.IOStats.IOWaitPct = clamp(m.IOStats.IOWaitPct+(r.Float64()-0.5)*2, 0, 40)
 	}
 
-	for i := range m.IOStats.TopFiles {
-		f := &m.IOStats.TopFiles[i]
-		if r.Float64() > 0.4 {
-			f.Reads += uint64(r.Intn(8))
+	// TopFiles + LatencyBuckets só simulam quando o eBPF io collector
+	// não está rodando — quando rodando, IOEBPFMsg substitui esses campos.
+	if m.usingMockIOFiles {
+		for i := range m.IOStats.TopFiles {
+			f := &m.IOStats.TopFiles[i]
+			if r.Float64() > 0.4 {
+				f.Reads += uint64(r.Intn(8))
+			}
+			if r.Float64() > 0.6 {
+				f.Writes += uint64(r.Intn(4))
+			}
+			f.Bytes += uint64(r.Intn(512))
+			f.LatencyMs = clamp(f.LatencyMs+(r.Float64()-0.5)*0.4, 0.05, 50)
+			if f.Type == "db" && r.Float64() > 0.7 {
+				f.Fsyncs++
+			}
 		}
-		if r.Float64() > 0.6 {
-			f.Writes += uint64(r.Intn(4))
+		for i := range m.IOStats.LatencyBuckets {
+			b := &m.IOStats.LatencyBuckets[i]
+			bias := 1.0
+			if i == 0 {
+				bias = 2.0
+			}
+			b.Read = clamp(b.Read+(r.Float64()-0.4)*2*bias, 1, 1000)
+			b.Write = clamp(b.Write+(r.Float64()-0.4)*2*bias, 1, 1000)
 		}
-		f.Bytes += uint64(r.Intn(512))
-		f.LatencyMs = clamp(f.LatencyMs+(r.Float64()-0.5)*0.4, 0.05, 50)
-		if f.Type == "db" && r.Float64() > 0.7 {
-			f.Fsyncs++
-		}
-	}
-	for i := range m.IOStats.LatencyBuckets {
-		b := &m.IOStats.LatencyBuckets[i]
-		bias := 1.0
-		if i == 0 {
-			bias = 2.0
-		}
-		b.Read = clamp(b.Read+(r.Float64()-0.4)*2*bias, 1, 1000)
-		b.Write = clamp(b.Write+(r.Float64()-0.4)*2*bias, 1, 1000)
 	}
 
 	// FDs — só simulamos quando não há collector real plugado
@@ -1086,6 +1123,23 @@ func waitForSyscalls(c *collector.SyscallsEBPFCollector) tea.Cmd {
 		v := <-ch
 		if m, ok := v.(map[string]uint64); ok {
 			return SyscallsMsg(m)
+		}
+		return TickMsg(time.Now())
+	}
+}
+
+func waitForIOEBPF(c *collector.IOEBPFCollector) tea.Cmd {
+	if c == nil {
+		return nil
+	}
+	return func() tea.Msg {
+		ch := c.Subscribe()
+		if ch == nil {
+			return TickMsg(time.Now())
+		}
+		v := <-ch
+		if s, ok := v.(collector.IOEBPFSnapshot); ok {
+			return IOEBPFMsg(s)
 		}
 		return TickMsg(time.Now())
 	}


### PR DESCRIPTION
Closes #11. Terceiro programa eBPF.

## Como funciona

`programs/io.bpf.c` hooks 4 tracepoints (`sys_enter/exit_read/write`). Enter guarda `{ts, fd, op, count}` por thread em `io_inflight_map`. Exit lê esse contexto, calcula latência, publica `io_event` via ring buffer (1MB).

Loader Go usa `cilium/ebpf/ringbuf.Reader` pra consumir eventos. Collector roda 2 goroutines:
- **read loop**: drena ringbuf, resolve `fd → path` via `/proc/<pid>/fd` (cache 2s), agrega por path
- **publish loop**: a cada 500ms snapshota `{TopFiles, LatencyBuckets}` pro model

Model substitui `IOStats.TopFiles` inteiro e atualiza `LatencyBuckets[i].Read/Write` quando `IOEBPFMsg` chega. Sim só roda quando `usingMockIOFiles=true`.

## Por que syscall-level e não block-layer

Issue mencionava `block:block_rq_*` (latência real de disco, exclui cache). Mas resolver path requer vmlinux.h / CO-RE. Syscall-level evita essa dependência — trade-off: inclui cache hits, mas pra UI "top files acessados" é o que o usuário espera ver. Block-layer fica como v2.

## Pra testar na VM

```bash
cd ~/xray && git pull && make build-ebpf
sudo ./bin/xray --pid $(pgrep firefox)
```

F5 (I/O) deve mostrar:
- **Top Files**: paths reais que o Firefox tá lendo/escrevendo (sockets, .db do profile, .log, fontes em /usr, etc) com ops/bytes/lat reais
- **Latency Distribution**: buckets <0.1ms, 0.1-1ms, 1-5ms, 5-20ms, >20ms populados pela janela de 500ms

Help overlay (`?`) deve mostrar `io-files ● real via eBPF`. Verifica programas carregados:

```
sudo bpftool prog list | grep io
# 110: tracepoint  name handle_enter_read   ...
# 111: tracepoint  name handle_exit_read    ...
# 112: tracepoint  name handle_enter_write  ...
# 113: tracepoint  name handle_exit_write   ...
```