### PR TITLE
fix: namespace-aware eBPF pid filter (WSL2 / containers)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,9 +61,11 @@ ptop/
 ├── go.mod, go.sum
 ├── Makefile, .goreleaser.yaml
 ├── cmd/ptop/main.go               entrypoint: parse flags, start model
+├── cmd/ebpfselftest/              root-only eBPF self-diagnostic
 ├── internal/
 │   ├── bpf/                       eBPF programs + loader (build tag `ebpf`)
 │   │   ├── programs/              .bpf.c sources, compiled by `make gen`
+│   │   │   ├── target.bpf.h       shared pid-namespace target filter
 │   │   │   ├── syscalls.bpf.c     raw_syscalls/sys_{enter,exit}
 │   │   │   ├── cpu.bpf.c          perf_event @ 100Hz/CPU
 │   │   │   ├── io.bpf.c           VFS read/write/fsync
@@ -72,6 +74,7 @@ ptop/
 │   │   │   ├── memory.bpf.c       mmap/brk/page-fault
 │   │   │   └── futex.bpf.c        futex wait/wake → lock graph
 │   │   ├── available.go           runtime feature flag (build-tag based)
+│   │   ├── target.go              pid-namespace target resolver (shared)
 │   │   ├── caps.go                CAP_BPF / CAP_PERFMON detection
 │   │   ├── caps_stub.go           non-Linux stub
 │   │   ├── caps_test.go
@@ -265,6 +268,17 @@ line wraps and the rest of the TUI flips upside down. `header.go` shows the
 priority-based segment dropping pattern: copy it for any new dynamic strip.
 
 ---
+
+## PID namespaces
+
+eBPF programs filter the target process via `bpf_get_ns_current_pid_tgid()`,
+resolving pids inside the target's PID namespace (dev+inode of
+`/proc/<pid>/ns/pid`, written by the Go loader into `struct target_filter`).
+This is required because `bpf_get_current_pid_tgid()` returns root-namespace
+pids — wrong when ptop runs inside a nested namespace (WSL2, Docker, LXC).
+The shared logic lives in `programs/target.bpf.h` and `bpf/target.go`; never
+filter with the bare `bpf_get_current_pid_tgid()` again. Verify with
+`make ebpf-selftest` → `sudo ./bin/ebpf-selftest`.
 
 ## Build tags
 

--- a/Makefile
+++ b/Makefile
@@ -58,6 +58,10 @@ BPF_SRCS := \
 
 BPF_OBJS := $(BPF_SRCS:.c=.o)
 
+# Every BPF object includes the shared filter header — editing it must
+# trigger a rebuild (the %.bpf.o rule below only tracks the .c file).
+$(BPF_OBJS): internal/bpf/programs/target.bpf.h
+
 CLANG  ?= clang
 
 # Default rule: .bpf.c → .bpf.o via clang -target bpf.

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all build build-ebpf run gen clean dev test test-all vet lint install install-bare install-ebpf uninstall
+.PHONY: all build build-ebpf run gen clean dev test test-all vet lint install install-bare install-ebpf uninstall ebpf-selftest
 
 .DEFAULT_GOAL := all
 
@@ -97,6 +97,13 @@ run: build-ebpf
 # /proc-only mode — no root, no eBPF
 dev: build
 	./bin/$(BINARY) --pid $(PID) --no-ebpf
+
+# ebpf-selftest builds the eBPF self-diagnostic. Run the result as root:
+# `sudo ./bin/ebpf-selftest` — it reports whether the eBPF collectors can
+# observe the target process (useful inside containers / WSL).
+ebpf-selftest: gen
+	go build -tags=ebpf -o bin/ebpf-selftest ./cmd/ebpfselftest
+	@echo "built bin/ebpf-selftest — run as root: sudo ./bin/ebpf-selftest"
 
 # ─── test / lint ─────────────────────────────────────────────────────────────
 

--- a/cmd/ebpfselftest/main.go
+++ b/cmd/ebpfselftest/main.go
@@ -7,10 +7,12 @@
 //	sudo ./bin/ebpf-selftest
 //
 // It targets its own process, generates a known workload (CPU burn + write
-// syscalls), and reports whether the eBPF counters moved.
+// syscalls), and reports whether the eBPF counters moved. Exit code is 0 on
+// PASS, 1 on FAIL — usable directly in CI / scripts.
 package main
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"time"
@@ -23,30 +25,37 @@ func main() {
 		fmt.Fprint(os.Stderr, d)
 		os.Exit(1)
 	}
+	if err := run(); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+}
 
+// run performs the self-test. Returning an error (instead of calling
+// os.Exit directly) ensures the deferred tracer Close() calls always run.
+func run() error {
 	pid := os.Getpid()
 	fmt.Printf("ptop eBPF self-test — target = self (pid %d)\n\n", pid)
 
 	cpuT, err := bpf.OpenCPUTracer(pid)
 	if err != nil {
-		fmt.Println("FAIL  cpu: OpenCPUTracer:", err)
-		os.Exit(1)
+		return fmt.Errorf("cpu: OpenCPUTracer: %w", err)
 	}
 	defer cpuT.Close()
 
 	scT, err := bpf.OpenSyscallTracer(pid)
 	if err != nil {
-		fmt.Println("FAIL  syscalls: OpenSyscallTracer:", err)
-		os.Exit(1)
+		return fmt.Errorf("syscalls: OpenSyscallTracer: %w", err)
 	}
 	defer scT.Close()
 
-	// Workload: CPU burn + real write(2) syscalls for 3 seconds.
 	devnull, err := os.OpenFile("/dev/null", os.O_WRONLY, 0)
 	if err != nil {
-		fmt.Println("FAIL  cannot open /dev/null:", err)
-		os.Exit(1)
+		return fmt.Errorf("open /dev/null: %w", err)
 	}
+	defer devnull.Close()
+
+	// Workload: CPU burn + real write(2) syscalls for 3 seconds.
 	buf := []byte("x")
 	var spin uint64
 	deadline := time.Now().Add(3 * time.Second)
@@ -56,7 +65,6 @@ func main() {
 		}
 		_, _ = devnull.Write(buf)
 	}
-	devnull.Close()
 	_ = spin
 
 	failed := false
@@ -65,7 +73,7 @@ func main() {
 	if samples > 0 {
 		fmt.Printf("PASS  cpu:      %d on-CPU samples observed\n", samples)
 	} else {
-		fmt.Println("FAIL  cpu:      0 samples — the eBPF filter did not match this process")
+		fmt.Fprintln(os.Stderr, "FAIL  cpu:      0 samples — the eBPF filter did not match this process")
 		failed = true
 	}
 
@@ -77,13 +85,13 @@ func main() {
 	if total > 0 {
 		fmt.Printf("PASS  syscalls: %d events across %d syscall ids\n", total, len(stats))
 	} else {
-		fmt.Println("FAIL  syscalls: 0 events — the eBPF filter did not match this process")
+		fmt.Fprintln(os.Stderr, "FAIL  syscalls: 0 events — the eBPF filter did not match this process")
 		failed = true
 	}
 
 	if failed {
-		fmt.Println("\neBPF self-test FAILED")
-		os.Exit(1)
+		return errors.New("eBPF self-test FAILED")
 	}
 	fmt.Println("\neBPF self-test PASSED")
+	return nil
 }

--- a/cmd/ebpfselftest/main.go
+++ b/cmd/ebpfselftest/main.go
@@ -1,0 +1,89 @@
+//go:build linux && ebpf
+
+// ebpf-selftest verifies that ptop's eBPF collectors can actually observe
+// the target process — useful inside containers / WSL, where nested PID
+// namespaces historically broke the filter. Run as root:
+//
+//	sudo ./bin/ebpf-selftest
+//
+// It targets its own process, generates a known workload (CPU burn + write
+// syscalls), and reports whether the eBPF counters moved.
+package main
+
+import (
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/trentas/ptop/internal/bpf"
+)
+
+func main() {
+	if d := bpf.GetCapStatus().Diagnose(); d != "" {
+		fmt.Fprint(os.Stderr, d)
+		os.Exit(1)
+	}
+
+	pid := os.Getpid()
+	fmt.Printf("ptop eBPF self-test — target = self (pid %d)\n\n", pid)
+
+	cpuT, err := bpf.OpenCPUTracer(pid)
+	if err != nil {
+		fmt.Println("FAIL  cpu: OpenCPUTracer:", err)
+		os.Exit(1)
+	}
+	defer cpuT.Close()
+
+	scT, err := bpf.OpenSyscallTracer(pid)
+	if err != nil {
+		fmt.Println("FAIL  syscalls: OpenSyscallTracer:", err)
+		os.Exit(1)
+	}
+	defer scT.Close()
+
+	// Workload: CPU burn + real write(2) syscalls for 3 seconds.
+	devnull, err := os.OpenFile("/dev/null", os.O_WRONLY, 0)
+	if err != nil {
+		fmt.Println("FAIL  cannot open /dev/null:", err)
+		os.Exit(1)
+	}
+	buf := []byte("x")
+	var spin uint64
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		for i := 0; i < 50000; i++ {
+			spin++
+		}
+		_, _ = devnull.Write(buf)
+	}
+	devnull.Close()
+	_ = spin
+
+	failed := false
+
+	samples, _ := cpuT.SampleCount()
+	if samples > 0 {
+		fmt.Printf("PASS  cpu:      %d on-CPU samples observed\n", samples)
+	} else {
+		fmt.Println("FAIL  cpu:      0 samples — the eBPF filter did not match this process")
+		failed = true
+	}
+
+	stats, _ := scT.Stats()
+	var total uint64
+	for _, s := range stats {
+		total += s.Count
+	}
+	if total > 0 {
+		fmt.Printf("PASS  syscalls: %d events across %d syscall ids\n", total, len(stats))
+	} else {
+		fmt.Println("FAIL  syscalls: 0 events — the eBPF filter did not match this process")
+		failed = true
+	}
+
+	if failed {
+		fmt.Println("\neBPF self-test FAILED")
+		os.Exit(1)
+	}
+	fmt.Println("\neBPF self-test PASSED")
+}

--- a/cmd/ebpfselftest/stub.go
+++ b/cmd/ebpfselftest/stub.go
@@ -1,0 +1,11 @@
+//go:build !linux || !ebpf
+
+// Stub so `go build ./...` / `go vet ./...` succeed in the default lane —
+// the real self-test only exists in the Linux eBPF build.
+package main
+
+import "fmt"
+
+func main() {
+	fmt.Println("ebpf-selftest requires a Linux build with -tags=ebpf")
+}

--- a/docs/superpowers/plans/2026-05-19-ebpf-pidns-fix.md
+++ b/docs/superpowers/plans/2026-05-19-ebpf-pidns-fix.md
@@ -1,0 +1,1699 @@
+# eBPF PID-namespace fix — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make ptop's 7 eBPF collectors filter the target process correctly inside nested PID namespaces (WSL2, Docker, LXC), with zero behavior change on native Linux.
+
+**Architecture:** Replace `bpf_get_current_pid_tgid()` (root-namespace PIDs) with `bpf_get_ns_current_pid_tgid()` (PIDs within a given namespace) across all eBPF programs. The namespace logic is centralized in one shared C header (`target.bpf.h`) and one shared Go resolver (`target.go`). The loader stats `/proc/<pid>/ns/pid` to obtain the namespace device+inode.
+
+**Tech Stack:** Go 1.22, cilium/ebpf, clang BPF target, golang.org/x/sys/unix.
+
+**Design spec:** `docs/superpowers/specs/2026-05-19-ebpf-pidns-fix-design.md`
+
+---
+
+## File Structure
+
+**New files:**
+- `internal/bpf/programs/target.bpf.h` — shared `struct target_filter` + `pid_is_target()` / `pid_target_ns()` helpers. Included by every `.bpf.c`.
+- `internal/bpf/target.go` — `targetFilter` Go struct + `resolveTarget()` + `writeTargetFilter()`. (`//go:build linux && ebpf`)
+- `internal/bpf/target_test.go` — unit tests for `resolveTarget` and struct layout. (`//go:build linux && ebpf`)
+- `cmd/ebpfselftest/main.go` — root-only eBPF self-diagnostic. (`//go:build linux && ebpf`)
+- `cmd/ebpfselftest/stub.go` — non-eBPF stub so the package always builds. (`//go:build !linux || !ebpf`)
+
+**Modified files:**
+- `internal/bpf/programs/{cpu,syscalls,io,network,memory,futex,threads}.bpf.c` — use the shared header.
+- `internal/bpf/{cpu,syscalls,io,network,memory,futex,threads}.go` — use `resolveTarget`/`writeTargetFilter`.
+- `internal/bpf/threads_stub.go` — `UpdateTrackedTIDs` → `PruneDeadTIDs` (API parity).
+- `internal/collector/threads_ebpf.go` — call-site swap.
+- `Makefile` — header prerequisite + `ebpf-selftest` target.
+- `CLAUDE.md` — document the new header and tool.
+
+**Regenerated (not committed, git-ignored):** `internal/bpf/programs/*.bpf.o`.
+
+---
+
+## Task 1: Shared Go resolver
+
+Builds the namespace-aware target filter on the Go side. Fully testable without root.
+
+**Files:**
+- Create: `internal/bpf/target.go`
+- Test: `internal/bpf/target_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `internal/bpf/target_test.go`:
+
+```go
+//go:build linux && ebpf
+
+package bpf
+
+import (
+	"os"
+	"testing"
+	"unsafe"
+)
+
+// The Go targetFilter must match `struct target_filter` in target.bpf.h
+// byte-for-byte, or the loader writes garbage into the BPF map.
+func TestTargetFilterSize(t *testing.T) {
+	if got := unsafe.Sizeof(targetFilter{}); got != 24 {
+		t.Fatalf("sizeof(targetFilter) = %d, want 24", got)
+	}
+}
+
+func TestResolveTargetSelf(t *testing.T) {
+	tf, err := resolveTarget(os.Getpid())
+	if err != nil {
+		t.Fatalf("resolveTarget(self): %v", err)
+	}
+	if tf.Pid != uint32(os.Getpid()) {
+		t.Errorf("Pid = %d, want %d", tf.Pid, os.Getpid())
+	}
+	if tf.Dev == 0 {
+		t.Error("Dev = 0, want the nsfs device number")
+	}
+	if tf.Ino == 0 {
+		t.Error("Ino = 0, want the pid-namespace inode")
+	}
+}
+
+func TestResolveTargetMissingPID(t *testing.T) {
+	if _, err := resolveTarget(0x7fffffff); err == nil {
+		t.Error("resolveTarget(nonexistent pid) = nil error, want failure")
+	}
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `go test -tags=ebpf ./internal/bpf/ -run TestResolveTarget -v`
+Expected: FAIL — build error, `undefined: resolveTarget` and `undefined: targetFilter`.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `internal/bpf/target.go`:
+
+```go
+//go:build linux && ebpf
+
+package bpf
+
+import (
+	"fmt"
+
+	"github.com/cilium/ebpf"
+	"golang.org/x/sys/unix"
+)
+
+// targetFilter mirrors `struct target_filter` in programs/target.bpf.h
+// byte-for-byte (24 bytes: u32 pid, u32 pad, u64 dev, u64 ino).
+type targetFilter struct {
+	Pid uint32
+	_   uint32
+	Dev uint64
+	Ino uint64
+}
+
+// resolveTarget builds the filter for pid: its tgid plus the device and
+// inode of the PID namespace it lives in (/proc/<pid>/ns/pid).
+//
+// On a native host in the root namespace this resolves to the initial PID
+// namespace, so the BPF-side bpf_get_ns_current_pid_tgid() call returns the
+// same values bpf_get_current_pid_tgid() returned before — identical
+// behavior. Inside a nested namespace (WSL2, containers) it resolves to that
+// namespace, which is what makes the filter match.
+func resolveTarget(pid int) (targetFilter, error) {
+	var st unix.Stat_t
+	if err := unix.Stat(fmt.Sprintf("/proc/%d/ns/pid", pid), &st); err != nil {
+		return targetFilter{}, fmt.Errorf("stat pid namespace of %d: %w", pid, err)
+	}
+	return targetFilter{Pid: uint32(pid), Dev: st.Dev, Ino: st.Ino}, nil
+}
+
+// writeTargetFilter stores the resolved filter at key 0 of an ARRAY[1] map.
+func writeTargetFilter(m *ebpf.Map, tf targetFilter) error {
+	var key uint32 = 0
+	return m.Update(&key, &tf, ebpf.UpdateAny)
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `go test -tags=ebpf ./internal/bpf/ -run TestResolveTarget -v`
+Expected: PASS — `TestResolveTargetSelf`, `TestResolveTargetMissingPID` pass.
+
+Run: `go test -tags=ebpf ./internal/bpf/ -run TestTargetFilterSize -v`
+Expected: PASS.
+
+- [ ] **Step 5: Vet**
+
+Run: `go vet -tags=ebpf ./internal/bpf/`
+Expected: no output (clean).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/bpf/target.go internal/bpf/target_test.go
+git commit -m "feat(bpf): add namespace-aware target resolver"
+```
+
+---
+
+## Task 2: Shared C header + cpu collector
+
+Creates `target.bpf.h`, wires the Makefile, and converts the first collector (cpu) — which proves the header compiles.
+
+**Files:**
+- Create: `internal/bpf/programs/target.bpf.h`
+- Modify: `Makefile`
+- Modify: `internal/bpf/programs/cpu.bpf.c`
+- Modify: `internal/bpf/cpu.go`
+
+- [ ] **Step 1: Create the shared header**
+
+Create `internal/bpf/programs/target.bpf.h`:
+
+```c
+/* SPDX-License-Identifier: GPL-2.0 */
+/*
+ * target.bpf.h — namespace-aware target-process filter shared by every
+ * ptop eBPF program.
+ *
+ * bpf_get_current_pid_tgid() returns PIDs in the INITIAL pid namespace.
+ * ptop's --pid is a namespace-local PID (what /proc and ps show). Under a
+ * nested pid namespace (WSL2, Docker, LXC) the two differ, so the old
+ * `tgid == target` comparison never matched. bpf_get_ns_current_pid_tgid()
+ * (kernel 5.7+) projects the current task's pid into a specific namespace,
+ * identified by the (dev, ino) of /proc/<pid>/ns/pid.
+ */
+#ifndef PTOP_TARGET_BPF_H
+#define PTOP_TARGET_BPF_H
+
+#include <linux/bpf.h>
+#include <bpf/bpf_helpers.h>
+
+/* Written by the Go loader (see internal/bpf/target.go). dev+ino identify
+ * the target's PID namespace; pid is the target tgid within that namespace. */
+struct target_filter {
+    __u32 pid;
+    __u32 _pad;
+    __u64 dev;
+    __u64 ino;
+};
+
+/* pid_target_ns resolves the current task's pid/tgid inside the target's
+ * namespace and writes them into *out. Returns 1 when the current task is
+ * the target process, 0 otherwise. target_map is an ARRAY[1] of
+ * struct target_filter. */
+static __always_inline int pid_target_ns(void *target_map,
+                                          struct bpf_pidns_info *out)
+{
+    __u32 key = 0;
+    struct target_filter *tf = bpf_map_lookup_elem(target_map, &key);
+    if (!tf || tf->pid == 0)
+        return 0;
+    if (bpf_get_ns_current_pid_tgid(tf->dev, tf->ino, out, sizeof(*out)) != 0)
+        return 0;
+    return out->tgid == tf->pid;
+}
+
+/* pid_is_target returns 1 when the current task belongs to the target
+ * process. Use this anywhere the old is_*_target() helpers were used. */
+static __always_inline int pid_is_target(void *target_map)
+{
+    struct bpf_pidns_info ns = {};
+    return pid_target_ns(target_map, &ns);
+}
+
+#endif /* PTOP_TARGET_BPF_H */
+```
+
+- [ ] **Step 2: Make `.bpf.o` depend on the header**
+
+In `Makefile`, find:
+
+```make
+BPF_OBJS := $(BPF_SRCS:.c=.o)
+
+CLANG  ?= clang
+```
+
+Replace with:
+
+```make
+BPF_OBJS := $(BPF_SRCS:.c=.o)
+
+# Every BPF object includes the shared filter header — editing it must
+# trigger a rebuild (the %.bpf.o rule below only tracks the .c file).
+$(BPF_OBJS): internal/bpf/programs/target.bpf.h
+
+CLANG  ?= clang
+```
+
+- [ ] **Step 3: Convert `cpu.bpf.c`**
+
+In `internal/bpf/programs/cpu.bpf.c`, find:
+
+```c
+#include <linux/bpf.h>
+#include <bpf/bpf_helpers.h>
+
+char LICENSE[] SEC("license") = "GPL";
+```
+
+Replace with:
+
+```c
+#include <linux/bpf.h>
+#include <bpf/bpf_helpers.h>
+#include "target.bpf.h"
+
+char LICENSE[] SEC("license") = "GPL";
+```
+
+In the same file, find:
+
+```c
+struct {
+    __uint(type, BPF_MAP_TYPE_ARRAY);
+    __type(key, __u32);
+    __type(value, __u32);
+    __uint(max_entries, 1);
+} cpu_target_pid SEC(".maps");
+```
+
+Replace with:
+
+```c
+struct {
+    __uint(type, BPF_MAP_TYPE_ARRAY);
+    __type(key, __u32);
+    __type(value, struct target_filter);
+    __uint(max_entries, 1);
+} cpu_target_pid SEC(".maps");
+```
+
+In the same file, find:
+
+```c
+SEC("perf_event")
+int handle_perf_event(void *ctx)
+{
+    __u32 key = 0;
+    __u32 *target = bpf_map_lookup_elem(&cpu_target_pid, &key);
+    if (!target || *target == 0)
+        return 0;
+
+    __u64 pid_tgid = bpf_get_current_pid_tgid();
+    __u32 tgid = (__u32)(pid_tgid >> 32);
+    if (tgid != *target)
+        return 0;
+
+    __u64 *count = bpf_map_lookup_elem(&cpu_target_samples, &key);
+    if (count)
+        __sync_fetch_and_add(count, 1);
+    return 0;
+}
+```
+
+Replace with:
+
+```c
+SEC("perf_event")
+int handle_perf_event(void *ctx)
+{
+    if (!pid_is_target(&cpu_target_pid))
+        return 0;
+
+    __u32 key = 0;
+    __u64 *count = bpf_map_lookup_elem(&cpu_target_samples, &key);
+    if (count)
+        __sync_fetch_and_add(count, 1);
+    return 0;
+}
+```
+
+- [ ] **Step 4: Convert `cpu.go`**
+
+In `internal/bpf/cpu.go`, find:
+
+```go
+	var key uint32 = 0
+	val := uint32(pid)
+	if err := targetMap.Update(&key, &val, ebpf.UpdateAny); err != nil {
+		t.Close()
+		return nil, fmt.Errorf("set cpu_target_pid: %w", err)
+	}
+```
+
+Replace with:
+
+```go
+	tf, err := resolveTarget(pid)
+	if err != nil {
+		t.Close()
+		return nil, err
+	}
+	if err := writeTargetFilter(targetMap, tf); err != nil {
+		t.Close()
+		return nil, fmt.Errorf("set cpu_target_pid: %w", err)
+	}
+```
+
+- [ ] **Step 5: Compile the BPF objects**
+
+Run: `make gen`
+Expected: success — all 7 `.bpf.c` compile, including `cpu.bpf.c` with the new header. No clang errors.
+
+- [ ] **Step 6: Build, vet and test the eBPF lane**
+
+Run: `go build -tags=ebpf -o /tmp/ptop-ebpf ./cmd/ptop`
+Expected: success.
+
+Run: `go vet -tags=ebpf ./...`
+Expected: no output (clean).
+
+Run: `go test -race -tags=ebpf ./...`
+Expected: PASS (all packages, including `internal/bpf` tests from Task 1).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add internal/bpf/programs/target.bpf.h Makefile internal/bpf/programs/cpu.bpf.c internal/bpf/cpu.go
+git commit -m "fix(bpf): namespace-aware pid filter for cpu collector"
+```
+
+---
+
+## Task 3: syscalls collector
+
+**Files:**
+- Modify: `internal/bpf/programs/syscalls.bpf.c`
+- Modify: `internal/bpf/syscalls.go`
+
+- [ ] **Step 1: Convert `syscalls.bpf.c`**
+
+In `internal/bpf/programs/syscalls.bpf.c`, find:
+
+```c
+#include <linux/bpf.h>
+#include <bpf/bpf_helpers.h>
+
+char LICENSE[] SEC("license") = "GPL";
+```
+
+Replace with:
+
+```c
+#include <linux/bpf.h>
+#include <bpf/bpf_helpers.h>
+#include "target.bpf.h"
+
+char LICENSE[] SEC("license") = "GPL";
+```
+
+In the same file, find:
+
+```c
+struct {
+    __uint(type, BPF_MAP_TYPE_ARRAY);
+    __type(key, __u32);
+    __type(value, __u32);
+    __uint(max_entries, 1);
+} target_pid SEC(".maps");
+```
+
+Replace with:
+
+```c
+struct {
+    __uint(type, BPF_MAP_TYPE_ARRAY);
+    __type(key, __u32);
+    __type(value, struct target_filter);
+    __uint(max_entries, 1);
+} target_pid SEC(".maps");
+```
+
+In the same file, find:
+
+```c
+// is_target returns 1 if the current tgid is the configured target pid, 0 otherwise.
+static __always_inline int is_target(void)
+{
+    __u32 key = 0;
+    __u32 *target = bpf_map_lookup_elem(&target_pid, &key);
+    if (!target || *target == 0)
+        return 0;
+    __u64 pid_tgid = bpf_get_current_pid_tgid();
+    __u32 tgid = (__u32)(pid_tgid >> 32);
+    return tgid == *target;
+}
+```
+
+Replace with:
+
+```c
+// is_target returns 1 if the current task belongs to the target process,
+// resolving pids inside the target's PID namespace (see target.bpf.h).
+static __always_inline int is_target(void)
+{
+    return pid_is_target(&target_pid);
+}
+```
+
+- [ ] **Step 2: Convert `syscalls.go`**
+
+In `internal/bpf/syscalls.go`, find:
+
+```go
+	var key uint32 = 0
+	val := uint32(pid)
+	if err := targetMap.Update(&key, &val, ebpf.UpdateAny); err != nil {
+		t.Close()
+		return nil, fmt.Errorf("set target_pid: %w", err)
+	}
+```
+
+Replace with:
+
+```go
+	tf, err := resolveTarget(pid)
+	if err != nil {
+		t.Close()
+		return nil, err
+	}
+	if err := writeTargetFilter(targetMap, tf); err != nil {
+		t.Close()
+		return nil, fmt.Errorf("set target_pid: %w", err)
+	}
+```
+
+- [ ] **Step 3: Compile, build, vet, test**
+
+Run: `make gen`
+Expected: success.
+
+Run: `go build -tags=ebpf -o /tmp/ptop-ebpf ./cmd/ptop && go vet -tags=ebpf ./... && go test -race -tags=ebpf ./...`
+Expected: build success, vet clean, tests PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add internal/bpf/programs/syscalls.bpf.c internal/bpf/syscalls.go
+git commit -m "fix(bpf): namespace-aware pid filter for syscalls collector"
+```
+
+---
+
+## Task 4: io collector
+
+**Files:**
+- Modify: `internal/bpf/programs/io.bpf.c`
+- Modify: `internal/bpf/io.go`
+
+- [ ] **Step 1: Convert `io.bpf.c`**
+
+In `internal/bpf/programs/io.bpf.c`, find:
+
+```c
+#include <linux/bpf.h>
+#include <bpf/bpf_helpers.h>
+
+char LICENSE[] SEC("license") = "GPL";
+```
+
+Replace with:
+
+```c
+#include <linux/bpf.h>
+#include <bpf/bpf_helpers.h>
+#include "target.bpf.h"
+
+char LICENSE[] SEC("license") = "GPL";
+```
+
+In the same file, find:
+
+```c
+struct {
+    __uint(type, BPF_MAP_TYPE_ARRAY);
+    __type(key, __u32);
+    __type(value, __u32);
+    __uint(max_entries, 1);
+} io_target_pid SEC(".maps");
+```
+
+Replace with:
+
+```c
+struct {
+    __uint(type, BPF_MAP_TYPE_ARRAY);
+    __type(key, __u32);
+    __type(value, struct target_filter);
+    __uint(max_entries, 1);
+} io_target_pid SEC(".maps");
+```
+
+In the same file, find:
+
+```c
+static __always_inline int is_io_target(void)
+{
+    __u32 key = 0;
+    __u32 *target = bpf_map_lookup_elem(&io_target_pid, &key);
+    if (!target || *target == 0)
+        return 0;
+    __u64 pid_tgid = bpf_get_current_pid_tgid();
+    __u32 tgid = (__u32)(pid_tgid >> 32);
+    return tgid == *target;
+}
+```
+
+Replace with:
+
+```c
+static __always_inline int is_io_target(void)
+{
+    return pid_is_target(&io_target_pid);
+}
+```
+
+- [ ] **Step 2: Convert `io.go`**
+
+In `internal/bpf/io.go`, find:
+
+```go
+	var key uint32 = 0
+	val := uint32(pid)
+	if err := targetMap.Update(&key, &val, ebpf.UpdateAny); err != nil {
+		t.Close()
+		return nil, fmt.Errorf("set io_target_pid: %w", err)
+	}
+```
+
+Replace with:
+
+```go
+	tf, err := resolveTarget(pid)
+	if err != nil {
+		t.Close()
+		return nil, err
+	}
+	if err := writeTargetFilter(targetMap, tf); err != nil {
+		t.Close()
+		return nil, fmt.Errorf("set io_target_pid: %w", err)
+	}
+```
+
+- [ ] **Step 3: Compile, build, vet, test**
+
+Run: `make gen`
+Expected: success.
+
+Run: `go build -tags=ebpf -o /tmp/ptop-ebpf ./cmd/ptop && go vet -tags=ebpf ./... && go test -race -tags=ebpf ./...`
+Expected: build success, vet clean, tests PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add internal/bpf/programs/io.bpf.c internal/bpf/io.go
+git commit -m "fix(bpf): namespace-aware pid filter for io collector"
+```
+
+---
+
+## Task 5: network collector
+
+**Files:**
+- Modify: `internal/bpf/programs/network.bpf.c`
+- Modify: `internal/bpf/network.go`
+
+- [ ] **Step 1: Convert `network.bpf.c`**
+
+In `internal/bpf/programs/network.bpf.c`, find:
+
+```c
+#include <linux/bpf.h>
+#include <linux/ptrace.h>
+#include <bpf/bpf_helpers.h>
+#include <bpf/bpf_tracing.h>
+
+char LICENSE[] SEC("license") = "GPL";
+```
+
+Replace with:
+
+```c
+#include <linux/bpf.h>
+#include <linux/ptrace.h>
+#include <bpf/bpf_helpers.h>
+#include <bpf/bpf_tracing.h>
+#include "target.bpf.h"
+
+char LICENSE[] SEC("license") = "GPL";
+```
+
+In the same file, find:
+
+```c
+struct {
+    __uint(type, BPF_MAP_TYPE_ARRAY);
+    __type(key, __u32);
+    __type(value, __u32);
+    __uint(max_entries, 1);
+} net_target_pid SEC(".maps");
+```
+
+Replace with:
+
+```c
+struct {
+    __uint(type, BPF_MAP_TYPE_ARRAY);
+    __type(key, __u32);
+    __type(value, struct target_filter);
+    __uint(max_entries, 1);
+} net_target_pid SEC(".maps");
+```
+
+In the same file, find:
+
+```c
+static __always_inline int is_net_target(void)
+{
+    __u32 key = 0;
+    __u32 *target = bpf_map_lookup_elem(&net_target_pid, &key);
+    if (!target || *target == 0)
+        return 0;
+    __u64 pid_tgid = bpf_get_current_pid_tgid();
+    __u32 tgid = (__u32)(pid_tgid >> 32);
+    return tgid == *target;
+}
+```
+
+Replace with:
+
+```c
+static __always_inline int is_net_target(void)
+{
+    return pid_is_target(&net_target_pid);
+}
+```
+
+- [ ] **Step 2: Convert `network.go`**
+
+In `internal/bpf/network.go`, find:
+
+```go
+	var key uint32 = 0
+	val := uint32(pid)
+	if err := targetMap.Update(&key, &val, ebpf.UpdateAny); err != nil {
+		t.Close()
+		return nil, fmt.Errorf("set net_target_pid: %w", err)
+	}
+```
+
+Replace with:
+
+```go
+	tf, err := resolveTarget(pid)
+	if err != nil {
+		t.Close()
+		return nil, err
+	}
+	if err := writeTargetFilter(targetMap, tf); err != nil {
+		t.Close()
+		return nil, fmt.Errorf("set net_target_pid: %w", err)
+	}
+```
+
+- [ ] **Step 3: Compile, build, vet, test**
+
+Run: `make gen`
+Expected: success.
+
+Run: `go build -tags=ebpf -o /tmp/ptop-ebpf ./cmd/ptop && go vet -tags=ebpf ./... && go test -race -tags=ebpf ./...`
+Expected: build success, vet clean, tests PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add internal/bpf/programs/network.bpf.c internal/bpf/network.go
+git commit -m "fix(bpf): namespace-aware pid filter for network collector"
+```
+
+---
+
+## Task 6: memory collector
+
+**Files:**
+- Modify: `internal/bpf/programs/memory.bpf.c`
+- Modify: `internal/bpf/memory.go`
+
+- [ ] **Step 1: Convert `memory.bpf.c`**
+
+In `internal/bpf/programs/memory.bpf.c`, find:
+
+```c
+#include <linux/bpf.h>
+#include <linux/ptrace.h>
+#include <bpf/bpf_helpers.h>
+#include <bpf/bpf_tracing.h>
+
+char LICENSE[] SEC("license") = "GPL";
+```
+
+Replace with:
+
+```c
+#include <linux/bpf.h>
+#include <linux/ptrace.h>
+#include <bpf/bpf_helpers.h>
+#include <bpf/bpf_tracing.h>
+#include "target.bpf.h"
+
+char LICENSE[] SEC("license") = "GPL";
+```
+
+In the same file, find:
+
+```c
+struct {
+    __uint(type, BPF_MAP_TYPE_ARRAY);
+    __type(key, __u32);
+    __type(value, __u32);
+    __uint(max_entries, 1);
+} mem_target_pid SEC(".maps");
+```
+
+Replace with:
+
+```c
+struct {
+    __uint(type, BPF_MAP_TYPE_ARRAY);
+    __type(key, __u32);
+    __type(value, struct target_filter);
+    __uint(max_entries, 1);
+} mem_target_pid SEC(".maps");
+```
+
+In the same file, find:
+
+```c
+static __always_inline int is_mem_target(void)
+{
+    __u32 key = 0;
+    __u32 *target = bpf_map_lookup_elem(&mem_target_pid, &key);
+    if (!target || *target == 0)
+        return 0;
+    __u64 pid_tgid = bpf_get_current_pid_tgid();
+    __u32 tgid = (__u32)(pid_tgid >> 32);
+    return tgid == *target;
+}
+```
+
+Replace with:
+
+```c
+static __always_inline int is_mem_target(void)
+{
+    return pid_is_target(&mem_target_pid);
+}
+```
+
+- [ ] **Step 2: Convert `memory.go`**
+
+In `internal/bpf/memory.go`, find:
+
+```go
+	var key uint32 = 0
+	val := uint32(pid)
+	if err := targetMap.Update(&key, &val, ebpf.UpdateAny); err != nil {
+		t.Close()
+		return nil, fmt.Errorf("set mem_target_pid: %w", err)
+	}
+```
+
+Replace with:
+
+```go
+	tf, err := resolveTarget(pid)
+	if err != nil {
+		t.Close()
+		return nil, err
+	}
+	if err := writeTargetFilter(targetMap, tf); err != nil {
+		t.Close()
+		return nil, fmt.Errorf("set mem_target_pid: %w", err)
+	}
+```
+
+- [ ] **Step 3: Compile, build, vet, test**
+
+Run: `make gen`
+Expected: success.
+
+Run: `go build -tags=ebpf -o /tmp/ptop-ebpf ./cmd/ptop && go vet -tags=ebpf ./... && go test -race -tags=ebpf ./...`
+Expected: build success, vet clean, tests PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add internal/bpf/programs/memory.bpf.c internal/bpf/memory.go
+git commit -m "fix(bpf): namespace-aware pid filter for memory collector"
+```
+
+---
+
+## Task 7: futex collector
+
+**Files:**
+- Modify: `internal/bpf/programs/futex.bpf.c`
+- Modify: `internal/bpf/futex.go`
+
+- [ ] **Step 1: Convert `futex.bpf.c`**
+
+In `internal/bpf/programs/futex.bpf.c`, find:
+
+```c
+#include <linux/bpf.h>
+#include <bpf/bpf_helpers.h>
+
+char LICENSE[] SEC("license") = "GPL";
+```
+
+Replace with:
+
+```c
+#include <linux/bpf.h>
+#include <bpf/bpf_helpers.h>
+#include "target.bpf.h"
+
+char LICENSE[] SEC("license") = "GPL";
+```
+
+In the same file, find:
+
+```c
+struct {
+    __uint(type, BPF_MAP_TYPE_ARRAY);
+    __type(key, __u32);
+    __type(value, __u32);
+    __uint(max_entries, 1);
+} futex_target_pid SEC(".maps");
+```
+
+Replace with:
+
+```c
+struct {
+    __uint(type, BPF_MAP_TYPE_ARRAY);
+    __type(key, __u32);
+    __type(value, struct target_filter);
+    __uint(max_entries, 1);
+} futex_target_pid SEC(".maps");
+```
+
+In the same file, find:
+
+```c
+static __always_inline int is_futex_target(void)
+{
+    __u32 key = 0;
+    __u32 *target = bpf_map_lookup_elem(&futex_target_pid, &key);
+    if (!target || *target == 0)
+        return 0;
+    __u64 pid_tgid = bpf_get_current_pid_tgid();
+    __u32 tgid = (__u32)(pid_tgid >> 32);
+    return tgid == *target;
+}
+```
+
+Replace with:
+
+```c
+static __always_inline int is_futex_target(void)
+{
+    return pid_is_target(&futex_target_pid);
+}
+```
+
+> Note: `handle_enter_futex` / `handle_exit_futex` keep using
+> `bpf_get_current_pid_tgid()` as the key of the `futex_inflight` map — that
+> only needs enter↔exit consistency, not namespace correctness. Do not change
+> those lines.
+
+- [ ] **Step 2: Convert `futex.go`**
+
+In `internal/bpf/futex.go`, find:
+
+```go
+	var key uint32 = 0
+	val := uint32(pid)
+	if err := targetMap.Update(&key, &val, ebpf.UpdateAny); err != nil {
+		t.Close()
+		return nil, fmt.Errorf("set futex_target_pid: %w", err)
+	}
+```
+
+Replace with:
+
+```go
+	tf, err := resolveTarget(pid)
+	if err != nil {
+		t.Close()
+		return nil, err
+	}
+	if err := writeTargetFilter(targetMap, tf); err != nil {
+		t.Close()
+		return nil, fmt.Errorf("set futex_target_pid: %w", err)
+	}
+```
+
+- [ ] **Step 3: Compile, build, vet, test**
+
+Run: `make gen`
+Expected: success.
+
+Run: `go build -tags=ebpf -o /tmp/ptop-ebpf ./cmd/ptop && go vet -tags=ebpf ./... && go test -race -tags=ebpf ./...`
+Expected: build success, vet clean, tests PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add internal/bpf/programs/futex.bpf.c internal/bpf/futex.go
+git commit -m "fix(bpf): namespace-aware pid filter for futex collector"
+```
+
+---
+
+## Task 8: threads collector
+
+The threads program filters by a TID whitelist matched against `sched_switch`'s
+root-namespace TIDs. It is replaced by: a `target_filter` check on `prev`
+(== `current` at the tracepoint) plus a self-populated `root2ns` LRU map that
+recovers the `next` thread's namespace-local TID. `tid_state` stays keyed by
+namespace-local TIDs, so the Go-side correlation is unchanged.
+
+**Files:**
+- Modify (full replace): `internal/bpf/programs/threads.bpf.c`
+- Modify (full replace): `internal/bpf/threads.go`
+- Modify: `internal/bpf/threads_stub.go`
+- Modify: `internal/collector/threads_ebpf.go`
+
+- [ ] **Step 1: Replace `threads.bpf.c`**
+
+Replace the entire contents of `internal/bpf/programs/threads.bpf.c` with:
+
+```c
+// SPDX-License-Identifier: GPL-2.0
+//
+// threads.bpf.c — tracks scheduler transitions (on-CPU ↔ off-CPU) of the
+// target PID's threads via the sched:sched_switch tracepoint.
+//
+// Why sched_switch and not /proc/<pid>/task/<tid>/stat?
+//   /proc gives cumulative utime+stime sampled at 1Hz — bad granularity
+//   for threads that oscillate quickly between running/blocked. The
+//   tracepoint fires on EVERY context switch, so on_cpu_ns reflects
+//   exactly what the kernel measured, in real time.
+//
+// Maps:
+//   threads_target_pid  ARRAY[1]   struct target_filter (written by Go)
+//   root2ns             LRU_HASH   root-ns tid → namespace-local tid
+//   tid_state           HASH       ns-local tid → struct thread_state
+//
+// PID-namespace handling:
+//   sched_switch delivers prev_pid/next_pid as ROOT-namespace TIDs, but the
+//   Go side and tid_state work in the target's namespace-local TIDs. At the
+//   tracepoint `current` == prev, so pid_target_ns() resolves prev's
+//   namespace-local tid; that {root_tid → ns_tid} pair is cached in root2ns.
+//   The `next` side then recovers the ns-local tid by looking up next_pid in
+//   root2ns (learned the previous time that thread was scheduled out). A
+//   brand-new thread is learned the first time it is `prev` — one context
+//   switch of warm-up, which the UI tolerates.
+
+#include <linux/bpf.h>
+#include <bpf/bpf_helpers.h>
+#include "target.bpf.h"
+
+char LICENSE[] SEC("license") = "GPL";
+
+// Stable layout of the sched:sched_switch tracepoint.
+// /sys/kernel/debug/tracing/events/sched/sched_switch/format
+struct sched_switch_args {
+    unsigned long long _pad;     // common_type/flags/preempt_count/pid (8B)
+    char prev_comm[16];          // offset 8
+    int prev_pid;                // offset 24
+    int prev_prio;               // offset 28
+    long prev_state;             // offset 32
+    char next_comm[16];          // offset 40
+    int next_pid;                // offset 56
+    int next_prio;               // offset 60
+};
+
+struct thread_state {
+    __u64 last_on_cpu_ns;
+    __u64 last_off_cpu_ns;
+    __u64 on_cpu_ns_total;
+    __u64 off_cpu_ns_total;
+    __u64 ctx_switches;
+};
+
+struct {
+    __uint(type, BPF_MAP_TYPE_ARRAY);
+    __type(key, __u32);
+    __type(value, struct target_filter);
+    __uint(max_entries, 1);
+} threads_target_pid SEC(".maps");
+
+// root2ns maps a root-namespace TID to the target's namespace-local TID.
+// Self-populated from the `prev` side of sched_switch; LRU evicts dead TIDs.
+struct {
+    __uint(type, BPF_MAP_TYPE_LRU_HASH);
+    __type(key, __u32);
+    __type(value, __u32);
+    __uint(max_entries, 8192);
+} root2ns SEC(".maps");
+
+struct {
+    __uint(type, BPF_MAP_TYPE_HASH);
+    __type(key, __u32);
+    __type(value, struct thread_state);
+    __uint(max_entries, 8192);
+} tid_state SEC(".maps");
+
+// Get-or-create entry in tid_state. Returns ptr (always non-null on success).
+// On update failure (pathological case), returns NULL.
+static __always_inline struct thread_state *get_or_create_state(__u32 tid)
+{
+    struct thread_state *s = bpf_map_lookup_elem(&tid_state, &tid);
+    if (s)
+        return s;
+    struct thread_state zero = {};
+    bpf_map_update_elem(&tid_state, &tid, &zero, BPF_ANY);
+    return bpf_map_lookup_elem(&tid_state, &tid);
+}
+
+SEC("tracepoint/sched/sched_switch")
+int handle_sched_switch(struct sched_switch_args *ctx)
+{
+    __u64 now = bpf_ktime_get_ns();
+
+    // prev == current at sched_switch. If it belongs to the target process,
+    // cache its root→ns TID mapping and do off-CPU accounting.
+    struct bpf_pidns_info ns = {};
+    if (pid_target_ns(&threads_target_pid, &ns)) {
+        __u32 root_tid = (__u32)ctx->prev_pid;
+        __u32 ns_tid = ns.pid;
+        bpf_map_update_elem(&root2ns, &root_tid, &ns_tid, BPF_ANY);
+
+        struct thread_state *s = get_or_create_state(ns_tid);
+        if (s) {
+            if (s->last_on_cpu_ns != 0) {
+                __u64 delta = now - s->last_on_cpu_ns;
+                __sync_fetch_and_add(&s->on_cpu_ns_total, delta);
+            }
+            s->last_off_cpu_ns = now;
+            __sync_fetch_and_add(&s->ctx_switches, 1);
+        }
+    }
+
+    // next entering CPU: recover its ns-local TID from root2ns (learned the
+    // last time it was scheduled out).
+    __u32 next_root = (__u32)ctx->next_pid;
+    __u32 *next_ns = bpf_map_lookup_elem(&root2ns, &next_root);
+    if (next_ns) {
+        struct thread_state *s = get_or_create_state(*next_ns);
+        if (s) {
+            if (s->last_off_cpu_ns != 0) {
+                __u64 delta = now - s->last_off_cpu_ns;
+                __sync_fetch_and_add(&s->off_cpu_ns_total, delta);
+            }
+            s->last_on_cpu_ns = now;
+        }
+    }
+    return 0;
+}
+```
+
+- [ ] **Step 2: Replace `threads.go`**
+
+Replace the entire contents of `internal/bpf/threads.go` with:
+
+```go
+//go:build linux && ebpf
+
+package bpf
+
+import (
+	"bytes"
+	_ "embed"
+	"errors"
+	"fmt"
+
+	"github.com/cilium/ebpf"
+	"github.com/cilium/ebpf/link"
+	"github.com/cilium/ebpf/rlimit"
+)
+
+//go:embed programs/threads.bpf.o
+var threadsBPFObj []byte
+
+// ThreadState mirrors `struct thread_state` in programs/threads.bpf.c 1:1.
+// 40 bytes aligned (5 × u64).
+type ThreadState struct {
+	LastOnCpuNs   uint64
+	LastOffCpuNs  uint64
+	OnCpuNsTotal  uint64
+	OffCpuNsTotal uint64
+	CtxSwitches   uint64
+}
+
+// ThreadsTracer loads threads.bpf.o, attaches sched:sched_switch, and exposes
+// Stats() to read tid_state (keyed by the target's namespace-local TIDs).
+type ThreadsTracer struct {
+	coll     *ebpf.Collection
+	link     link.Link
+	stateMap *ebpf.Map
+}
+
+func OpenThreadsTracer(pid int) (*ThreadsTracer, error) {
+	if pid <= 0 {
+		return nil, errors.New("invalid pid")
+	}
+	if err := rlimit.RemoveMemlock(); err != nil {
+		return nil, fmt.Errorf("rlimit: %w", err)
+	}
+
+	spec, err := ebpf.LoadCollectionSpecFromReader(bytes.NewReader(threadsBPFObj))
+	if err != nil {
+		return nil, fmt.Errorf("parse threads BPF object: %w", err)
+	}
+	coll, err := ebpf.NewCollection(spec)
+	if err != nil {
+		return nil, fmt.Errorf("load threads collection: %w", err)
+	}
+	t := &ThreadsTracer{coll: coll}
+
+	targetMap := coll.Maps["threads_target_pid"]
+	if targetMap == nil {
+		t.Close()
+		return nil, errors.New("threads_target_pid map missing")
+	}
+	tf, err := resolveTarget(pid)
+	if err != nil {
+		t.Close()
+		return nil, err
+	}
+	if err := writeTargetFilter(targetMap, tf); err != nil {
+		t.Close()
+		return nil, fmt.Errorf("set threads_target_pid: %w", err)
+	}
+
+	t.stateMap = coll.Maps["tid_state"]
+	if t.stateMap == nil {
+		t.Close()
+		return nil, errors.New("tid_state map missing")
+	}
+
+	prog := coll.Programs["handle_sched_switch"]
+	if prog == nil {
+		t.Close()
+		return nil, errors.New("handle_sched_switch program missing")
+	}
+	l, err := link.Tracepoint("sched", "sched_switch", prog, nil)
+	if err != nil {
+		t.Close()
+		return nil, fmt.Errorf("attach sched/sched_switch: %w", err)
+	}
+	t.link = l
+
+	return t, nil
+}
+
+// PruneDeadTIDs deletes tid_state entries for TIDs no longer alive, so a
+// recycled TID does not inherit stale counters. `live` holds the
+// namespace-local TIDs currently present under /proc/<pid>/task/.
+func (t *ThreadsTracer) PruneDeadTIDs(live []int) error {
+	if t == nil || t.stateMap == nil {
+		return errors.New("tracer not initialized")
+	}
+	alive := make(map[uint32]struct{}, len(live))
+	for _, tid := range live {
+		if tid > 0 {
+			alive[uint32(tid)] = struct{}{}
+		}
+	}
+	var dead []uint32
+	var k uint32
+	var v ThreadState
+	iter := t.stateMap.Iterate()
+	for iter.Next(&k, &v) {
+		if _, ok := alive[k]; !ok {
+			dead = append(dead, k)
+		}
+	}
+	if err := iter.Err(); err != nil {
+		return err
+	}
+	for i := range dead {
+		_ = t.stateMap.Delete(&dead[i])
+	}
+	return nil
+}
+
+// Stats returns a complete snapshot of the tid_state map, keyed by the
+// target's namespace-local TIDs.
+func (t *ThreadsTracer) Stats() (map[uint32]ThreadState, error) {
+	if t == nil || t.stateMap == nil {
+		return nil, errors.New("tracer not initialized")
+	}
+	out := make(map[uint32]ThreadState, 64)
+	var k uint32
+	var v ThreadState
+	iter := t.stateMap.Iterate()
+	for iter.Next(&k, &v) {
+		out[k] = v
+	}
+	if err := iter.Err(); err != nil {
+		return out, err
+	}
+	return out, nil
+}
+
+func (t *ThreadsTracer) Close() error {
+	if t == nil {
+		return nil
+	}
+	if t.link != nil {
+		_ = t.link.Close()
+		t.link = nil
+	}
+	if t.coll != nil {
+		t.coll.Close()
+		t.coll = nil
+		t.stateMap = nil
+	}
+	return nil
+}
+```
+
+- [ ] **Step 3: Update the non-eBPF stub**
+
+In `internal/bpf/threads_stub.go`, find:
+
+```go
+func (*ThreadsTracer) UpdateTrackedTIDs([]int) error    { return errThreadsStub }
+```
+
+Replace with:
+
+```go
+func (*ThreadsTracer) PruneDeadTIDs([]int) error        { return errThreadsStub }
+```
+
+- [ ] **Step 4: Update the collector call site**
+
+In `internal/collector/threads_ebpf.go`, find:
+
+```go
+//   - sync tracked_tids in the BPF map (add new ones, remove stragglers)
+```
+
+Replace with:
+
+```go
+//   - prune tid_state for TIDs that have exited
+```
+
+In the same file, find:
+
+```go
+	// Sync tracked_tids in the BPF map.
+	if err := c.tracer.UpdateTrackedTIDs(tidList); err != nil {
+		// Not fatal: keep publishing /proc data even if the sync fails.
+		_ = err
+	}
+```
+
+Replace with:
+
+```go
+	// Prune tid_state for threads that exited since the last tick.
+	if err := c.tracer.PruneDeadTIDs(tidList); err != nil {
+		// Not fatal: keep publishing /proc data even if the prune fails.
+		_ = err
+	}
+```
+
+- [ ] **Step 5: Compile, build, vet, test (both lanes)**
+
+Run: `make gen`
+Expected: success.
+
+Run: `go build -tags=ebpf -o /tmp/ptop-ebpf ./cmd/ptop && go vet -tags=ebpf ./... && go test -race -tags=ebpf ./...`
+Expected: build success, vet clean, tests PASS.
+
+Run: `go build -o /tmp/ptop ./cmd/ptop && go vet ./... && go test -race ./...`
+Expected: build success, vet clean, tests PASS (the default lane uses `threads_stub.go`).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/bpf/programs/threads.bpf.c internal/bpf/threads.go internal/bpf/threads_stub.go internal/collector/threads_ebpf.go
+git commit -m "fix(bpf): namespace-aware pid filter for threads collector"
+```
+
+---
+
+## Task 9: ebpf-selftest diagnostic tool
+
+A root-only tool that verifies the eBPF collectors can observe the target
+process — a permanent self-diagnostic for container/WSL users.
+
+**Files:**
+- Create: `cmd/ebpfselftest/main.go`
+- Create: `cmd/ebpfselftest/stub.go`
+- Modify: `Makefile`
+
+- [ ] **Step 1: Create the tool**
+
+Create `cmd/ebpfselftest/main.go`:
+
+```go
+//go:build linux && ebpf
+
+// ebpf-selftest verifies that ptop's eBPF collectors can actually observe
+// the target process — useful inside containers / WSL, where nested PID
+// namespaces historically broke the filter. Run as root:
+//
+//	sudo ./bin/ebpf-selftest
+//
+// It targets its own process, generates a known workload (CPU burn + write
+// syscalls), and reports whether the eBPF counters moved.
+package main
+
+import (
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/trentas/ptop/internal/bpf"
+)
+
+func main() {
+	if d := bpf.GetCapStatus().Diagnose(); d != "" {
+		fmt.Fprint(os.Stderr, d)
+		os.Exit(1)
+	}
+
+	pid := os.Getpid()
+	fmt.Printf("ptop eBPF self-test — target = self (pid %d)\n\n", pid)
+
+	cpuT, err := bpf.OpenCPUTracer(pid)
+	if err != nil {
+		fmt.Println("FAIL  cpu: OpenCPUTracer:", err)
+		os.Exit(1)
+	}
+	defer cpuT.Close()
+
+	scT, err := bpf.OpenSyscallTracer(pid)
+	if err != nil {
+		fmt.Println("FAIL  syscalls: OpenSyscallTracer:", err)
+		os.Exit(1)
+	}
+	defer scT.Close()
+
+	// Workload: CPU burn + real write(2) syscalls for 3 seconds.
+	devnull, err := os.OpenFile("/dev/null", os.O_WRONLY, 0)
+	if err != nil {
+		fmt.Println("FAIL  cannot open /dev/null:", err)
+		os.Exit(1)
+	}
+	buf := []byte("x")
+	var spin uint64
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		for i := 0; i < 50000; i++ {
+			spin++
+		}
+		_, _ = devnull.Write(buf)
+	}
+	devnull.Close()
+	_ = spin
+
+	failed := false
+
+	samples, _ := cpuT.SampleCount()
+	if samples > 0 {
+		fmt.Printf("PASS  cpu:      %d on-CPU samples observed\n", samples)
+	} else {
+		fmt.Println("FAIL  cpu:      0 samples — the eBPF filter did not match this process")
+		failed = true
+	}
+
+	stats, _ := scT.Stats()
+	var total uint64
+	for _, s := range stats {
+		total += s.Count
+	}
+	if total > 0 {
+		fmt.Printf("PASS  syscalls: %d events across %d syscall ids\n", total, len(stats))
+	} else {
+		fmt.Println("FAIL  syscalls: 0 events — the eBPF filter did not match this process")
+		failed = true
+	}
+
+	if failed {
+		fmt.Println("\neBPF self-test FAILED")
+		os.Exit(1)
+	}
+	fmt.Println("\neBPF self-test PASSED")
+}
+```
+
+Create `cmd/ebpfselftest/stub.go`:
+
+```go
+//go:build !linux || !ebpf
+
+// Stub so `go build ./...` / `go vet ./...` succeed in the default lane —
+// the real self-test only exists in the Linux eBPF build.
+package main
+
+import "fmt"
+
+func main() {
+	fmt.Println("ebpf-selftest requires a Linux build with -tags=ebpf")
+}
+```
+
+- [ ] **Step 2: Add the Makefile target**
+
+In `Makefile`, find:
+
+```make
+.PHONY: all build build-ebpf run gen clean dev test test-all vet lint install install-bare install-ebpf uninstall
+```
+
+Replace with:
+
+```make
+.PHONY: all build build-ebpf run gen clean dev test test-all vet lint install install-bare install-ebpf uninstall ebpf-selftest
+```
+
+In `Makefile`, find:
+
+```make
+# /proc-only mode — no root, no eBPF
+dev: build
+	./bin/$(BINARY) --pid $(PID) --no-ebpf
+```
+
+Replace with:
+
+```make
+# /proc-only mode — no root, no eBPF
+dev: build
+	./bin/$(BINARY) --pid $(PID) --no-ebpf
+
+# ebpf-selftest builds the eBPF self-diagnostic. Run the result as root:
+# `sudo ./bin/ebpf-selftest` — it reports whether the eBPF collectors can
+# observe the target process (useful inside containers / WSL).
+ebpf-selftest: gen
+	go build -tags=ebpf -o bin/ebpf-selftest ./cmd/ebpfselftest
+	@echo "built bin/ebpf-selftest — run as root: sudo ./bin/ebpf-selftest"
+```
+
+- [ ] **Step 3: Build both lanes**
+
+Run: `go build -tags=ebpf -o /tmp/selftest-ebpf ./cmd/ebpfselftest`
+Expected: success.
+
+Run: `go build -o /tmp/selftest ./cmd/ebpfselftest`
+Expected: success (uses `stub.go`).
+
+Run: `go vet ./... && go vet -tags=ebpf ./...`
+Expected: no output (clean) — confirms `cmd/ebpfselftest` is buildable in both lanes.
+
+Run: `make ebpf-selftest`
+Expected: success — prints `built bin/ebpf-selftest — run as root: sudo ./bin/ebpf-selftest`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add cmd/ebpfselftest/main.go cmd/ebpfselftest/stub.go Makefile
+git commit -m "feat: add ebpf-selftest diagnostic tool"
+```
+
+---
+
+## Task 10: Final verification and docs
+
+- [ ] **Step 1: Update `CLAUDE.md` — eBPF programs listing**
+
+In `CLAUDE.md`, find:
+
+```
+│   ├── bpf/                       eBPF programs + loader (build tag `ebpf`)
+│   │   ├── programs/              .bpf.c sources, compiled by `make gen`
+│   │   │   ├── syscalls.bpf.c     raw_syscalls/sys_{enter,exit}
+```
+
+Replace with:
+
+```
+│   ├── bpf/                       eBPF programs + loader (build tag `ebpf`)
+│   │   ├── programs/              .bpf.c sources, compiled by `make gen`
+│   │   │   ├── target.bpf.h       shared pid-namespace target filter
+│   │   │   ├── syscalls.bpf.c     raw_syscalls/sys_{enter,exit}
+```
+
+- [ ] **Step 2: Update `CLAUDE.md` — loader listing**
+
+In `CLAUDE.md`, find:
+
+```
+│   │   ├── available.go           runtime feature flag (build-tag based)
+│   │   ├── caps.go                CAP_BPF / CAP_PERFMON detection
+```
+
+Replace with:
+
+```
+│   │   ├── available.go           runtime feature flag (build-tag based)
+│   │   ├── target.go              pid-namespace target resolver (shared)
+│   │   ├── caps.go                CAP_BPF / CAP_PERFMON detection
+```
+
+- [ ] **Step 3: Update `CLAUDE.md` — cmd listing**
+
+In `CLAUDE.md`, find:
+
+```
+├── cmd/ptop/main.go               entrypoint: parse flags, start model
+```
+
+Replace with:
+
+```
+├── cmd/ptop/main.go               entrypoint: parse flags, start model
+├── cmd/ebpfselftest/              root-only eBPF self-diagnostic
+```
+
+- [ ] **Step 4: Document the namespace requirement in `CLAUDE.md`**
+
+In `CLAUDE.md`, find:
+
+```
+## Build tags
+
+- `//go:build linux && ebpf` — real eBPF code (loader + program objects)
+- `//go:build !linux || !ebpf` — stubs that fail `Start` cleanly
+```
+
+Replace with:
+
+```
+## PID namespaces
+
+eBPF programs filter the target process via `bpf_get_ns_current_pid_tgid()`,
+resolving pids inside the target's PID namespace (dev+inode of
+`/proc/<pid>/ns/pid`, written by the Go loader into `struct target_filter`).
+This is required because `bpf_get_current_pid_tgid()` returns root-namespace
+pids — wrong when ptop runs inside a nested namespace (WSL2, Docker, LXC).
+The shared logic lives in `programs/target.bpf.h` and `bpf/target.go`; never
+filter with the bare `bpf_get_current_pid_tgid()` again. Verify with
+`make ebpf-selftest` → `sudo ./bin/ebpf-selftest`.
+
+## Build tags
+
+- `//go:build linux && ebpf` — real eBPF code (loader + program objects)
+- `//go:build !linux || !ebpf` — stubs that fail `Start` cleanly
+```
+
+- [ ] **Step 5: Full clean rebuild — both lanes**
+
+Run: `make clean && make gen`
+Expected: success — all 7 `.bpf.c` compile.
+
+Run: `go build -o /tmp/ptop ./cmd/ptop && go vet ./... && go test -race -count=1 ./...`
+Expected: default lane — build success, vet clean, all tests PASS.
+
+Run: `go build -tags=ebpf -o /tmp/ptop-ebpf ./cmd/ptop && go vet -tags=ebpf ./... && go test -race -count=1 -tags=ebpf ./...`
+Expected: eBPF lane — build success, vet clean, all tests PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add CLAUDE.md
+git commit -m "docs: document the eBPF pid-namespace filter"
+```
+
+- [ ] **Step 7: Hand off for root verification**
+
+Build the binary and the self-test for the user:
+
+Run: `make build-ebpf && make ebpf-selftest`
+Expected: `bin/ptop` and `bin/ebpf-selftest` produced.
+
+Tell the user to run, on **WSL2** and on a **native Linux host**:
+
+1. `sudo ./bin/ebpf-selftest` — expect `eBPF self-test PASSED`.
+2. `sudo ./bin/ptop --pid <PID>` of a busy process — expect F1 to show real
+   CPU %, F2 to populate syscalls, F4 to show per-thread CPU % and context
+   switches, and the `?` overlay to show `real via eBPF` for cpu, syscalls,
+   io-files, network, memory, locks and threads.
+
+Do not claim the fix works on either platform until the user confirms these
+runs.
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Shared C header + Go resolver (spec §4) → Tasks 1, 2.
+- Six uniform collectors (spec §5) → Tasks 2 (cpu), 3, 4, 5, 6, 7.
+- Threads collector (spec §6) → Task 8.
+- Non-regression on native Linux (spec §7) → both-lane vet/test/build in every
+  task; explicit default-lane checks in Tasks 8, 9, 10; `target_test.go` (CI).
+- Error handling (spec §8) → `resolveTarget` error path wired through every
+  loader; `target_test.go` covers the missing-pid and struct-size cases.
+- Testing & verification (spec §9) → Task 1 unit tests; per-task `make gen` +
+  both-lane checks; Task 10 root-run handoff.
+- ebpf-selftest tool (spec §10) → Task 9.
+- Out of scope (spec §2): `model.go` CPU fallback hardening — not touched, as
+  intended.
+
+**Placeholder scan:** none — every step has concrete code or exact commands.
+`<PID>` in Task 10 Step 7 is a literal the user substitutes.
+
+**Type consistency:** `targetFilter` (Go, Task 1) ↔ `struct target_filter`
+(C, Task 2) — both 24 bytes, asserted by `TestTargetFilterSize`.
+`resolveTarget`/`writeTargetFilter` defined in Task 1, used identically in
+Tasks 2–8. `pid_is_target`/`pid_target_ns` defined in Task 2's header, used in
+Tasks 2–8. `PruneDeadTIDs` defined in Task 8 (`threads.go` + stub), called in
+Task 8 (`threads_ebpf.go`). No mismatches.

--- a/docs/superpowers/specs/2026-05-19-ebpf-pidns-fix-design.md
+++ b/docs/superpowers/specs/2026-05-19-ebpf-pidns-fix-design.md
@@ -1,0 +1,310 @@
+# eBPF PID-namespace fix — design
+
+**Date:** 2026-05-19
+**Status:** approved (brainstorming) → ready for implementation plan
+
+---
+
+## 1. Problem & root cause
+
+On WSL2 (and inside Docker/LXC) every eBPF collector reports nothing. CPU and
+syscalls show empty because they have no `/proc` fallback; threads, memory,
+io-throughput, io-wait, fds and network still look populated because they have
+`/proc`-derived data.
+
+**Root cause:** WSL2 runs the whole distro inside a nested PID namespace. ptop's
+eBPF programs filter events with:
+
+```c
+__u32 tgid = (__u32)(bpf_get_current_pid_tgid() >> 32);
+if (tgid != *target) return 0;
+```
+
+`bpf_get_current_pid_tgid()` returns the PID in the **initial** PID namespace.
+The `--pid` the user passes (and everything `ps`/`top`/`/proc` show inside the
+distro) is the PID in the **distro's** namespace. On a normal host both are the
+same namespace; under WSL2 they differ, so the comparison never matches.
+
+**Evidence (instrumented diagnostic, run as root on WSL2):** the BPF programs
+load, attach and run (`sys_enter` fired 301,723×, `perf_event` 4,797×); the
+`target_pid` map held the correct value (`175347`); but `tgid == target` matched
+**0 times** while the process did 279,829 `write` syscalls. The process's PID
+namespace is `pid:[4026532221]` — the kernel's initial namespace is always
+`pid:[4026531836]`.
+
+This affects all 7 eBPF programs: cpu, syscalls, io, network, memory, futex
+(uniform `is_X_target()` helper) and threads (a TID whitelist matched against
+`sched_switch`'s root-namespace TIDs).
+
+## 2. Goal & non-goals
+
+**Goal:** all 7 eBPF collectors filter the target process correctly when ptop
+runs inside a nested PID namespace, with **zero behavior change** on a native
+Linux host in the root namespace.
+
+**Non-goals (out of scope):**
+
+- Hardening `model.go` to fall back to `/proc` when the eBPF CPU collector
+  starts successfully but yields `0`. The namespace fix makes eBPF work; a
+  "is 0% real or broken?" heuristic adds complexity without need. Deferred.
+- macOS: untouched. All eBPF code is `//go:build linux && ebpf`; the macOS
+  libproc/Mach path never compiles it.
+
+## 3. Approach
+
+Replace `bpf_get_current_pid_tgid()` with **`bpf_get_ns_current_pid_tgid(dev,
+ino, &nsdata, sizeof(nsdata))`** (kernel 5.7+; ptop already requires 5.8+). The
+helper returns the pid/tgid of the current task **as seen within the PID
+namespace identified by (dev, ino)**.
+
+The fix is a single uniform code path — there is no "WSL branch". On a native
+host the target's `/proc/<pid>/ns/pid` resolves to the initial namespace, and
+the helper returns exactly what `bpf_get_current_pid_tgid()` returned before.
+
+The namespace logic is centralized in **one shared C header** and **one shared
+Go resolver**, eliminating the 6–7× duplicated `is_X_target()` pattern.
+
+## 4. Shared components
+
+### 4.1 C header — `internal/bpf/programs/target.bpf.h` (new)
+
+```c
+#ifndef PTOP_TARGET_BPF_H
+#define PTOP_TARGET_BPF_H
+#include <linux/bpf.h>
+#include <bpf/bpf_helpers.h>
+
+/* Written by the Go loader. dev+ino identify the target's PID namespace;
+ * pid is the target tgid as seen WITHIN that namespace. */
+struct target_filter {
+    __u32 pid;
+    __u32 _pad;
+    __u64 dev;
+    __u64 ino;
+};
+
+/* 1 if the current task belongs to the target process, resolving pids
+ * inside the target's PID namespace (correct under WSL2/containers). */
+static __always_inline int pid_is_target(void *target_map) {
+    __u32 key = 0;
+    struct target_filter *tf = bpf_map_lookup_elem(target_map, &key);
+    if (!tf || tf->pid == 0) return 0;
+    struct bpf_pidns_info ns = {};
+    if (bpf_get_ns_current_pid_tgid(tf->dev, tf->ino, &ns, sizeof(ns)) != 0)
+        return 0;
+    return ns.tgid == tf->pid;
+}
+
+/* Variant that also yields the namespace-local pid/tgid (used by threads).
+ * Returns 1 and fills *out when the current task is the target. */
+static __always_inline int pid_target_ns(void *target_map,
+                                          struct bpf_pidns_info *out) {
+    __u32 key = 0;
+    struct target_filter *tf = bpf_map_lookup_elem(target_map, &key);
+    if (!tf || tf->pid == 0) return 0;
+    if (bpf_get_ns_current_pid_tgid(tf->dev, tf->ino, out, sizeof(*out)) != 0)
+        return 0;
+    return out->tgid == tf->pid;
+}
+#endif
+```
+
+`struct bpf_pidns_info { __u32 pid; __u32 tgid; }` comes from `<linux/bpf.h>`,
+already included by every program. `#include "target.bpf.h"` resolves via
+clang's same-directory search for quoted includes — no Makefile change.
+
+### 4.2 Go resolver — `internal/bpf/target.go` (new, `//go:build linux && ebpf`)
+
+```go
+// targetFilter mirrors `struct target_filter` byte-for-byte (24 bytes).
+type targetFilter struct {
+    Pid uint32
+    _   uint32
+    Dev uint64
+    Ino uint64
+}
+
+// resolveTarget builds the filter for pid: its tgid plus the device+inode
+// of its PID namespace. On a native host in the root namespace this resolves
+// to the initial pidns, so the BPF-side comparison is identical to the old
+// bpf_get_current_pid_tgid() path.
+func resolveTarget(pid int) (targetFilter, error) {
+    var st unix.Stat_t
+    if err := unix.Stat(fmt.Sprintf("/proc/%d/ns/pid", pid), &st); err != nil {
+        return targetFilter{}, fmt.Errorf("stat pid namespace of %d: %w", pid, err)
+    }
+    return targetFilter{Pid: uint32(pid), Dev: st.Dev, Ino: st.Ino}, nil
+}
+
+// writeTargetFilter writes the resolved filter into an ARRAY[1] map at key 0.
+func writeTargetFilter(m *ebpf.Map, tf targetFilter) error {
+    var key uint32 = 0
+    return m.Update(&key, &tf, ebpf.UpdateAny)
+}
+```
+
+### 4.3 Data flow
+
+`OpenXTracer(pid)` → load collection → `resolveTarget(pid)` (`stat` the ns) →
+`writeTargetFilter(targetMap, tf)` → attach. Per event at runtime:
+`pid_is_target(&X_target_pid)` → the kernel projects the current task's pid
+into the target's namespace and compares.
+
+## 5. The six uniform collectors — cpu, syscalls, io, network, memory, futex
+
+Mechanical, identical change per collector:
+
+- **`.bpf.c`:** `#include "target.bpf.h"`; delete the local `is_X_target()`
+  helper; the `X_target_pid` map value type changes from `__u32` to
+  `struct target_filter`. `cpu.bpf.c` has the filter inline in
+  `handle_perf_event` — it becomes `if (!pid_is_target(&cpu_target_pid)) return 0;`.
+  All other call sites become `pid_is_target(&X_target_pid)`.
+- **loader (`.go`):** replace the `key`/`val`/`Update` block with
+  `resolveTarget(pid)` + `writeTargetFilter(targetMap, tf)`, propagating any
+  error through `t.Close()` + return (same shape as today).
+
+Map names stay (`cpu_target_pid`, `net_target_pid`, …) to keep the diff small;
+only the value type changes.
+
+**Unchanged:** `pid_tgid` used as *keys* of in-flight maps (`enter_ts` in
+syscalls, `io_inflight_map`, `futex_inflight`) keeps `bpf_get_current_pid_tgid()`
+— those only need enter↔exit consistency, not namespace correctness.
+
+## 6. The threads collector
+
+`threads.bpf.c` filters with a TID whitelist (`tracked_tids`, populated by Go
+from `/proc/<pid>/task/`) matched against `sched_switch`'s `prev_pid`/`next_pid`
+— which are root-namespace TIDs. No CO-RE is needed to fix it.
+
+`sched_switch` fires with `current == prev` (already documented in the file's
+header comment). So `bpf_get_ns_current_pid_tgid()` resolves `prev`. The `next`
+side is recovered from a self-populated mapping built on the `prev` side.
+
+- **`threads.bpf.c`:**
+  - `threads_target_pid` value type → `struct target_filter`.
+  - Remove the `tracked_tids` map and `is_tracked()`.
+  - Add `root2ns`: `BPF_MAP_TYPE_LRU_HASH`, key `__u32` (root-ns tid), value
+    `__u32` (ns-local tid), `max_entries` 8192. LRU evicts dead TIDs by itself.
+  - `handle_sched_switch`:
+    - `prev` (= current): `pid_target_ns(&threads_target_pid, &ns)`. If it is a
+      target thread, record `root2ns[ctx->prev_pid] = ns.pid`, then do off-CPU
+      accounting + `ctx_switches++` on `tid_state[ns.pid]`.
+    - `next`: look up `root2ns[ctx->next_pid]`; if present, do on-CPU accounting
+      on `tid_state[<ns-local tid>]`.
+  - `tid_state` stays keyed by **ns-local tid** — Go-side correlation unchanged.
+  - Warm-up: a brand-new thread is learned the first time it is `prev` (one
+    context switch). The original code already accepted a ~1s learning window;
+    this is strictly better.
+- **`threads.go`:** remove `UpdateTrackedTIDs()` and the `trackedMap` field;
+  write the `target_filter` via the shared resolver; add `PruneDeadTIDs(live
+  []int)` that deletes `tid_state` entries whose ns-local tid is not in `live`
+  — this inherits the orphan/recycled-TID cleanup that lived inside
+  `UpdateTrackedTIDs`.
+- **`threads_ebpf.go`:** the periodic `UpdateTrackedTIDs` call site becomes
+  `PruneDeadTIDs` (the collector already walks `/proc/<pid>/task/` each cycle,
+  so it has the live ns-local TID set).
+
+## 7. Non-regression on native Linux
+
+The user's primary concern. Why native Linux (root namespace) cannot silently
+regress, and how each real risk is covered:
+
+- **One code path.** There is no WSL-specific branch. On a native host
+  `/proc/<pid>/ns/pid` is the initial namespace; `bpf_get_ns_current_pid_tgid`
+  with the initial ns's (dev, ino) returns the same pid/tgid as
+  `bpf_get_current_pid_tgid`. Native is the depth-0 degenerate case of the same
+  logic the WSL test exercises at depth 1.
+- **CI guards native Linux automatically.** `.github/workflows/ci.yml` runs on
+  `ubuntu-latest` (native, root namespace): `make gen` + `vet`/`test`/`build`
+  for both the default and `-tags=ebpf` lanes. The new `target_test.go` runs
+  there on every PR.
+- **Real regression surface #1 — `struct target_filter` ABI.** A C↔Go layout
+  mismatch would write garbage and break the filter everywhere, native
+  included. Covered by a unit test asserting `unsafe.Sizeof(targetFilter{}) ==
+  24` and field offsets, run in CI on native Linux.
+- **Real regression surface #2 — the threads rewrite.** Removing
+  `tracked_tids`/`UpdateTrackedTIDs` and adding `root2ns` is the only
+  substantive *logic* change; it changes native behavior too. It must be
+  verified end-to-end on a native Linux host (F4 panel showing per-thread CPU%
+  and context switches), not only on WSL.
+- **No silent failure on the map value-type change.** cilium/ebpf's `Map.Update`
+  checks the value size against the map spec; a loader writing the wrong type
+  fails loudly at `OpenXTracer` time rather than degrading silently.
+
+## 8. Error handling & edge cases
+
+- **Kernel version:** `bpf_get_ns_current_pid_tgid` is 5.7+; ptop already
+  requires 5.8+ (`CapStatus.KernelSupportsBPF`). No new floor, no new fallback.
+- **`resolveTarget` failure** (target exited between launch and load): `stat`
+  fails → `OpenXTracer` returns an error → the existing `model.go` fallback
+  (`/proc` or mock) takes over.
+- **Helper returns non-zero at runtime** (current task not in the target's ns,
+  e.g. the WSL root-namespace processes): treated as "not target" → `return 0`.
+- **`struct target_filter` layout:** `u32, u32, u64, u64` = 24 bytes, 8-aligned;
+  Go struct uses an explicit `_ uint32` pad. Asserted by a unit test.
+
+## 9. Testing & verification
+
+**Automated, no root (this host + CI):**
+
+- TDD unit tests in `internal/bpf/target_test.go` (`//go:build linux && ebpf`):
+  `resolveTarget` returns non-zero Dev/Ino and `Pid == os.Getpid()` for
+  `/proc/self`; `unsafe.Sizeof(targetFilter{}) == 24`. Tests written first.
+- `make gen` — all 7 `.bpf.c` compile against the new shared header.
+- `go vet ./...` and `go vet -tags=ebpf ./...`.
+- `go test -race ./...` and `go test -race -tags=ebpf ./...`.
+- All of the above also run in CI on native Linux (root namespace).
+
+**Manual, requires root (the user):**
+
+- On **WSL2**: `sudo ./bin/ptop --pid <PID>` — F1 shows real CPU%, F2 populates
+  syscalls, the `?` overlay shows `real via eBPF` for all 7 subsystems.
+- On a **native Linux host**: the same end-to-end check, with explicit
+  attention to the F4 threads panel (the largest logic change).
+- `make ebpf-selftest` (below) on both for a fast pass/fail.
+
+No claim of "works on WSL / works natively" is made until the user confirms the
+manual runs.
+
+## 10. ebpf-selftest tool
+
+Commit a trimmed version of the throwaway diagnostic as `cmd/ebpfselftest`
+(`//go:build linux && ebpf`) plus a `make ebpf-selftest` target. It opens the
+cpu and syscalls tracers against its own PID, generates a known workload (CPU
+burn + `write` syscalls), and prints per-collector pass/fail with counts. It is
+a permanent self-diagnostic for anyone running ptop in a container or WSL.
+
+## 11. Files touched
+
+**New (4):**
+- `internal/bpf/programs/target.bpf.h`
+- `internal/bpf/target.go`
+- `internal/bpf/target_test.go`
+- `cmd/ebpfselftest/main.go`
+
+**Modified `.bpf.c` (7):** cpu, syscalls, io, network, memory, threads, futex.
+
+**Modified loaders (7):** cpu.go, syscalls.go, io.go, network.go, memory.go,
+threads.go, futex.go.
+
+**Modified collector (1):** `threads_ebpf.go` (call-site swap).
+
+**Modified build (1):** `Makefile` (add `ebpf-selftest` target; add the new
+`.bpf.h` as a prerequisite of the `.bpf.o` rule so edits to it trigger a
+rebuild).
+
+**Regenerated:** all `internal/bpf/programs/*.bpf.o` via `make gen`.
+
+The `*_stub.go` files (non-eBPF lane) do not reference the new code; the
+implementation plan confirms threads stub parity after the `UpdateTrackedTIDs`
+removal.
+
+## 12. Implementation order
+
+1. Shared components: `target.bpf.h`, `target.go`, `target_test.go` (TDD).
+2. The six uniform collectors (`.bpf.c` + loader), one at a time, `make gen`
+   after each.
+3. The threads collector (`.bpf.c`, `threads.go`, `threads_ebpf.go`).
+4. `cmd/ebpfselftest` + `Makefile` target.
+5. Full verification: both lanes vet/test/build, `make gen`; hand off to the
+   user for the root runs on WSL2 and native Linux.

--- a/internal/bpf/cpu.go
+++ b/internal/bpf/cpu.go
@@ -56,9 +56,12 @@ func OpenCPUTracer(pid int) (*CPUTracer, error) {
 		t.Close()
 		return nil, errors.New("cpu_target_pid map not found")
 	}
-	var key uint32 = 0
-	val := uint32(pid)
-	if err := targetMap.Update(&key, &val, ebpf.UpdateAny); err != nil {
+	tf, err := resolveTarget(pid)
+	if err != nil {
+		t.Close()
+		return nil, err
+	}
+	if err := writeTargetFilter(targetMap, tf); err != nil {
 		t.Close()
 		return nil, fmt.Errorf("set cpu_target_pid: %w", err)
 	}

--- a/internal/bpf/futex.go
+++ b/internal/bpf/futex.go
@@ -58,9 +58,12 @@ func OpenFutexTracer(pid int) (*FutexTracer, error) {
 		t.Close()
 		return nil, errors.New("futex_target_pid map missing")
 	}
-	var key uint32 = 0
-	val := uint32(pid)
-	if err := targetMap.Update(&key, &val, ebpf.UpdateAny); err != nil {
+	tf, err := resolveTarget(pid)
+	if err != nil {
+		t.Close()
+		return nil, err
+	}
+	if err := writeTargetFilter(targetMap, tf); err != nil {
 		t.Close()
 		return nil, fmt.Errorf("set futex_target_pid: %w", err)
 	}

--- a/internal/bpf/io.go
+++ b/internal/bpf/io.go
@@ -68,9 +68,12 @@ func OpenIOTracer(pid int) (*IOTracer, error) {
 		t.Close()
 		return nil, errors.New("io_target_pid map missing")
 	}
-	var key uint32 = 0
-	val := uint32(pid)
-	if err := targetMap.Update(&key, &val, ebpf.UpdateAny); err != nil {
+	tf, err := resolveTarget(pid)
+	if err != nil {
+		t.Close()
+		return nil, err
+	}
+	if err := writeTargetFilter(targetMap, tf); err != nil {
 		t.Close()
 		return nil, fmt.Errorf("set io_target_pid: %w", err)
 	}

--- a/internal/bpf/io.go
+++ b/internal/bpf/io.go
@@ -62,7 +62,7 @@ func OpenIOTracer(pid int) (*IOTracer, error) {
 	}
 	t := &IOTracer{coll: coll}
 
-	// Set target_pid
+	// Set the target filter
 	targetMap := coll.Maps["io_target_pid"]
 	if targetMap == nil {
 		t.Close()

--- a/internal/bpf/memory.go
+++ b/internal/bpf/memory.go
@@ -56,9 +56,12 @@ func OpenMemoryTracer(pid int) (*MemoryTracer, error) {
 		t.Close()
 		return nil, errors.New("mem_target_pid map missing")
 	}
-	var key uint32 = 0
-	val := uint32(pid)
-	if err := targetMap.Update(&key, &val, ebpf.UpdateAny); err != nil {
+	tf, err := resolveTarget(pid)
+	if err != nil {
+		t.Close()
+		return nil, err
+	}
+	if err := writeTargetFilter(targetMap, tf); err != nil {
 		t.Close()
 		return nil, fmt.Errorf("set mem_target_pid: %w", err)
 	}

--- a/internal/bpf/network.go
+++ b/internal/bpf/network.go
@@ -89,9 +89,12 @@ func OpenNetTracer(pid int) (*NetTracer, error) {
 		t.Close()
 		return nil, errors.New("net_target_pid map missing")
 	}
-	var key uint32 = 0
-	val := uint32(pid)
-	if err := targetMap.Update(&key, &val, ebpf.UpdateAny); err != nil {
+	tf, err := resolveTarget(pid)
+	if err != nil {
+		t.Close()
+		return nil, err
+	}
+	if err := writeTargetFilter(targetMap, tf); err != nil {
 		t.Close()
 		return nil, fmt.Errorf("set net_target_pid: %w", err)
 	}

--- a/internal/bpf/programs/cpu.bpf.c
+++ b/internal/bpf/programs/cpu.bpf.c
@@ -17,13 +17,14 @@
 
 #include <linux/bpf.h>
 #include <bpf/bpf_helpers.h>
+#include "target.bpf.h"
 
 char LICENSE[] SEC("license") = "GPL";
 
 struct {
     __uint(type, BPF_MAP_TYPE_ARRAY);
     __type(key, __u32);
-    __type(value, __u32);
+    __type(value, struct target_filter);
     __uint(max_entries, 1);
 } cpu_target_pid SEC(".maps");
 
@@ -37,16 +38,10 @@ struct {
 SEC("perf_event")
 int handle_perf_event(void *ctx)
 {
+    if (!pid_is_target(&cpu_target_pid))
+        return 0;
+
     __u32 key = 0;
-    __u32 *target = bpf_map_lookup_elem(&cpu_target_pid, &key);
-    if (!target || *target == 0)
-        return 0;
-
-    __u64 pid_tgid = bpf_get_current_pid_tgid();
-    __u32 tgid = (__u32)(pid_tgid >> 32);
-    if (tgid != *target)
-        return 0;
-
     __u64 *count = bpf_map_lookup_elem(&cpu_target_samples, &key);
     if (count)
         __sync_fetch_and_add(count, 1);

--- a/internal/bpf/programs/cpu.bpf.c
+++ b/internal/bpf/programs/cpu.bpf.c
@@ -3,13 +3,14 @@
 // cpu.bpf.c — CPU sampling of the target PID via perf_event at 100Hz per CPU.
 //
 // Maps:
-//   cpu_target_pid       ARRAY[1]  target pid (written by the Go loader)
+//   cpu_target_pid       ARRAY[1]  struct target_filter (written by the Go loader)
 //   cpu_target_samples   ARRAY[1]  accumulated counter of samples where the
 //                                   target was on-CPU
 //
 // The Go loader opens a PERF_TYPE_SOFTWARE/PERF_COUNT_SW_CPU_CLOCK perf_event
 // with sample_freq=100 on each CPU. Each time the kernel fires a sample,
-// if the current tgid == target_pid, the counter is incremented.
+// if the current task is the target — resolved within its PID namespace via
+// pid_is_target() (see target.bpf.h) — the counter is incremented.
 //
 // % computation on the Go side:
 //   delta_samples / (sample_freq × elapsed_seconds × NCPU) × 100 = % of

--- a/internal/bpf/programs/futex.bpf.c
+++ b/internal/bpf/programs/futex.bpf.c
@@ -10,7 +10,7 @@
 //   serializing.
 //
 // Maps:
-//   futex_target_pid    ARRAY[1]  target pid (written by the Go loader)
+//   futex_target_pid    ARRAY[1]  struct target_filter (written by the Go loader)
 //   futex_inflight      HASH      tgid_pid → {uaddr, op, ts_ns}
 //                                 correlates enter→exit to compute
 //                                 per-call latency
@@ -25,6 +25,7 @@
 
 #include <linux/bpf.h>
 #include <bpf/bpf_helpers.h>
+#include "target.bpf.h"
 
 char LICENSE[] SEC("license") = "GPL";
 
@@ -82,7 +83,7 @@ struct futex_stat {
 struct {
     __uint(type, BPF_MAP_TYPE_ARRAY);
     __type(key, __u32);
-    __type(value, __u32);
+    __type(value, struct target_filter);
     __uint(max_entries, 1);
 } futex_target_pid SEC(".maps");
 
@@ -102,13 +103,7 @@ struct {
 
 static __always_inline int is_futex_target(void)
 {
-    __u32 key = 0;
-    __u32 *target = bpf_map_lookup_elem(&futex_target_pid, &key);
-    if (!target || *target == 0)
-        return 0;
-    __u64 pid_tgid = bpf_get_current_pid_tgid();
-    __u32 tgid = (__u32)(pid_tgid >> 32);
-    return tgid == *target;
+    return pid_is_target(&futex_target_pid);
 }
 
 static __always_inline int is_wait_op(__u32 op)

--- a/internal/bpf/programs/io.bpf.c
+++ b/internal/bpf/programs/io.bpf.c
@@ -4,7 +4,7 @@
 // of the target PID, measures per-call latency and emits events via ring buffer.
 //
 // Maps:
-//   io_target_pid       ARRAY[1]   target pid (written by the Go loader)
+//   io_target_pid       ARRAY[1]   struct target_filter (written by the Go loader)
 //   io_inflight_map     HASH       tgid_pid → {ts_ns, fd, op, count_req}
 //                                  tracks an in-flight syscall to correlate
 //                                  enter/exit
@@ -23,6 +23,7 @@
 
 #include <linux/bpf.h>
 #include <bpf/bpf_helpers.h>
+#include "target.bpf.h"
 
 char LICENSE[] SEC("license") = "GPL";
 
@@ -75,7 +76,7 @@ struct io_event {
 struct {
     __uint(type, BPF_MAP_TYPE_ARRAY);
     __type(key, __u32);
-    __type(value, __u32);
+    __type(value, struct target_filter);
     __uint(max_entries, 1);
 } io_target_pid SEC(".maps");
 
@@ -93,13 +94,7 @@ struct {
 
 static __always_inline int is_io_target(void)
 {
-    __u32 key = 0;
-    __u32 *target = bpf_map_lookup_elem(&io_target_pid, &key);
-    if (!target || *target == 0)
-        return 0;
-    __u64 pid_tgid = bpf_get_current_pid_tgid();
-    __u32 tgid = (__u32)(pid_tgid >> 32);
-    return tgid == *target;
+    return pid_is_target(&io_target_pid);
 }
 
 static __always_inline void enter_io(__u32 op, __u32 fd, __u64 count)

--- a/internal/bpf/programs/memory.bpf.c
+++ b/internal/bpf/programs/memory.bpf.c
@@ -10,12 +10,12 @@
 // Why kprobe handle_mm_fault and not the exceptions:page_fault_user tracepoint?
 //   exceptions:page_fault_user is x86-only (lives in arch/x86/). handle_mm_fault
 //   is the canonical function in mm/memory.c, exists on every Linux arch, is
-//   called in process context and bpf_get_current_pid_tgid() works.
+//   called in process context where the pid filter works.
 //   Trade-off: the kprobe can fail if the kernel has the symbol inlined or
 //   renamed (rare for handle_mm_fault). The Go loader treats it as a warning.
 //
 // Maps:
-//   mem_target_pid    ARRAY[1]  target pid (written by the Go loader)
+//   mem_target_pid    ARRAY[1]  struct target_filter (written by the Go loader)
 //   mem_counters      ARRAY[1]  struct {page_faults, mmaps, munmaps, brks}
 //
 // RSS is NOT sampled here — /proc/<pid>/statm is cheap and stable; doing RSS
@@ -26,6 +26,7 @@
 #include <linux/ptrace.h>
 #include <bpf/bpf_helpers.h>
 #include <bpf/bpf_tracing.h>
+#include "target.bpf.h"
 
 char LICENSE[] SEC("license") = "GPL";
 
@@ -39,7 +40,7 @@ struct mem_counters {
 struct {
     __uint(type, BPF_MAP_TYPE_ARRAY);
     __type(key, __u32);
-    __type(value, __u32);
+    __type(value, struct target_filter);
     __uint(max_entries, 1);
 } mem_target_pid SEC(".maps");
 
@@ -52,13 +53,7 @@ struct {
 
 static __always_inline int is_mem_target(void)
 {
-    __u32 key = 0;
-    __u32 *target = bpf_map_lookup_elem(&mem_target_pid, &key);
-    if (!target || *target == 0)
-        return 0;
-    __u64 pid_tgid = bpf_get_current_pid_tgid();
-    __u32 tgid = (__u32)(pid_tgid >> 32);
-    return tgid == *target;
+    return pid_is_target(&mem_target_pid);
 }
 
 static __always_inline struct mem_counters *get_counters(void)

--- a/internal/bpf/programs/network.bpf.c
+++ b/internal/bpf/programs/network.bpf.c
@@ -16,21 +16,22 @@
 // of the sock.
 //
 // Maps:
-//   net_target_pid   ARRAY[1]  target pid (written by the Go loader)
+//   net_target_pid   ARRAY[1]  struct target_filter (written by the Go loader)
 //   net_conn_map     HASH      net_key → net_val (state, RTT, tx/rx bytes)
 //   sock_to_key      HASH      sock_ptr → net_key (correlation)
 //
 // Limitations:
 //   - Pre-existing connections (opened before ptop attached) don't enter
 //     sock_to_key, so tx/rx stay 0 for them. New connections work.
-//   - bpf_get_current_pid_tgid() in softirq returns the interrupted task —
-//     may skip or misattribute on transitions in the softirq path.
+//   - the pid filter resolves the *current* task; in softirq that is the
+//     interrupted task, so it may skip or misattribute on the softirq path.
 //     tcp_sendmsg/cleanup_rbuf run in process context, so OK.
 
 #include <linux/bpf.h>
 #include <linux/ptrace.h>
 #include <bpf/bpf_helpers.h>
 #include <bpf/bpf_tracing.h>
+#include "target.bpf.h"
 
 char LICENSE[] SEC("license") = "GPL";
 
@@ -87,7 +88,7 @@ struct net_val {
 struct {
     __uint(type, BPF_MAP_TYPE_ARRAY);
     __type(key, __u32);
-    __type(value, __u32);
+    __type(value, struct target_filter);
     __uint(max_entries, 1);
 } net_target_pid SEC(".maps");
 
@@ -109,13 +110,7 @@ struct {
 
 static __always_inline int is_net_target(void)
 {
-    __u32 key = 0;
-    __u32 *target = bpf_map_lookup_elem(&net_target_pid, &key);
-    if (!target || *target == 0)
-        return 0;
-    __u64 pid_tgid = bpf_get_current_pid_tgid();
-    __u32 tgid = (__u32)(pid_tgid >> 32);
-    return tgid == *target;
+    return pid_is_target(&net_target_pid);
 }
 
 SEC("tracepoint/sock/inet_sock_set_state")

--- a/internal/bpf/programs/syscalls.bpf.c
+++ b/internal/bpf/programs/syscalls.bpf.c
@@ -4,7 +4,7 @@
 // raw_syscalls of the target PID.
 //
 // Maps:
-//   target_pid     ARRAY[1]  target pid (written by the Go loader via map.Update)
+//   target_pid     ARRAY[1]  struct target_filter (written by the Go loader)
 //   syscall_count  HASH      syscall_id → {count, total_lat_ns}
 //   enter_ts       HASH      tgid_pid → {ts_ns, syscall_id}
 //                            correlates enter→exit to compute latency

--- a/internal/bpf/programs/syscalls.bpf.c
+++ b/internal/bpf/programs/syscalls.bpf.c
@@ -20,6 +20,7 @@
 
 #include <linux/bpf.h>
 #include <bpf/bpf_helpers.h>
+#include "target.bpf.h"
 
 char LICENSE[] SEC("license") = "GPL";
 
@@ -52,7 +53,7 @@ struct enter_data {
 struct {
     __uint(type, BPF_MAP_TYPE_ARRAY);
     __type(key, __u32);
-    __type(value, __u32);
+    __type(value, struct target_filter);
     __uint(max_entries, 1);
 } target_pid SEC(".maps");
 
@@ -70,16 +71,11 @@ struct {
     __uint(max_entries, 10240);
 } enter_ts SEC(".maps");
 
-// is_target returns 1 if the current tgid is the configured target pid, 0 otherwise.
+// is_target returns 1 if the current task belongs to the target process,
+// resolving pids inside the target's PID namespace (see target.bpf.h).
 static __always_inline int is_target(void)
 {
-    __u32 key = 0;
-    __u32 *target = bpf_map_lookup_elem(&target_pid, &key);
-    if (!target || *target == 0)
-        return 0;
-    __u64 pid_tgid = bpf_get_current_pid_tgid();
-    __u32 tgid = (__u32)(pid_tgid >> 32);
-    return tgid == *target;
+    return pid_is_target(&target_pid);
 }
 
 SEC("tracepoint/raw_syscalls/sys_enter")

--- a/internal/bpf/programs/target.bpf.h
+++ b/internal/bpf/programs/target.bpf.h
@@ -1,0 +1,52 @@
+/* SPDX-License-Identifier: GPL-2.0 */
+/*
+ * target.bpf.h — namespace-aware target-process filter shared by every
+ * ptop eBPF program.
+ *
+ * bpf_get_current_pid_tgid() returns PIDs in the INITIAL pid namespace.
+ * ptop's --pid is a namespace-local PID (what /proc and ps show). Under a
+ * nested pid namespace (WSL2, Docker, LXC) the two differ, so the old
+ * `tgid == target` comparison never matched. bpf_get_ns_current_pid_tgid()
+ * (kernel 5.7+) projects the current task's pid into a specific namespace,
+ * identified by the (dev, ino) of /proc/<pid>/ns/pid.
+ */
+#ifndef PTOP_TARGET_BPF_H
+#define PTOP_TARGET_BPF_H
+
+#include <linux/bpf.h>
+#include <bpf/bpf_helpers.h>
+
+/* Written by the Go loader (see internal/bpf/target.go). dev+ino identify
+ * the target's PID namespace; pid is the target tgid within that namespace. */
+struct target_filter {
+    __u32 pid;
+    __u32 _pad;
+    __u64 dev;
+    __u64 ino;
+};
+
+/* pid_target_ns resolves the current task's pid/tgid inside the target's
+ * namespace and writes them into *out. Returns 1 when the current task is
+ * the target process, 0 otherwise. target_map is an ARRAY[1] of
+ * struct target_filter. */
+static __always_inline int pid_target_ns(void *target_map,
+                                          struct bpf_pidns_info *out)
+{
+    __u32 key = 0;
+    struct target_filter *tf = bpf_map_lookup_elem(target_map, &key);
+    if (!tf || tf->pid == 0)
+        return 0;
+    if (bpf_get_ns_current_pid_tgid(tf->dev, tf->ino, out, sizeof(*out)) != 0)
+        return 0;
+    return out->tgid == tf->pid;
+}
+
+/* pid_is_target returns 1 when the current task belongs to the target
+ * process. Use this anywhere the old is_*_target() helpers were used. */
+static __always_inline int pid_is_target(void *target_map)
+{
+    struct bpf_pidns_info ns = {};
+    return pid_target_ns(target_map, &ns);
+}
+
+#endif /* PTOP_TARGET_BPF_H */

--- a/internal/bpf/programs/threads.bpf.c
+++ b/internal/bpf/programs/threads.bpf.c
@@ -60,6 +60,8 @@ struct {
 
 // root2ns maps a root-namespace TID to the target's namespace-local TID.
 // Self-populated from the `prev` side of sched_switch; LRU evicts dead TIDs.
+// Only target-process threads are ever inserted, so 8192 entries comfortably
+// covers any realistic thread count.
 struct {
     __uint(type, BPF_MAP_TYPE_LRU_HASH);
     __type(key, __u32);

--- a/internal/bpf/programs/threads.bpf.c
+++ b/internal/bpf/programs/threads.bpf.c
@@ -10,25 +10,23 @@
 //   exactly what the kernel measured, in real time.
 //
 // Maps:
-//   threads_target_pid  ARRAY[1]  target pid (written by the Go loader)
-//   tracked_tids        HASH      TID → 1, populated periodically by
-//                                 user-space (Go walks /proc/<pid>/task/).
-//                                 Required because sched_switch fires
-//                                 GLOBALLY — filtering only by prev_pid
-//                                 would miss the "next ON-CPU" event.
-//   tid_state           HASH      TID → {last_on_ns, last_off_ns,
-//                                 on_cpu_ns_total, off_cpu_ns_total,
-//                                 ctx_switches}
+//   threads_target_pid  ARRAY[1]   struct target_filter (written by Go)
+//   root2ns             LRU_HASH   root-ns tid → namespace-local tid
+//   tid_state           HASH       ns-local tid → struct thread_state
 //
-// Filtering:
-//   Instead of bpf_get_current_pid_tgid() (which is reliable in syscall
-//   context, but in sched_switch `current` is prev and isn't always the
-//   target), we use a TID whitelist (`tracked_tids`) updated by the Go
-//   side every ~1s. Threads that are born/die within that interval may
-//   miss switches; acceptable for the UI.
+// PID-namespace handling:
+//   sched_switch delivers prev_pid/next_pid as ROOT-namespace TIDs, but the
+//   Go side and tid_state work in the target's namespace-local TIDs. At the
+//   tracepoint `current` == prev, so pid_target_ns() resolves prev's
+//   namespace-local tid; that {root_tid → ns_tid} pair is cached in root2ns.
+//   The `next` side then recovers the ns-local tid by looking up next_pid in
+//   root2ns (learned the previous time that thread was scheduled out). A
+//   brand-new thread is learned the first time it is `prev` — one context
+//   switch of warm-up, which the UI tolerates.
 
 #include <linux/bpf.h>
 #include <bpf/bpf_helpers.h>
+#include "target.bpf.h"
 
 char LICENSE[] SEC("license") = "GPL";
 
@@ -56,16 +54,18 @@ struct thread_state {
 struct {
     __uint(type, BPF_MAP_TYPE_ARRAY);
     __type(key, __u32);
-    __type(value, __u32);
+    __type(value, struct target_filter);
     __uint(max_entries, 1);
 } threads_target_pid SEC(".maps");
 
+// root2ns maps a root-namespace TID to the target's namespace-local TID.
+// Self-populated from the `prev` side of sched_switch; LRU evicts dead TIDs.
 struct {
-    __uint(type, BPF_MAP_TYPE_HASH);
+    __uint(type, BPF_MAP_TYPE_LRU_HASH);
     __type(key, __u32);
-    __type(value, __u8);
+    __type(value, __u32);
     __uint(max_entries, 8192);
-} tracked_tids SEC(".maps");
+} root2ns SEC(".maps");
 
 struct {
     __uint(type, BPF_MAP_TYPE_HASH);
@@ -73,11 +73,6 @@ struct {
     __type(value, struct thread_state);
     __uint(max_entries, 8192);
 } tid_state SEC(".maps");
-
-static __always_inline int is_tracked(__u32 tid)
-{
-    return bpf_map_lookup_elem(&tracked_tids, &tid) != NULL;
-}
 
 // Get-or-create entry in tid_state. Returns ptr (always non-null on success).
 // On update failure (pathological case), returns NULL.
@@ -96,10 +91,15 @@ int handle_sched_switch(struct sched_switch_args *ctx)
 {
     __u64 now = bpf_ktime_get_ns();
 
-    // prev_pid is leaving CPU
-    __u32 prev_tid = (__u32)ctx->prev_pid;
-    if (prev_tid != 0 && is_tracked(prev_tid)) {
-        struct thread_state *s = get_or_create_state(prev_tid);
+    // prev == current at sched_switch. If it belongs to the target process,
+    // cache its root→ns TID mapping and do off-CPU accounting.
+    struct bpf_pidns_info ns = {};
+    if (pid_target_ns(&threads_target_pid, &ns)) {
+        __u32 root_tid = (__u32)ctx->prev_pid;
+        __u32 ns_tid = ns.pid;
+        bpf_map_update_elem(&root2ns, &root_tid, &ns_tid, BPF_ANY);
+
+        struct thread_state *s = get_or_create_state(ns_tid);
         if (s) {
             if (s->last_on_cpu_ns != 0) {
                 __u64 delta = now - s->last_on_cpu_ns;
@@ -110,10 +110,12 @@ int handle_sched_switch(struct sched_switch_args *ctx)
         }
     }
 
-    // next_pid is entering CPU
-    __u32 next_tid = (__u32)ctx->next_pid;
-    if (next_tid != 0 && is_tracked(next_tid)) {
-        struct thread_state *s = get_or_create_state(next_tid);
+    // next entering CPU: recover its ns-local TID from root2ns (learned the
+    // last time it was scheduled out).
+    __u32 next_root = (__u32)ctx->next_pid;
+    __u32 *next_ns = bpf_map_lookup_elem(&root2ns, &next_root);
+    if (next_ns) {
+        struct thread_state *s = get_or_create_state(*next_ns);
         if (s) {
             if (s->last_off_cpu_ns != 0) {
                 __u64 delta = now - s->last_off_cpu_ns;

--- a/internal/bpf/syscalls.go
+++ b/internal/bpf/syscalls.go
@@ -72,9 +72,12 @@ func OpenSyscallTracer(pid int) (*SyscallTracer, error) {
 		t.Close()
 		return nil, errors.New("target_pid map not found in BPF object")
 	}
-	var key uint32 = 0
-	val := uint32(pid)
-	if err := targetMap.Update(&key, &val, ebpf.UpdateAny); err != nil {
+	tf, err := resolveTarget(pid)
+	if err != nil {
+		t.Close()
+		return nil, err
+	}
+	if err := writeTargetFilter(targetMap, tf); err != nil {
 		t.Close()
 		return nil, fmt.Errorf("set target_pid: %w", err)
 	}

--- a/internal/bpf/target.go
+++ b/internal/bpf/target.go
@@ -1,0 +1,41 @@
+//go:build linux && ebpf
+
+package bpf
+
+import (
+	"fmt"
+
+	"github.com/cilium/ebpf"
+	"golang.org/x/sys/unix"
+)
+
+// targetFilter mirrors `struct target_filter` in programs/target.bpf.h
+// byte-for-byte (24 bytes: u32 pid, u32 pad, u64 dev, u64 ino).
+type targetFilter struct {
+	Pid uint32
+	_   uint32
+	Dev uint64
+	Ino uint64
+}
+
+// resolveTarget builds the filter for pid: its tgid plus the device and
+// inode of the PID namespace it lives in (/proc/<pid>/ns/pid).
+//
+// On a native host in the root namespace this resolves to the initial PID
+// namespace, so the BPF-side bpf_get_ns_current_pid_tgid() call returns the
+// same values bpf_get_current_pid_tgid() returned before — identical
+// behavior. Inside a nested namespace (WSL2, containers) it resolves to that
+// namespace, which is what makes the filter match.
+func resolveTarget(pid int) (targetFilter, error) {
+	var st unix.Stat_t
+	if err := unix.Stat(fmt.Sprintf("/proc/%d/ns/pid", pid), &st); err != nil {
+		return targetFilter{}, fmt.Errorf("stat pid namespace of %d: %w", pid, err)
+	}
+	return targetFilter{Pid: uint32(pid), Dev: st.Dev, Ino: st.Ino}, nil
+}
+
+// writeTargetFilter stores the resolved filter at key 0 of an ARRAY[1] map.
+func writeTargetFilter(m *ebpf.Map, tf targetFilter) error {
+	var key uint32 = 0
+	return m.Update(&key, &tf, ebpf.UpdateAny)
+}

--- a/internal/bpf/target_test.go
+++ b/internal/bpf/target_test.go
@@ -9,10 +9,19 @@ import (
 )
 
 // The Go targetFilter must match `struct target_filter` in target.bpf.h
-// byte-for-byte, or the loader writes garbage into the BPF map.
-func TestTargetFilterSize(t *testing.T) {
-	if got := unsafe.Sizeof(targetFilter{}); got != 24 {
+// byte-for-byte, or the loader writes garbage into the BPF map. Size alone
+// is not enough — field offsets must match too, since the kernel reads the
+// struct verbatim.
+func TestTargetFilterLayout(t *testing.T) {
+	var tf targetFilter
+	if got := unsafe.Sizeof(tf); got != 24 {
 		t.Fatalf("sizeof(targetFilter) = %d, want 24", got)
+	}
+	if got := unsafe.Offsetof(tf.Dev); got != 8 {
+		t.Fatalf("offsetof(targetFilter.Dev) = %d, want 8", got)
+	}
+	if got := unsafe.Offsetof(tf.Ino); got != 16 {
+		t.Fatalf("offsetof(targetFilter.Ino) = %d, want 16", got)
 	}
 }
 
@@ -33,6 +42,8 @@ func TestResolveTargetSelf(t *testing.T) {
 }
 
 func TestResolveTargetMissingPID(t *testing.T) {
+	// 0x7fffffff exceeds Linux's hard cap on pid_max (PID_MAX_LIMIT = 4194304),
+	// so this PID is guaranteed not to exist on any kernel.
 	if _, err := resolveTarget(0x7fffffff); err == nil {
 		t.Error("resolveTarget(nonexistent pid) = nil error, want failure")
 	}

--- a/internal/bpf/target_test.go
+++ b/internal/bpf/target_test.go
@@ -1,0 +1,39 @@
+//go:build linux && ebpf
+
+package bpf
+
+import (
+	"os"
+	"testing"
+	"unsafe"
+)
+
+// The Go targetFilter must match `struct target_filter` in target.bpf.h
+// byte-for-byte, or the loader writes garbage into the BPF map.
+func TestTargetFilterSize(t *testing.T) {
+	if got := unsafe.Sizeof(targetFilter{}); got != 24 {
+		t.Fatalf("sizeof(targetFilter) = %d, want 24", got)
+	}
+}
+
+func TestResolveTargetSelf(t *testing.T) {
+	tf, err := resolveTarget(os.Getpid())
+	if err != nil {
+		t.Fatalf("resolveTarget(self): %v", err)
+	}
+	if tf.Pid != uint32(os.Getpid()) {
+		t.Errorf("Pid = %d, want %d", tf.Pid, os.Getpid())
+	}
+	if tf.Dev == 0 {
+		t.Error("Dev = 0, want the nsfs device number")
+	}
+	if tf.Ino == 0 {
+		t.Error("Ino = 0, want the pid-namespace inode")
+	}
+}
+
+func TestResolveTargetMissingPID(t *testing.T) {
+	if _, err := resolveTarget(0x7fffffff); err == nil {
+		t.Error("resolveTarget(nonexistent pid) = nil error, want failure")
+	}
+}

--- a/internal/bpf/threads.go
+++ b/internal/bpf/threads.go
@@ -91,6 +91,11 @@ func OpenThreadsTracer(pid int) (*ThreadsTracer, error) {
 // PruneDeadTIDs deletes tid_state entries for TIDs no longer alive, so a
 // recycled TID does not inherit stale counters. `live` holds the
 // namespace-local TIDs currently present under /proc/<pid>/task/.
+//
+// The root2ns map is intentionally left unpruned: it is an LRU_HASH that
+// evicts dead entries on its own, and a stale entry at worst produces a
+// tid_state row the collector never publishes (it only emits TIDs found
+// under /proc/<pid>/task/).
 func (t *ThreadsTracer) PruneDeadTIDs(live []int) error {
 	if t == nil || t.stateMap == nil {
 		return errors.New("tracer not initialized")
@@ -103,7 +108,7 @@ func (t *ThreadsTracer) PruneDeadTIDs(live []int) error {
 	}
 	var dead []uint32
 	var k uint32
-	var v ThreadState
+	var v ThreadState // unused; the Iterate API requires a value pointer
 	iter := t.stateMap.Iterate()
 	for iter.Next(&k, &v) {
 		if _, ok := alive[k]; !ok {

--- a/internal/bpf/threads.go
+++ b/internal/bpf/threads.go
@@ -26,14 +26,12 @@ type ThreadState struct {
 	CtxSwitches   uint64
 }
 
-// ThreadsTracer loads threads.bpf.o, attaches sched:sched_switch, and
-// exposes Stats() to read tid_state + UpdateTrackedTIDs() to update the
-// set of TIDs the BPF program should track.
+// ThreadsTracer loads threads.bpf.o, attaches sched:sched_switch, and exposes
+// Stats() to read tid_state (keyed by the target's namespace-local TIDs).
 type ThreadsTracer struct {
-	coll        *ebpf.Collection
-	link        link.Link
-	stateMap    *ebpf.Map
-	trackedMap  *ebpf.Map
+	coll     *ebpf.Collection
+	link     link.Link
+	stateMap *ebpf.Map
 }
 
 func OpenThreadsTracer(pid int) (*ThreadsTracer, error) {
@@ -59,18 +57,20 @@ func OpenThreadsTracer(pid int) (*ThreadsTracer, error) {
 		t.Close()
 		return nil, errors.New("threads_target_pid map missing")
 	}
-	var key uint32 = 0
-	val := uint32(pid)
-	if err := targetMap.Update(&key, &val, ebpf.UpdateAny); err != nil {
+	tf, err := resolveTarget(pid)
+	if err != nil {
+		t.Close()
+		return nil, err
+	}
+	if err := writeTargetFilter(targetMap, tf); err != nil {
 		t.Close()
 		return nil, fmt.Errorf("set threads_target_pid: %w", err)
 	}
 
 	t.stateMap = coll.Maps["tid_state"]
-	t.trackedMap = coll.Maps["tracked_tids"]
-	if t.stateMap == nil || t.trackedMap == nil {
+	if t.stateMap == nil {
 		t.Close()
-		return nil, errors.New("tid_state / tracked_tids map missing")
+		return nil, errors.New("tid_state map missing")
 	}
 
 	prog := coll.Programs["handle_sched_switch"]
@@ -88,51 +88,39 @@ func OpenThreadsTracer(pid int) (*ThreadsTracer, error) {
 	return t, nil
 }
 
-// UpdateTrackedTIDs syncs the tracked_tids map with the supplied slice.
-// Adds new TIDs and removes ones that disappeared. Called periodically by
-// the collector (Go side) — it already walks /proc/<pid>/task/ to collect
-// state/wchan.
-func (t *ThreadsTracer) UpdateTrackedTIDs(tids []int) error {
-	if t == nil || t.trackedMap == nil {
+// PruneDeadTIDs deletes tid_state entries for TIDs no longer alive, so a
+// recycled TID does not inherit stale counters. `live` holds the
+// namespace-local TIDs currently present under /proc/<pid>/task/.
+func (t *ThreadsTracer) PruneDeadTIDs(live []int) error {
+	if t == nil || t.stateMap == nil {
 		return errors.New("tracer not initialized")
 	}
-	desired := make(map[uint32]struct{}, len(tids))
-	for _, tid := range tids {
+	alive := make(map[uint32]struct{}, len(live))
+	for _, tid := range live {
 		if tid > 0 {
-			desired[uint32(tid)] = struct{}{}
+			alive[uint32(tid)] = struct{}{}
 		}
 	}
-
-	// List existing
-	existing := make(map[uint32]struct{}, len(desired))
+	var dead []uint32
 	var k uint32
-	var v uint8
-	iter := t.trackedMap.Iterate()
+	var v ThreadState
+	iter := t.stateMap.Iterate()
 	for iter.Next(&k, &v) {
-		existing[k] = struct{}{}
-	}
-
-	// Add missing
-	for tid := range desired {
-		if _, ok := existing[tid]; !ok {
-			one := uint8(1)
-			if err := t.trackedMap.Update(&tid, &one, ebpf.UpdateAny); err != nil {
-				return fmt.Errorf("add tid %d: %w", tid, err)
-			}
+		if _, ok := alive[k]; !ok {
+			dead = append(dead, k)
 		}
 	}
-	// Remove orphans
-	for tid := range existing {
-		if _, ok := desired[tid]; !ok {
-			_ = t.trackedMap.Delete(&tid)
-			// Also clear state so recycled TIDs don't inherit counters.
-			_ = t.stateMap.Delete(&tid)
-		}
+	if err := iter.Err(); err != nil {
+		return err
+	}
+	for i := range dead {
+		_ = t.stateMap.Delete(&dead[i])
 	}
 	return nil
 }
 
-// Stats returns a complete snapshot of the tid_state map.
+// Stats returns a complete snapshot of the tid_state map, keyed by the
+// target's namespace-local TIDs.
 func (t *ThreadsTracer) Stats() (map[uint32]ThreadState, error) {
 	if t == nil || t.stateMap == nil {
 		return nil, errors.New("tracer not initialized")
@@ -162,7 +150,6 @@ func (t *ThreadsTracer) Close() error {
 		t.coll.Close()
 		t.coll = nil
 		t.stateMap = nil
-		t.trackedMap = nil
 	}
 	return nil
 }

--- a/internal/bpf/threads_stub.go
+++ b/internal/bpf/threads_stub.go
@@ -17,7 +17,7 @@ type ThreadState struct {
 type ThreadsTracer struct{}
 
 func OpenThreadsTracer(int) (*ThreadsTracer, error)     { return nil, errThreadsStub }
-func (*ThreadsTracer) UpdateTrackedTIDs([]int) error    { return errThreadsStub }
+func (*ThreadsTracer) PruneDeadTIDs([]int) error        { return errThreadsStub }
 func (*ThreadsTracer) Stats() (map[uint32]ThreadState, error) {
 	return nil, errThreadsStub
 }

--- a/internal/collector/threads_ebpf.go
+++ b/internal/collector/threads_ebpf.go
@@ -27,7 +27,7 @@ import (
 // Lifecycle:
 //   - tick every 1s
 //   - read /proc/<pid>/task/ → collect state/wchan/name + list of live TIDs
-//   - sync tracked_tids in the BPF map (add new ones, remove stragglers)
+//   - prune tid_state for TIDs that have exited
 //   - read tid_state from BPF, compute deltas vs previous snapshot
 //   - publish []ThreadInfo
 type ThreadsEBPFCollector struct {
@@ -143,9 +143,9 @@ func (c *ThreadsEBPFCollector) collect() ([]ThreadInfo, error) {
 		tidList = append(tidList, tid)
 	}
 
-	// Sync tracked_tids in the BPF map.
-	if err := c.tracer.UpdateTrackedTIDs(tidList); err != nil {
-		// Not fatal: keep publishing /proc data even if the sync fails.
+	// Prune tid_state for threads that exited since the last tick.
+	if err := c.tracer.PruneDeadTIDs(tidList); err != nil {
+		// Not fatal: keep publishing /proc data even if the prune fails.
 		_ = err
 	}
 


### PR DESCRIPTION
## Summary

ptop's eBPF collectors went silent inside WSL2 — no CPU%, no syscalls. Root
cause: the eBPF programs filter the target process with
`bpf_get_current_pid_tgid()`, which returns PIDs in the **initial** PID
namespace, while ptop passes the **namespace-local** `--pid` (what `ps`/`top`/
`/proc` show). WSL2 runs the whole distro inside a nested PID namespace, so the
`tgid == target` comparison never matched and every eBPF collector recorded
nothing. CPU and syscalls have no `/proc` fallback, so those panels showed
empty; the rest looked populated only because of their `/proc`-derived data.
Same failure applies to Docker/LXC.

Diagnosed with an instrumented probe: BPF programs loaded, attached, and ran
(`sys_enter` fired 301k×), the `target_pid` map held the correct value, yet
`tgid == target` matched **0** times — the process's PID namespace was
`pid:[4026532221]`, not the kernel's initial `pid:[4026531836]`.

## What changed

- All **7** eBPF programs (cpu, syscalls, io, network, memory, futex, threads)
  now filter via **`bpf_get_ns_current_pid_tgid()`**, resolving PIDs inside the
  target's PID namespace (dev+inode of `/proc/<pid>/ns/pid`).
- Centralized in one shared C header (`internal/bpf/programs/target.bpf.h` —
  `struct target_filter`, `pid_is_target()`, `pid_target_ns()`) and one shared
  Go resolver (`internal/bpf/target.go` — `resolveTarget`/`writeTargetFilter`).
- `threads` (the non-mechanical case) is reworked without CO-RE: a
  self-populating `root2ns` LRU map recovers namespace-local TIDs from the
  `sched_switch` `prev` side; the `tracked_tids` whitelist is removed.
- New `cmd/ebpfselftest` + `make ebpf-selftest` — a root-only self-diagnostic.
- **No-op on native Linux in the root namespace**: `bpf_get_ns_current_pid_tgid()`
  with the initial namespace returns exactly what `bpf_get_current_pid_tgid()`
  did. macOS is untouched (eBPF code is `linux && ebpf` only).

Design + plan: `docs/superpowers/specs/2026-05-19-ebpf-pidns-fix-design.md`,
`docs/superpowers/plans/2026-05-19-ebpf-pidns-fix.md`.

## Test plan

Automated (CI, both lanes — native Linux / root namespace):
- [x] `go vet` / `go test -race` / `go build` — default and `-tags=ebpf`
- [x] `make gen` compiles all 7 `.bpf.c`
- [x] `target_test.go` asserts the `target_filter` C↔Go ABI (size + offsets)

Manual, needs root — **the real proof, please run on each setup**:
- [ ] **WSL2:** `make ebpf-selftest && sudo ./bin/ebpf-selftest` → `eBPF self-test PASSED`
- [ ] **native Linux:** same — `eBPF self-test PASSED` (no regression)
- [ ] `make build-ebpf && sudo ./bin/ptop --pid <busy-pid>` → F1 shows real
      CPU%, F2 populates syscalls, F4 shows per-thread CPU%, and the `?` overlay
      shows `real via eBPF` for all 7 subsystems
- [ ] (optional) inside a Docker container — same checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)