### PR TITLE
macos: socket Tx/Rx + F3 column, Tier 1 audit, and chrome-honesty follow-ups

### DIFF
--- a/assets/mockup.jsx
+++ b/assets/mockup.jsx
@@ -36,9 +36,9 @@ function useSimulatedData() {
   const [cpuHistory,       setCpuHistory]       = useState(()=>Array(60).fill(0).map(()=>Math.random()*30+5));
   const [syscallCounts,    setSyscallCounts]    = useState(()=>Object.fromEntries(SYSCALLS.map(s=>[s,Math.floor(Math.random()*200)])));
   const [netEvents,        setNetEvents]        = useState([
-    { id:1, type:"TCP",  remote:"10.0.1.5:5432",         state:"WAIT",        latency:42, dir:"→" },
-    { id:2, type:"TCP",  remote:"10.0.0.1:443",          state:"ESTABLISHED", latency:8,  dir:"↔" },
-    { id:3, type:"UNIX", remote:"/var/run/docker.sock",  state:"ESTABLISHED", latency:1,  dir:"→" },
+    { id:1, type:"TCP",  remote:"10.0.1.5:5432",         state:"WAIT",        latency:42, dir:"→", tx:12000,  rx:88000  },
+    { id:2, type:"TCP",  remote:"10.0.0.1:443",          state:"ESTABLISHED", latency:8,  dir:"↔", tx:480000, rx:500000 },
+    { id:3, type:"UNIX", remote:"/var/run/docker.sock",  state:"ESTABLISHED", latency:1,  dir:"→", tx:22000,  rx:22000  },
   ]);
   const [memStats,         setMemStats]         = useState({ rss:148, heap:92, pageFaults:14, allocs:320 });
   const [threads,          setThreads]          = useState([
@@ -240,17 +240,22 @@ function SyscallBars({ counts }) {
   );
 }
 
-function NetPanel({ events }) {
+// showTraffic adds the TX/RX column. Only the dedicated F3 view enables it;
+// the narrow F1 overview panel omits it to keep REMOTE readable. The TX/RX
+// reading is OS-dependent in the real TUI — cumulative bytes on Linux/eBPF,
+// current send/recv socket-buffer occupancy (a backlog gauge) on macOS.
+function NetPanel({ events, showTraffic }) {
   const sc=s=>s==="WAIT"?COLORS.amber:s==="RECV"?COLORS.cyan:s==="ESTABLISHED"?COLORS.green:COLORS.muted;
   return (
     <div style={{ padding:"4px 10px", display:"flex", flexDirection:"column", gap:4 }}>
-      <div style={{ display:"flex", fontSize:9, color:COLORS.muted, marginBottom:2 }}><span style={{ width:36 }}>TYPE</span><span style={{ flex:1 }}>REMOTE</span><span style={{ width:60 }}>STATE</span><span style={{ width:52, textAlign:"right" }}>LAT</span></div>
+      <div style={{ display:"flex", fontSize:9, color:COLORS.muted, marginBottom:2 }}><span style={{ width:36 }}>TYPE</span><span style={{ flex:1 }}>REMOTE</span><span style={{ width:60 }}>STATE</span><span style={{ width:52, textAlign:"right" }}>LAT</span>{showTraffic&&<span style={{ width:120, textAlign:"right" }}>TX/RX</span>}</div>
       {events.map(e=>(
         <div key={e.id} style={{ display:"flex", fontSize:10, color:COLORS.text, alignItems:"center" }}>
           <span style={{ width:36, color:COLORS.blue }}>{e.type}</span>
           <span style={{ flex:1, color:COLORS.bright }}>{e.dir} {e.remote}</span>
           <span style={{ width:60, color:sc(e.state) }}>{e.state}</span>
           <span style={{ width:52, textAlign:"right", color:e.latency>30?COLORS.amber:COLORS.green }}>{e.latency.toFixed(0)}ms</span>
+          {showTraffic&&<span style={{ width:120, textAlign:"right", color:COLORS.muted }}>↑{fmt(e.tx||0)} ↓{fmt(e.rx||0)}</span>}
         </div>
       ))}
     </div>
@@ -425,7 +430,7 @@ function NetworkView({ data }) {
   return (
     <div style={{ display:"flex", flex:1, gap:1, overflow:"hidden", padding:1 }}>
       <div style={{ display:"flex", flexDirection:"column", flex:2, gap:1 }}>
-        <Box title="▸ Active Connections" flex={1}><NetPanel events={data.netEvents}/></Box>
+        <Box title="▸ Active Connections" flex={1}><NetPanel events={data.netEvents} showTraffic/></Box>
         <Box title="▸ Latency Trend" flex={1.5}>
           <div style={{ padding:"8px 12px", display:"flex", flexDirection:"column", gap:10 }}>
             {data.netEvents.map(e=>{ const pct=Math.min(100,(e.latency/100)*100); const color=e.latency>30?COLORS.amber:COLORS.green; return (

--- a/internal/collector/collectors_darwin_test.go
+++ b/internal/collector/collectors_darwin_test.go
@@ -1,0 +1,128 @@
+//go:build darwin
+
+package collector
+
+import (
+	"os"
+	"testing"
+	"time"
+)
+
+// Integration smoke tests for the darwin collectors that previously had no
+// dedicated coverage. Each starts against this process and confirms a
+// correctly-typed message arrives within a deadline. They exercise the real
+// libproc path, not mocks.
+
+// recvWithin reads one message from ch or fails after d.
+func recvWithin(t *testing.T, ch <-chan interface{}, d time.Duration) interface{} {
+	t.Helper()
+	select {
+	case v := <-ch:
+		return v
+	case <-time.After(d):
+		t.Fatalf("no message within %s", d)
+		return nil
+	}
+}
+
+func TestMemCollector_self(t *testing.T) {
+	c := NewMemCollector()
+	if err := c.Start(os.Getpid()); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer c.Stop()
+
+	s, ok := recvWithin(t, c.Subscribe(), 3*time.Second).(MemStats)
+	if !ok {
+		t.Fatal("expected MemStats")
+	}
+	if s.RSSBytes == 0 {
+		t.Fatalf("self should have non-zero RSS, got %+v", s)
+	}
+	t.Logf("mem: rss=%d faults=%d allocs/s=%d", s.RSSBytes, s.PageFaults, s.AllocsPerS)
+}
+
+func TestThreadsCollector_self(t *testing.T) {
+	c := NewThreadsCollector()
+	if err := c.Start(os.Getpid()); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer c.Stop()
+
+	threads, ok := recvWithin(t, c.Subscribe(), 3*time.Second).([]ThreadInfo)
+	if !ok {
+		t.Fatal("expected []ThreadInfo")
+	}
+	if len(threads) == 0 {
+		t.Fatal("self should have at least one thread")
+	}
+	// State labels must be the canonical strings the F4 view colors on.
+	for _, th := range threads {
+		switch th.State {
+		case "running", "sleeping", "blocked", "stopped", "unknown":
+		default:
+			t.Fatalf("unexpected thread state label %q", th.State)
+		}
+	}
+	t.Logf("threads: %d (first=%q state=%q)", len(threads), threads[0].Name, threads[0].State)
+}
+
+func TestIOThroughputCollector_self(t *testing.T) {
+	c := NewIOThroughputCollector()
+	if err := c.Start(os.Getpid()); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer c.Stop()
+
+	s, ok := recvWithin(t, c.Subscribe(), 3*time.Second).(IOThroughputSample)
+	if !ok {
+		t.Fatal("expected IOThroughputSample")
+	}
+	if s.ReadBytesPerS < 0 || s.WriteBytesPerS < 0 {
+		t.Fatalf("throughput must be non-negative, got %+v", s)
+	}
+	t.Logf("io throughput: r=%.0fB/s w=%.0fB/s", s.ReadBytesPerS, s.WriteBytesPerS)
+}
+
+func TestIOWaitCollector_self(t *testing.T) {
+	c := NewIOWaitCollector()
+	if err := c.Start(os.Getpid()); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer c.Stop()
+
+	s, ok := recvWithin(t, c.Subscribe(), 3*time.Second).(IOWaitSample)
+	if !ok {
+		t.Fatal("expected IOWaitSample")
+	}
+	if s.Pct < 0 || s.Pct > 100 {
+		t.Fatalf("iowait %% out of range: %v", s.Pct)
+	}
+	t.Logf("iowait: %.1f%%", s.Pct)
+}
+
+func TestFDCollector_self(t *testing.T) {
+	c := NewFDCollector()
+	if err := c.Start(os.Getpid()); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer c.Stop()
+
+	// The collector emits FDEvent / TimelineEvent as well as the []FDEntry
+	// snapshot; loop until the snapshot arrives.
+	deadline := time.After(3 * time.Second)
+	for {
+		select {
+		case v := <-c.Subscribe():
+			if fds, ok := v.([]FDEntry); ok {
+				if len(fds) == 0 {
+					t.Fatal("self should have open FDs")
+				}
+				t.Logf("fds: %d entries (first type=%q desc=%q)", len(fds), fds[0].Type, fds[0].Desc)
+				return
+			}
+		case <-deadline:
+			t.Fatal("no []FDEntry snapshot within 3s")
+		}
+	}
+}

--- a/internal/collector/fds_darwin.go
+++ b/internal/collector/fds_darwin.go
@@ -22,10 +22,12 @@ import (
 //     Linux build is the only place this is real-time; both /proc and
 //     darwin fall back to "never active". Marking everything Active is
 //     misleading, so we mark nothing.
-//   - Bytes column is 0 for the same reason — we don't have a cumulative
-//     file-position equivalent. For TCP sockets the kernel exposes
-//     in/out byte counters via socket_info, but those need extra fields in
-//     the libproc wrapper; deferred to a follow-up.
+//   - Bytes column is 0: there's no cumulative file-position equivalent on
+//     macOS, and sockets are no exception — socket_info exposes only the
+//     current send/recv buffer occupancy (sbi_cc), not lifetime byte
+//     totals, so there's nothing cumulative to put here. The F3 view does
+//     surface that occupancy as a backlog gauge (NetConn.Tx/RxBytes); the
+//     F6 Bytes column stays 0 to avoid mixing a gauge into a counter slot.
 
 type FDCollector struct {
 	pid  int

--- a/internal/collector/iowait_darwin.go
+++ b/internal/collector/iowait_darwin.go
@@ -8,19 +8,25 @@ import (
 	"time"
 )
 
-// IOWaitCollector approximates per-process I/O-wait % by summing the
-// blocked-uninterruptible time across the process's threads.
+// IOWaitCollector approximates per-process I/O-wait % from the fraction of
+// the process's threads sitting in the uninterruptible-blocked state.
 //
 // macOS doesn't expose a `delayacct_blkio_ticks` equivalent in libproc, but
 // we can infer "thread is blocked on synchronous disk I/O" from
 // ProcPidThreadInfo.RunState == ThreadStateUninterruptible. That maps to
 // Linux 'D' state — the canonical signal for "waiting on disk".
 //
+// Each snapshot records blocked/total threads; the published % is that ratio
+// averaged over the publish window. Averaging the *fraction* (rather than
+// counting snapshots where any thread was blocked) avoids the multi-thread
+// bias where a single stuck thread in a 100-thread process would read as
+// 100% iowait.
+//
 // Caveats:
-//   - Imprecise: thread state is sampled instantaneously every 500ms; we
-//     get the fraction of samples in 'D', not the actual fraction of time.
-//     A thread that blocks for 100ms between samples is invisible.
-//   - For a coarse "is this process disk-bound right now?" indicator it's
+//   - Imprecise: thread state is sampled every 100ms, so we get the fraction
+//     of threads in 'D' at sample points, not the actual fraction of time.
+//     A thread that blocks for <100ms between samples is invisible.
+//   - For a coarse "how disk-bound is this process right now?" indicator it's
 //     useful; for accurate iowait accounting we'd need eBPF-grade tracing
 //     and macOS doesn't have the Tier 1 path for that.
 
@@ -30,9 +36,8 @@ type IOWaitCollector struct {
 	stop chan struct{}
 	mu   sync.Mutex
 
-	samples       int // total state snapshots taken since last publish
-	blockedHits   int // snapshots where at least one thread was in 'D'
-	lastPublishAt time.Time
+	samples     int     // total state snapshots taken since last publish
+	blockedFrac float64 // running sum of (blocked threads / total threads) per snapshot
 }
 
 func NewIOWaitCollector() *IOWaitCollector {
@@ -60,7 +65,6 @@ func (c *IOWaitCollector) loop() {
 	publishT := time.NewTicker(500 * time.Millisecond)
 	defer sampleT.Stop()
 	defer publishT.Stop()
-	c.lastPublishAt = time.Now()
 	for {
 		select {
 		case <-c.stop:
@@ -78,23 +82,25 @@ func (c *IOWaitCollector) snapshot() {
 	if err != nil {
 		return
 	}
-	anyBlocked := false
+	total := 0
+	blocked := 0
 	for _, tid := range tids {
 		info, err := ProcPidThreadInfo(c.pid, tid)
 		if err != nil {
-			continue
+			continue // thread may have exited between list and per-thread call
 		}
+		total++
 		if info.RunState == ThreadStateUninterruptible {
-			anyBlocked = true
-			break
+			blocked++
 		}
+	}
+	if total == 0 {
+		return
 	}
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	c.samples++
-	if anyBlocked {
-		c.blockedHits++
-	}
+	c.blockedFrac += float64(blocked) / float64(total)
 }
 
 func (c *IOWaitCollector) publish() {
@@ -102,11 +108,10 @@ func (c *IOWaitCollector) publish() {
 	now := time.Now()
 	var pct float64
 	if c.samples > 0 {
-		pct = float64(c.blockedHits) / float64(c.samples) * 100
+		pct = c.blockedFrac / float64(c.samples) * 100
 	}
 	c.samples = 0
-	c.blockedHits = 0
-	c.lastPublishAt = now
+	c.blockedFrac = 0
 	c.mu.Unlock()
 
 	select {

--- a/internal/collector/libproc_darwin.go
+++ b/internal/collector/libproc_darwin.go
@@ -84,6 +84,12 @@ static int wrap_proc_name(int pid, void *buf, uint32_t bufsize, int *out_errno) 
     return n;
 }
 
+static int wrap_proc_pidpath(int pid, void *buf, uint32_t bufsize, int *out_errno) {
+    int n = proc_pidpath(pid, buf, bufsize);
+    if (n <= 0) { *out_errno = errno; }
+    return n;
+}
+
 // inet_ntop for IPv4 / IPv6 addresses pulled from socket_fdinfo. Returns
 // length written or -1 on error.
 static int fmt_v4(const struct in_addr *a, char *out, size_t n) {
@@ -160,6 +166,19 @@ func ProcName(pid int) (string, error) {
 	n := C.wrap_proc_name(C.int(pid), unsafe.Pointer(&buf[0]), C.uint32_t(len(buf)), &cerrno)
 	if n <= 0 {
 		return "", fmt.Errorf("proc_name(%d): %w", pid, syscall.Errno(cerrno))
+	}
+	return string(buf[:n]), nil
+}
+
+// ProcPath returns the absolute executable path for pid via proc_pidpath —
+// the macOS equivalent of readlink(/proc/<pid>/exe). The buffer is sized to
+// PROC_PIDPATHINFO_MAXSIZE (4*MAXPATHLEN).
+func ProcPath(pid int) (string, error) {
+	var buf [4096]byte
+	var cerrno C.int
+	n := C.wrap_proc_pidpath(C.int(pid), unsafe.Pointer(&buf[0]), C.uint32_t(len(buf)), &cerrno)
+	if n <= 0 {
+		return "", fmt.Errorf("proc_pidpath(%d): %w", pid, syscall.Errno(cerrno))
 	}
 	return string(buf[:n]), nil
 }

--- a/internal/collector/libproc_darwin.go
+++ b/internal/collector/libproc_darwin.go
@@ -384,6 +384,16 @@ type LPSocketFDInfo struct {
 	TCPState   int32  // 0=CLOSED, 1=LISTEN, 2=SYN_SENT, 4=ESTABLISHED, etc — only valid when SockType=STREAM
 	LocalAddr  string
 	RemoteAddr string
+
+	// SndQueued / RcvQueued are the current send/receive socket-buffer
+	// occupancy in bytes (socket_info.soi_snd/soi_rcv.sbi_cc). This is the
+	// instantaneous backlog — NOT cumulative traffic. macOS libproc has no
+	// public cumulative byte counter for sockets, so this is the closest
+	// real signal: a growing SndQueued means the peer/network is draining
+	// slower than the process writes; a growing RcvQueued means the process
+	// is reading slower than data arrives.
+	SndQueued uint64
+	RcvQueued uint64
 }
 
 // TCP states (from <netinet/tcp_fsm.h>).
@@ -411,9 +421,11 @@ func FDSocketInfo(pid int, fd int32) (LPSocketFDInfo, error) {
 	}
 
 	out := LPSocketFDInfo{
-		Family:   int32(raw.psi.soi_family),
-		SockType: int32(raw.psi.soi_type),
-		Protocol: int32(raw.psi.soi_protocol),
+		Family:    int32(raw.psi.soi_family),
+		SockType:  int32(raw.psi.soi_type),
+		Protocol:  int32(raw.psi.soi_protocol),
+		SndQueued: uint64(raw.psi.soi_snd.sbi_cc),
+		RcvQueued: uint64(raw.psi.soi_rcv.sbi_cc),
 	}
 
 	// soi_proto is a union of in_sockinfo / un_sockinfo / tcp_sockinfo / ...

--- a/internal/collector/network_darwin.go
+++ b/internal/collector/network_darwin.go
@@ -13,12 +13,17 @@ import (
 // every second via proc_pidinfo(PROC_PIDLISTFDS) + proc_pidfdinfo
 // (PROC_PIDFDSOCKETINFO).
 //
-// Fields not populated (no public path on macOS):
-//   - LatencyMs (RTT): NEFilterDataProvider doesn't expose it; PKTAP-based
-//     inference needs a system extension. Stays 0.
-//   - TxBytes / RxBytes: socket_info has byte counters but they're not in
-//     our LPSocketFDInfo struct yet; leaving 0 for now and adding them in
-//     a follow-up if the F3 view's "Traffic" column gains importance.
+// Field semantics on darwin (differ from the Linux eBPF collector):
+//   - LatencyMs (RTT): no public path. NEFilterDataProvider doesn't expose
+//     it and PKTAP-based inference needs a system extension. Stays 0.
+//   - TxBytes / RxBytes: macOS libproc has NO cumulative per-socket byte
+//     counter. The only real signal is the current socket-buffer occupancy
+//     (socket_info.soi_snd/soi_rcv.sbi_cc), so TxBytes/RxBytes here are the
+//     bytes currently QUEUED in the send/receive buffers, not lifetime
+//     totals. A non-zero value means the kernel is holding data the peer
+//     (Tx) or the process (Rx) hasn't drained yet — useful as a backlog
+//     indicator, but the F3 "Traffic" column must be read as a gauge, not
+//     a counter. See LPSocketFDInfo.SndQueued/RcvQueued.
 //   - Dir (→/←/↔): inferred from local vs remote address presence.
 //
 // The label "eBPF" in the type name lies on darwin; the source string is
@@ -143,8 +148,9 @@ func socketToNetConn(fd int, s LPSocketFDInfo) NetConn {
 		State:     state,
 		Dir:       dir,
 		LatencyMs: 0,
-		TxBytes:   0,
-		RxBytes:   0,
+		// Queued buffer occupancy, not cumulative traffic — see file header.
+		TxBytes: s.SndQueued,
+		RxBytes: s.RcvQueued,
 	}
 }
 

--- a/internal/collector/network_darwin.go
+++ b/internal/collector/network_darwin.go
@@ -5,7 +5,6 @@ package collector
 import (
 	"fmt"
 	"sort"
-	"sync"
 	"time"
 )
 
@@ -34,7 +33,6 @@ type NetworkEBPFCollector struct {
 	pid  int
 	ch   chan interface{}
 	stop chan struct{}
-	mu   sync.Mutex
 }
 
 func NewNetworkEBPFCollector() *NetworkEBPFCollector {

--- a/internal/collector/network_darwin.go
+++ b/internal/collector/network_darwin.go
@@ -4,6 +4,7 @@ package collector
 
 import (
 	"fmt"
+	"sort"
 	"sync"
 	"time"
 )
@@ -101,7 +102,47 @@ func (c *NetworkEBPFCollector) collect() ([]NetConn, error) {
 		}
 		out = append(out, nc)
 	}
+
+	// A macOS process typically holds many idle UDP sockets bound to the
+	// wildcard address plus a few real connections. proc_pidinfo lists them
+	// in FD order, which buries the interesting ESTABLISHED connections at
+	// the bottom where the F3 panel's row limit clips them. Sort so the most
+	// useful rows surface first: connected (has a remote peer) before
+	// listeners/idle, TCP before UDP, then by remote for stable ordering.
+	sort.SliceStable(out, func(i, j int) bool {
+		if ri, rj := connRank(out[i]), connRank(out[j]); ri != rj {
+			return ri < rj
+		}
+		if out[i].Type != out[j].Type {
+			return typeRank(out[i].Type) < typeRank(out[j].Type)
+		}
+		return out[i].Remote < out[j].Remote
+	})
 	return out, nil
+}
+
+// connRank orders connections by usefulness: an active peer connection first,
+// then anything with a TCP state (e.g. a listener), then idle/unconnected.
+func connRank(c NetConn) int {
+	switch {
+	case c.Dir == "↔": // has a remote peer
+		return 0
+	case c.State != "": // TCP socket with a state but no peer (listener, etc.)
+		return 1
+	default: // unconnected UDP / wildcard
+		return 2
+	}
+}
+
+func typeRank(t string) int {
+	switch t {
+	case "TCP":
+		return 0
+	case "UDP":
+		return 1
+	default:
+		return 2
+	}
 }
 
 // socketToNetConn maps the libproc LPSocketFDInfo into the public NetConn

--- a/internal/collector/network_darwin_test.go
+++ b/internal/collector/network_darwin_test.go
@@ -47,6 +47,25 @@ func TestSocketToNetConn_queuedBytes(t *testing.T) {
 	}
 }
 
+// TestConnRank pins the F3 ordering: an active peer connection outranks a
+// listener, which outranks an idle/unconnected socket. macOS processes hold
+// many idle UDP wildcard sockets that would otherwise bury real connections.
+func TestConnRank(t *testing.T) {
+	connected := NetConn{Type: "TCP", Dir: "↔", State: "ESTABLISHED", Remote: "[fe80::1]:1024"}
+	listener := NetConn{Type: "TCP", Dir: "←", State: "LISTEN", Remote: "0.0.0.0:443"}
+	idleUDP := NetConn{Type: "UDP", Dir: "←", State: "", Remote: "0.0.0.0:0"}
+
+	if connRank(connected) >= connRank(listener) {
+		t.Fatalf("connected (%d) should rank before listener (%d)", connRank(connected), connRank(listener))
+	}
+	if connRank(listener) >= connRank(idleUDP) {
+		t.Fatalf("listener (%d) should rank before idle UDP (%d)", connRank(listener), connRank(idleUDP))
+	}
+	if typeRank("TCP") >= typeRank("UDP") {
+		t.Fatalf("TCP should rank before UDP")
+	}
+}
+
 // TestFDSocketInfo_queuedBytes_live drives the wrapper against a real TCP
 // connection. We stuff the sender's buffer without ever reading on the peer,
 // so bytes pile up in either the send or receive buffer; FDSocketInfo must

--- a/internal/collector/network_darwin_test.go
+++ b/internal/collector/network_darwin_test.go
@@ -1,0 +1,172 @@
+//go:build darwin
+
+package collector
+
+import (
+	"net"
+	"os"
+	"testing"
+	"time"
+)
+
+// TestSocketToNetConn_queuedBytes verifies that the socket-buffer occupancy
+// from libproc (SndQueued/RcvQueued) is surfaced on the F3 NetConn as
+// Tx/RxBytes. This is a gauge (current backlog), not a cumulative counter —
+// the mapping is what the test pins down.
+func TestSocketToNetConn_queuedBytes(t *testing.T) {
+	s := LPSocketFDInfo{
+		Family:     2, // AF_INET
+		SockType:   1, // SOCK_STREAM
+		TCPState:   TCPStateEstablished,
+		LocalAddr:  "127.0.0.1:5000",
+		RemoteAddr: "127.0.0.1:6000",
+		SndQueued:  4096,
+		RcvQueued:  1024,
+	}
+	nc := socketToNetConn(7, s)
+
+	if nc.Type != "TCP" {
+		t.Fatalf("Type = %q, want TCP", nc.Type)
+	}
+	if nc.State != "ESTABLISHED" {
+		t.Fatalf("State = %q, want ESTABLISHED", nc.State)
+	}
+	if nc.Dir != "↔" {
+		t.Fatalf("Dir = %q, want ↔ (has remote)", nc.Dir)
+	}
+	if nc.TxBytes != 4096 {
+		t.Fatalf("TxBytes = %d, want 4096 (from SndQueued)", nc.TxBytes)
+	}
+	if nc.RxBytes != 1024 {
+		t.Fatalf("RxBytes = %d, want 1024 (from RcvQueued)", nc.RxBytes)
+	}
+	// A listener (no remote) maps to the local bind and the "←" direction.
+	listener := LPSocketFDInfo{Family: 2, SockType: 1, TCPState: TCPStateListen, LocalAddr: "127.0.0.1:5000"}
+	if lnc := socketToNetConn(8, listener); lnc.Dir != "←" || lnc.Remote != "127.0.0.1:5000" {
+		t.Fatalf("listener mapping: Dir=%q Remote=%q, want ← / local bind", lnc.Dir, lnc.Remote)
+	}
+}
+
+// TestFDSocketInfo_queuedBytes_live drives the wrapper against a real TCP
+// connection. We stuff the sender's buffer without ever reading on the peer,
+// so bytes pile up in either the send or receive buffer; FDSocketInfo must
+// then report non-zero occupancy for at least one of the process's sockets.
+// Kernel buffering is timing-dependent, so this is best-effort: if nothing is
+// queued we log and skip rather than fail.
+func TestFDSocketInfo_queuedBytes_live(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Skipf("cannot listen: %v", err)
+	}
+	defer ln.Close()
+
+	conn, err := net.Dial("tcp", ln.Addr().String())
+	if err != nil {
+		t.Skipf("cannot dial: %v", err)
+	}
+	defer conn.Close()
+
+	// Accept but deliberately never read — the peer's receive buffer (and
+	// then our send buffer) fills up.
+	peer, err := ln.Accept()
+	if err != nil {
+		t.Skipf("cannot accept: %v", err)
+	}
+	defer peer.Close()
+
+	// Write more than a typical socket buffer (several hundred KB) without
+	// blocking forever: a deadline bounds the test if buffers are huge.
+	_ = conn.(*net.TCPConn).SetWriteDeadline(time.Now().Add(500 * time.Millisecond))
+	blob := make([]byte, 1<<20) // 1 MiB
+	_, _ = conn.Write(blob)
+
+	// Give the kernel a moment to settle the buffers.
+	time.Sleep(50 * time.Millisecond)
+
+	fds, err := ListFDs(os.Getpid())
+	if err != nil {
+		t.Fatalf("ListFDs(self): %v", err)
+	}
+	var maxQueued uint64
+	for _, fd := range fds {
+		if fd.Type != FDTypeSocket {
+			continue
+		}
+		s, err := FDSocketInfo(os.Getpid(), fd.FD)
+		if err != nil {
+			continue
+		}
+		if q := s.SndQueued + s.RcvQueued; q > maxQueued {
+			maxQueued = q
+		}
+	}
+	if maxQueued == 0 {
+		t.Skip("no socket buffer occupancy observed (kernel drained immediately); mapping still covered by the unit test")
+	}
+	t.Logf("max socket buffer occupancy across self sockets = %d bytes", maxQueued)
+}
+
+// TestNetworkCollector_live drives the full darwin collector pipeline end to
+// end against this process: ListFDs → FDSocketInfo → socketToNetConn →
+// Subscribe(). It opens a real TCP connection, stuffs the sender, then
+// confirms a published []NetConn carries a TCP entry with non-zero Tx or Rx
+// (the queued-buffer reading). This is the closest thing to running ptop
+// against a live process without a TTY.
+func TestNetworkCollector_live(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Skipf("cannot listen: %v", err)
+	}
+	defer ln.Close()
+	conn, err := net.Dial("tcp", ln.Addr().String())
+	if err != nil {
+		t.Skipf("cannot dial: %v", err)
+	}
+	defer conn.Close()
+	peer, err := ln.Accept()
+	if err != nil {
+		t.Skipf("cannot accept: %v", err)
+	}
+	defer peer.Close()
+
+	_ = conn.(*net.TCPConn).SetWriteDeadline(time.Now().Add(500 * time.Millisecond))
+	_, _ = conn.Write(make([]byte, 1<<20)) // 1 MiB, peer never reads
+
+	c := NewNetworkEBPFCollector()
+	if err := c.Start(os.Getpid()); err != nil {
+		t.Fatalf("collector Start(self): %v", err)
+	}
+	defer c.Stop()
+
+	// First publish lands immediately (loop calls collectAndEmit before the
+	// ticker); give it a generous deadline regardless.
+	var conns []NetConn
+	select {
+	case v := <-c.Subscribe():
+		nc, ok := v.([]NetConn)
+		if !ok {
+			t.Fatalf("expected []NetConn, got %T", v)
+		}
+		conns = nc
+	case <-time.After(3 * time.Second):
+		t.Fatal("collector published nothing within 3s")
+	}
+
+	var tcpCount int
+	var maxQueued uint64
+	for _, nc := range conns {
+		if nc.Type == "TCP" {
+			tcpCount++
+		}
+		if q := nc.TxBytes + nc.RxBytes; q > maxQueued {
+			maxQueued = q
+		}
+	}
+	t.Logf("collector published %d conns (%d TCP), max Tx+Rx = %d bytes", len(conns), tcpCount, maxQueued)
+	if tcpCount == 0 {
+		t.Fatal("expected at least one TCP connection from the live socket pair")
+	}
+	if maxQueued == 0 {
+		t.Skip("no queued bytes surfaced (kernel drained immediately); pipeline still exercised")
+	}
+}

--- a/internal/tui/header.go
+++ b/internal/tui/header.go
@@ -35,7 +35,6 @@ func renderHeader(m Model) string {
 		Render(m.ProcessName)
 
 	pidBadge := Badge(fmt.Sprintf("PID %d", m.cfg.PID), ColorBlue)
-	rtBadge := Badge(m.Runtime, ColorCyan)
 
 	stateColor := ColorGreen
 	switch strings.ToUpper(m.State) {
@@ -55,10 +54,16 @@ func renderHeader(m Model) string {
 		{sep, 0},
 		{procName, 0},
 		{pidBadge, 0},
-		{rtBadge, 2},
-		{stateBadge, 1},
-		{fdBadge, 1},
 	}
+	// Only show the runtime badge if we actually know the runtime (see
+	// Model.Runtime). Empty → omit, rather than display a mock value.
+	if m.Runtime != "" {
+		leftSegs = append(leftSegs, seg{Badge(m.Runtime, ColorCyan), 2})
+	}
+	leftSegs = append(leftSegs,
+		seg{stateBadge, 1},
+		seg{fdBadge, 1},
+	)
 
 	uptime := time.Since(m.StartedAt)
 	upMin := int(uptime.Minutes())

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -1,10 +1,12 @@
 package tui
 
 import (
+	"debug/buildinfo"
 	"fmt"
 	"math"
 	"math/rand"
 	"os"
+	"path/filepath"
 	"sort"
 	"strings"
 	"time"
@@ -213,11 +215,10 @@ func NewModel(cfg Config) Model {
 	m := Model{
 		cfg:              cfg,
 		ProcessName:      detectProcessName(cfg.PID),
-		// Runtime is the inspected process's language/runtime badge. We have
-		// no reliable way to detect it (it was previously hardcoded to a mock
-		// "Go 1.22", which lied for every non-Go process), so leave it empty
-		// and let the header omit the badge until a real detector exists.
-		Runtime:   "",
+		// Runtime is the inspected process's language/runtime badge, best-effort
+		// detected from the executable (Go build info / interpreter basename).
+		// Empty when unknown — the header omits the badge rather than guess.
+		Runtime:   detectRuntime(cfg.PID),
 		State:     "RUNNING",
 		StartedAt:        time.Now(),
 		ActiveTab:        TabOverview,
@@ -1366,5 +1367,57 @@ func detectProcessName(pid int) string {
 		return "(?)"
 	}
 	return name
+}
+
+// detectRuntime best-effort identifies the inspected process's language or
+// runtime for the header badge. It resolves the executable path (per-OS, via
+// osExePath in process_path_{linux,darwin}.go), reads embedded Go build info,
+// and otherwise guesses from the binary basename. Returns "" when unknown —
+// the header omits the badge rather than ever showing a mock value.
+func detectRuntime(pid int) string {
+	if pid <= 0 {
+		return ""
+	}
+	exe := osExePath(pid)
+	if exe == "" {
+		return ""
+	}
+	if bi, err := buildinfo.ReadFile(exe); err == nil && bi.GoVersion != "" {
+		return formatGoVersion(bi.GoVersion)
+	}
+	return runtimeFromBasename(filepath.Base(exe))
+}
+
+// formatGoVersion turns a runtime version string like "go1.22.3" into the
+// badge form "Go 1.22" (major.minor — patch is noise in a status badge).
+func formatGoVersion(v string) string {
+	v = strings.TrimPrefix(v, "go")
+	if parts := strings.Split(v, "."); len(parts) >= 2 {
+		return "Go " + parts[0] + "." + parts[1]
+	}
+	return "Go " + v
+}
+
+// runtimeFromBasename maps a known interpreter/executable name to a label.
+// Unknown names return "" so the badge stays hidden.
+func runtimeFromBasename(base string) string {
+	switch base = strings.ToLower(base); {
+	case strings.HasPrefix(base, "python"):
+		return "Python"
+	case base == "node" || base == "nodejs":
+		return "Node.js"
+	case base == "deno":
+		return "Deno"
+	case base == "bun":
+		return "Bun"
+	case base == "java":
+		return "JVM"
+	case base == "ruby":
+		return "Ruby"
+	case base == "perl":
+		return "Perl"
+	default:
+		return ""
+	}
 }
 

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -213,8 +213,12 @@ func NewModel(cfg Config) Model {
 	m := Model{
 		cfg:              cfg,
 		ProcessName:      detectProcessName(cfg.PID),
-		Runtime:          "Go 1.22",
-		State:            "RUNNING",
+		// Runtime is the inspected process's language/runtime badge. We have
+		// no reliable way to detect it (it was previously hardcoded to a mock
+		// "Go 1.22", which lied for every non-Go process), so leave it empty
+		// and let the header omit the badge until a real detector exists.
+		Runtime:   "",
+		State:     "RUNNING",
 		StartedAt:        time.Now(),
 		ActiveTab:        TabOverview,
 		FDFilter:         "all",

--- a/internal/tui/panels.go
+++ b/internal/tui/panels.go
@@ -461,21 +461,38 @@ func netStateColor(state string) lipgloss.Color {
 	}
 }
 
-func renderNetMini(conns []collector.NetConn, w, h int) string {
+// renderNetMini renders the connection table (TYPE REMOTE STATE LAT). When
+// showTraffic is set it appends a TX/RX column carrying NetConn.Tx/RxBytes —
+// only the dedicated F3 view enables it; the narrow F1 overview panel omits
+// it to keep REMOTE readable.
+//
+// TX/RX semantics are OS-dependent (the field is the same, the meaning is not):
+// on Linux/eBPF the values are cumulative bytes sent/received; on macOS libproc
+// has no cumulative counter, so they are the current send/recv socket-buffer
+// occupancy (a backlog gauge). The ? overlay reports the active source so the
+// user can tell which reading they're looking at.
+func renderNetMini(conns []collector.NetConn, w, h int, showTraffic bool) string {
 	const typeW = 5
 	const stateW = 12
 	const latW = 7
-	remoteW := w - typeW - stateW - latW - 4
+	const txrxW = 18
+	overhead := typeW + stateW + latW + 4
+	if showTraffic {
+		overhead += txrxW + 1
+	}
+	remoteW := w - overhead
 	if remoteW < 8 {
 		remoteW = 8
 	}
 
-	header := MutedStyle.Render(
-		padRight("TYPE", typeW) + " " +
-			padRight("REMOTE", remoteW) + " " +
-			padRight("STATE", stateW) + " " +
-			lipgloss.NewStyle().Width(latW).Background(ColorPanel).Align(lipgloss.Right).Render("LAT"),
-	)
+	headerCols := padRight("TYPE", typeW) + " " +
+		padRight("REMOTE", remoteW) + " " +
+		padRight("STATE", stateW) + " " +
+		lipgloss.NewStyle().Width(latW).Background(ColorPanel).Align(lipgloss.Right).Render("LAT")
+	if showTraffic {
+		headerCols += " " + lipgloss.NewStyle().Width(txrxW).Background(ColorPanel).Align(lipgloss.Right).Render("TX/RX")
+	}
+	header := MutedStyle.Render(headerCols)
 
 	lines := []string{header}
 	for _, c := range conns {
@@ -498,8 +515,13 @@ func renderNetMini(conns []collector.NetConn, w, h int) string {
 		}
 		lat := lipgloss.NewStyle().Foreground(latColor).Background(ColorPanel).Width(latW).Align(lipgloss.Right).
 			Render(fmt.Sprintf("%.0fms", c.LatencyMs))
-		lines = append(lines, panelRow(t, remote, state, lat))
-
+		if showTraffic {
+			txrx := lipgloss.NewStyle().Foreground(ColorMuted).Background(ColorPanel).Width(txrxW).Align(lipgloss.Right).
+				Render(fmt.Sprintf("↑%s ↓%s", fmtBytes(c.TxBytes), fmtBytes(c.RxBytes)))
+			lines = append(lines, panelRow(t, remote, state, lat, txrx))
+		} else {
+			lines = append(lines, panelRow(t, remote, state, lat))
+		}
 	}
 	return strings.Join(lines, "\n")
 }

--- a/internal/tui/platform_darwin.go
+++ b/internal/tui/platform_darwin.go
@@ -17,4 +17,8 @@ const (
 	syscallsUnavailable = true
 	ioFilesUnavailable  = true
 	locksUnavailable    = true
+
+	// No eBPF on macOS — the footer must not claim it. Tier 1 collects via
+	// libproc + Mach (see issue #22).
+	statusBarSourceLabel = "libproc + Mach · Tier 1 · no eBPF"
 )

--- a/internal/tui/platform_darwin.go
+++ b/internal/tui/platform_darwin.go
@@ -17,8 +17,10 @@ const (
 	syscallsUnavailable = true
 	ioFilesUnavailable  = true
 	locksUnavailable    = true
-
-	// No eBPF on macOS — the footer must not claim it. Tier 1 collects via
-	// libproc + Mach (see issue #22).
-	statusBarSourceLabel = "libproc + Mach · Tier 1 · no eBPF"
 )
+
+// statusBarSourceLabel — no eBPF on macOS, so the footer must not claim it.
+// Tier 1 collects via libproc + Mach (see issue #22).
+func statusBarSourceLabel() string {
+	return "libproc + Mach · Tier 1 · no eBPF"
+}

--- a/internal/tui/platform_linux.go
+++ b/internal/tui/platform_linux.go
@@ -2,6 +2,11 @@
 
 package tui
 
+import (
+	"os"
+	"strings"
+)
+
 // Platform-specific labels and feature availability flags. The help overlay
 // and the collector wiring code in model.go branch on these so the source
 // string ("/proc" vs "libproc") and the panel availability stay honest
@@ -24,9 +29,23 @@ const (
 	syscallsUnavailable = false
 	ioFilesUnavailable  = false
 	locksUnavailable    = false
-
-	// statusBarSourceLabel is the footer's data-source descriptor. It must
-	// describe how this build actually collects, never claim a path it can't
-	// take (the macOS variant deliberately omits eBPF).
-	statusBarSourceLabel = "eBPF kernel 6.8 · sampling 100Hz · overhead <0.5%"
 )
+
+// statusBarSourceLabel is the footer's data-source descriptor. It must
+// describe how this build actually collects, never claim a path it can't
+// take. The kernel release is read live (it used to be hardcoded "6.8"), and
+// the old unmeasured "overhead <0.5%" claim is gone. The 100Hz figure is real
+// — the eBPF cpu.bpf.c perf_event runs at sample_freq=100.
+func statusBarSourceLabel() string {
+	return "eBPF kernel " + kernelRelease() + " · sampling 100Hz"
+}
+
+// kernelRelease returns the running kernel version (uname -r), or "?" if the
+// procfs entry can't be read.
+func kernelRelease() string {
+	data, err := os.ReadFile("/proc/sys/kernel/osrelease")
+	if err != nil {
+		return "?"
+	}
+	return strings.TrimSpace(string(data))
+}

--- a/internal/tui/platform_linux.go
+++ b/internal/tui/platform_linux.go
@@ -24,4 +24,9 @@ const (
 	syscallsUnavailable = false
 	ioFilesUnavailable  = false
 	locksUnavailable    = false
+
+	// statusBarSourceLabel is the footer's data-source descriptor. It must
+	// describe how this build actually collects, never claim a path it can't
+	// take (the macOS variant deliberately omits eBPF).
+	statusBarSourceLabel = "eBPF kernel 6.8 · sampling 100Hz · overhead <0.5%"
 )

--- a/internal/tui/process_path_darwin.go
+++ b/internal/tui/process_path_darwin.go
@@ -1,0 +1,16 @@
+//go:build darwin
+
+package tui
+
+import "github.com/trentas/ptop/internal/collector"
+
+// osExePath resolves the absolute executable path for pid via libproc's
+// proc_pidpath — the macOS equivalent of readlink(/proc/<pid>/exe). Returns
+// "" when the path can't be read (process gone, not owned by this euid).
+func osExePath(pid int) string {
+	p, err := collector.ProcPath(pid)
+	if err != nil {
+		return ""
+	}
+	return p
+}

--- a/internal/tui/process_path_linux.go
+++ b/internal/tui/process_path_linux.go
@@ -1,0 +1,19 @@
+//go:build linux
+
+package tui
+
+import (
+	"fmt"
+	"os"
+)
+
+// osExePath resolves the absolute executable path for pid via the
+// /proc/<pid>/exe symlink — the same source `readlink` and most tools use.
+// Returns "" when the link can't be read (process gone, permission denied).
+func osExePath(pid int) string {
+	p, err := os.Readlink(fmt.Sprintf("/proc/%d/exe", pid))
+	if err != nil {
+		return ""
+	}
+	return p
+}

--- a/internal/tui/runtime_test.go
+++ b/internal/tui/runtime_test.go
@@ -1,0 +1,64 @@
+package tui
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+// TestDetectRuntime_self runs the detector against the test binary itself,
+// which is a Go program — so it must report a "Go <major>.<minor>" badge.
+// This exercises the full path: osExePath (per-OS) → buildinfo.ReadFile.
+func TestDetectRuntime_self(t *testing.T) {
+	got := detectRuntime(os.Getpid())
+	if !strings.HasPrefix(got, "Go ") {
+		t.Fatalf("detectRuntime(self) = %q, want a \"Go x.y\" badge (test binary is Go)", got)
+	}
+	t.Logf("self runtime = %q", got)
+}
+
+func TestDetectRuntime_invalidPID(t *testing.T) {
+	if got := detectRuntime(0); got != "" {
+		t.Fatalf("detectRuntime(0) = %q, want empty", got)
+	}
+	if got := detectRuntime(-1); got != "" {
+		t.Fatalf("detectRuntime(-1) = %q, want empty", got)
+	}
+}
+
+func TestFormatGoVersion(t *testing.T) {
+	cases := map[string]string{
+		"go1.22.3": "Go 1.22",
+		"go1.22":   "Go 1.22",
+		"go1.21.0": "Go 1.21",
+		"1.20.5":   "Go 1.20", // tolerate a missing "go" prefix
+		"go2":      "Go 2",    // no minor → pass through
+	}
+	for in, want := range cases {
+		if got := formatGoVersion(in); got != want {
+			t.Errorf("formatGoVersion(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestRuntimeFromBasename(t *testing.T) {
+	cases := map[string]string{
+		"python3.11":        "Python",
+		"python":            "Python",
+		"node":              "Node.js",
+		"nodejs":            "Node.js",
+		"deno":              "Deno",
+		"bun":               "Bun",
+		"java":              "JVM",
+		"ruby":              "Ruby",
+		"perl":              "Perl",
+		"PYTHON3":           "Python", // case-insensitive
+		"some-daemon":       "",       // unknown → no badge
+		"identityservicesd": "",
+	}
+	for in, want := range cases {
+		if got := runtimeFromBasename(in); got != want {
+			t.Errorf("runtimeFromBasename(%q) = %q, want %q", in, got, want)
+		}
+	}
+}

--- a/internal/tui/statusbar.go
+++ b/internal/tui/statusbar.go
@@ -71,7 +71,7 @@ func renderStatusBar(m Model) string {
 				Background(barBg).
 				Render("● REC"))
 		}
-		rightParts = append(rightParts, lblStyle.Render(statusBarSourceLabel))
+		rightParts = append(rightParts, lblStyle.Render(statusBarSourceLabel()))
 	}
 	right := strings.Join(rightParts, lblStyle.Render("  "))
 

--- a/internal/tui/statusbar.go
+++ b/internal/tui/statusbar.go
@@ -71,7 +71,7 @@ func renderStatusBar(m Model) string {
 				Background(barBg).
 				Render("● REC"))
 		}
-		rightParts = append(rightParts, lblStyle.Render("eBPF kernel 6.8 · sampling 100Hz · overhead <0.5%"))
+		rightParts = append(rightParts, lblStyle.Render(statusBarSourceLabel))
 	}
 	right := strings.Join(rightParts, lblStyle.Render("  "))
 

--- a/internal/tui/view_network.go
+++ b/internal/tui/view_network.go
@@ -9,9 +9,9 @@ import (
 
 // renderNetworkView (F3) — assets/mockup.jsx → NetworkView
 //
-//   ┌── Active Connections (left) ────────┬── Network Events (1/3) ─┐
-//   │ TYPE REMOTE         STATE   LAT     │ 12:34 NET TCP SYN  …    │
-//   │ ...                                  │                          │
+//   ┌── Active Connections (left) ──────────────┬── Network Events ─┐
+//   │ TYPE REMOTE       STATE   LAT      TX/RX   │ 12:34 NET TCP …   │
+//   │ ...                                         │                   │
 //   ├── Latency Trend ────────────────────┤                          │
 //   │ remote        ▇▇▇▇▇▇  42ms          │                          │
 //   └─────────────────────────────────────┴──────────────────────────┘
@@ -25,7 +25,7 @@ func renderNetworkView(m Model, w, h int) string {
 	leftHs := splitFlex([]float64{1.0, 1.5}, h)
 
 	conns := Panel("Active Connections",
-		renderNetMini(m.NetConns, leftW-2, leftHs[0]-3),
+		renderNetMini(m.NetConns, leftW-2, leftHs[0]-3, true),
 		leftW, leftHs[0])
 
 	latency := Panel("Latency Trend",

--- a/internal/tui/view_overview.go
+++ b/internal/tui/view_overview.go
@@ -59,7 +59,7 @@ func renderOverviewView(m Model, w, h int) string {
 		rightW, rightHs[1])
 
 	netPanel := Panel("Network",
-		renderNetMini(m.NetConns, rightW-2, rightHs[2]-3),
+		renderNetMini(m.NetConns, rightW-2, rightHs[2]-3, false),
 		rightW, rightHs[2])
 
 	memPanel := Panel("Memory",


### PR DESCRIPTION
## Summary

Extends the macOS Tier 1 port (#22) with real socket traffic data, a new F3 column to surface it, and a round of audit fixes uncovered while live-testing.

### Feature — socket Tx/Rx + F3 TX/RX column (`f998d87`)
- macOS libproc has **no cumulative per-socket byte counter**, so `NetConn.Tx/RxBytes` are populated from the current send/recv socket-buffer occupancy (`socket_info.soi_snd/soi_rcv.sbi_cc`) — a backlog *gauge*, not lifetime totals. New `SndQueued`/`RcvQueued` on `LPSocketFDInfo`.
- New **TX/RX column** in the dedicated F3 view (`renderNetMini` gains a `showTraffic` flag; the narrow F1 overview keeps it off). Reading is OS-dependent — cumulative on Linux/eBPF, queued on macOS — documented in the collector and mirrored in `assets/mockup.jsx`.
- Fixed misleading comments that claimed `socket_info` carries cumulative counters.

### Fixes from live testing (`815b83d`)
- **A. F3 ordering:** `proc_pidinfo` lists FDs numerically, burying ESTABLISHED TCP connections under a process's many idle UDP wildcard sockets (past the panel's row limit). The collector now sorts: connected first, then listeners, then idle; TCP before UDP.
- **B. Status bar honesty:** it claimed `eBPF kernel 6.8 · sampling 100Hz · overhead <0.5%` on every platform — false on macOS. Now a per-platform constant: `libproc + Mach · Tier 1 · no eBPF` on darwin.
- **C. Runtime badge:** dropped the hardcoded mock `Go 1.22` header badge; `Model.Runtime` defaults empty and the header omits the badge until a real detector exists.

### Audit cleanup (`5c1a35e`)
- Removed dead `sync.Mutex` on `NetworkEBPFCollector` and write-only `lastPublishAt` on `IOWaitCollector`.
- Fixed the iowait multi-thread bias (one stuck thread in a large pool no longer reads as 100%); now averages the blocked-thread fraction per snapshot.
- Added integration smoke tests for the darwin mem, threads, io-throughput, io-wait and fd collectors.

## Testing
- `go build`, `go vet`, `go test ./...` all green on darwin.
- New unit tests: `socketToNetConn` mapping, `connRank`/`typeRank` ordering, per-collector smoke tests.
- New live tests against real sockets: `TestFDSocketInfo_queuedBytes_live` (observed 1 MiB queued), `TestNetworkCollector_live` (full pipeline).
- Verified live against `identityservicesd` (PID 990): 6 IPv6 TCP connections now sort to the top above 9 idle UDP sockets, TX/RX column renders, footer shows libproc, no Go badge.

## Notes
- F3 intentionally deviates from `assets/mockup.jsx` (TX/RX column) — the mockup was updated to match.
- Follow-up worth filing: the Linux status-bar string still hardcodes the kernel version / sampling / overhead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)