### PR TITLE
serve: sink abstraction + JSONL export — close #51

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,7 +88,10 @@ jobs:
 
       # Wire-compatibility gate: fail if the schema breaks consumers pinned to
       # the version on main. Skipped on push to main (it would compare against
-      # itself); runs on PRs, where it matters.
+      # itself); runs on PRs, where it matters. The PR checkout is a detached
+      # HEAD with no local `main`, so fetch it first for buf to compare against.
       - name: buf breaking (vs main)
         if: github.event_name == 'pull_request'
-        run: go run github.com/bufbuild/buf/cmd/buf@v1.70.0 breaking --against '.git#branch=main'
+        run: |
+          git fetch --no-tags origin main:main
+          go run github.com/bufbuild/buf/cmd/buf@v1.70.0 breaking --against '.git#branch=main'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,10 +59,12 @@ jobs:
         run: go build -tags=ebpf -o /tmp/ptop-ebpf ./cmd/ptop
 
   proto:
-    name: buf lint · format · generate
+    name: buf lint · format · generate · breaking
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # buf breaking compares against the main branch ref
 
       - uses: actions/setup-go@v5
         with:
@@ -84,5 +86,9 @@ jobs:
           go run github.com/bufbuild/buf/cmd/buf@v1.70.0 generate
           git diff --exit-code
 
-      # NOTE: `buf breaking --against '.git#branch=main'` lands in a follow-up,
-      # once the schema exists on main and there's a baseline to compare against.
+      # Wire-compatibility gate: fail if the schema breaks consumers pinned to
+      # the version on main. Skipped on push to main (it would compare against
+      # itself); runs on PRs, where it matters.
+      - name: buf breaking (vs main)
+        if: github.event_name == 'pull_request'
+        run: go run github.com/bufbuild/buf/cmd/buf@v1.70.0 breaking --against '.git#branch=main'

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,11 @@
 *.prof
 coverage.out
 
+# Runtime exports (--export / 's' key / --serve --export)
+ptop-export-*.jsonl
+ptop-events-*.jsonl
+ptop-snapshot-*.json
+
 # IDE / editor
 .idea/
 .vscode/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,7 +92,8 @@ ptop/
 │   │   └── *_stub.go              stubs for non-Linux / no-ebpf builds
 │   ├── serve/                     headless gRPC server (ptop --serve)
 │   │   ├── serve.go               addr parse + privilege boundary + Run
-│   │   ├── hub.go                 fan-in collectors → fan-out subscribers
+│   │   ├── hub.go                 fan-in collectors → fan-out to sinks
+│   │   ├── sink.go                Sink iface: gRPC subscriber + JSONL writer
 │   │   ├── service.go             EventStream gRPC service impl
 │   │   └── mapper.go              collector value → streampb.Event
 │   └── tui/                       Bubbletea + Lipgloss
@@ -332,6 +333,11 @@ subscribers (fan-out), with bounded per-subscriber buffers that drop-with-counte
 under backpressure (surfaced as `StreamMeta`). `addr` is `unix:///path` or
 `tcp://host:port`. SIGINT/SIGTERM shuts down and releases collectors. The
 collector→`streampb` mapping + server live in `internal/serve`.
+
+The gRPC subscriber and the JSONL writer are interchangeable `Sink`s
+(`internal/serve/sink.go`) fed by the hub. `--serve --export` adds the JSONL
+sink: it writes one protojson `Event` per line to `ptop-events-<ts>.jsonl`
+(event-level — distinct from the TUI's state-snapshot `ptop-export-<ts>.jsonl`).
 
 Version metadata is injected via `-ldflags` at release time
 (`main.version`, `main.commit`, `main.buildDate`). In dev they stay as

--- a/cmd/ptop/main.go
+++ b/cmd/ptop/main.go
@@ -8,6 +8,7 @@ import (
 	"os/signal"
 	"runtime"
 	"syscall"
+	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/trentas/ptop/internal/bpf"
@@ -78,7 +79,7 @@ func main() {
 
 	// Headless mode: serve the collector stream over gRPC instead of the TUI.
 	if *serveAddr != "" {
-		runServe(*serveAddr, *pid, *noEBPF)
+		runServe(*serveAddr, *pid, *noEBPF, *export)
 		return
 	}
 
@@ -113,15 +114,21 @@ func main() {
 
 // runServe builds the collector Set and streams it over gRPC until SIGINT/
 // SIGTERM. The Set's lifecycle is owned here: serve.Run only stops the server,
-// so we stop the collectors after it returns.
-func runServe(addr string, pid int, noEBPF bool) {
+// so we stop the collectors after it returns. With export, it also writes an
+// event-level JSONL (distinct from the TUI's state-snapshot ptop-export-*.jsonl).
+func runServe(addr string, pid int, noEBPF, export bool) {
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
+
+	var opts serve.Options
+	if export {
+		opts.JSONLPath = fmt.Sprintf("ptop-events-%s.jsonl", time.Now().Format("20060102-150405"))
+	}
 
 	set := collector.NewSet(collector.SetConfig{PID: pid, NoEBPF: noEBPF})
 	defer set.Stop()
 
-	if err := serve.Run(ctx, addr, pid, set.Collectors()); err != nil {
+	if err := serve.Run(ctx, addr, pid, set.Collectors(), opts); err != nil {
 		set.Stop() // os.Exit skips the defer
 		fmt.Fprintf(os.Stderr, "fatal error: %v\n", err)
 		os.Exit(1)

--- a/internal/serve/hub.go
+++ b/internal/serve/hub.go
@@ -3,44 +3,28 @@ package serve
 import (
 	"context"
 	"sync"
-	"sync/atomic"
 
 	"github.com/trentas/ptop/pkg/collector"
 	pb "github.com/trentas/ptop/pkg/streampb"
 )
 
-// subBuffer bounds each subscriber's queue. A subscriber that can't keep up has
-// events dropped (counted), never blocking the collector or growing unbounded.
-const subBuffer = 256
-
-// subscriber is one connected client. ch is its bounded queue; filter (nil =
-// all) restricts categories; dropped counts events shed under backpressure
-// (read atomically by the service goroutine to emit StreamMeta).
-type subscriber struct {
-	ch      chan *pb.SubscribeResponse
-	filter  map[pb.Category]bool
-	dropped uint64
-}
-
-func (s *subscriber) wants(c pb.Category) bool {
-	return s.filter == nil || s.filter[c]
-}
-
-// Hub fans collector events in from many channels and out to many subscribers.
-// One Hub per server instance (one target PID).
+// Hub fans collector events in from many channels and out to many Sinks. One
+// Hub per server instance (one target PID). Sinks are interchangeable consumers
+// of the unified event stream: a gRPC subscriber and a JSONL writer are both
+// just Sinks (see sink.go).
 type Hub struct {
-	pid  int
-	mu   sync.Mutex
-	subs map[*subscriber]struct{}
+	pid   int
+	mu    sync.Mutex
+	sinks map[Sink]struct{}
 }
 
 func NewHub(pid int) *Hub {
-	return &Hub{pid: pid, subs: make(map[*subscriber]struct{})}
+	return &Hub{pid: pid, sinks: make(map[Sink]struct{})}
 }
 
 // Start launches one fan-in goroutine per collector. Each maps published values
-// to Events and broadcasts them. The goroutines exit when ctx is cancelled or
-// their source channel closes. Non-blocking — returns immediately.
+// to Events and broadcasts them to every sink. The goroutines exit when ctx is
+// cancelled or their source channel closes. Non-blocking — returns immediately.
 func (h *Hub) Start(ctx context.Context, cols []collector.Collector) {
 	for _, c := range cols {
 		ch := c.Subscribe()
@@ -67,49 +51,43 @@ func (h *Hub) drain(ctx context.Context, ch <-chan interface{}) {
 	}
 }
 
+// broadcast hands the event to every sink. Emit must not block (sinks own their
+// buffering), so the collector drain path is never stalled by a slow consumer.
 func (h *Hub) broadcast(ev *pb.Event) {
-	resp := &pb.SubscribeResponse{Kind: &pb.SubscribeResponse_Event{Event: ev}}
 	h.mu.Lock()
 	defer h.mu.Unlock()
-	for s := range h.subs {
-		if !s.wants(ev.GetCategory()) {
-			continue
-		}
-		select {
-		case s.ch <- resp:
-		default:
-			// Slow consumer: shed the event and count it. The service goroutine
-			// surfaces the count as a StreamMeta.
-			atomic.AddUint64(&s.dropped, 1)
-		}
+	for s := range h.sinks {
+		s.Emit(ev)
 	}
 }
 
-// subscribe registers a client with an optional category filter.
-func (h *Hub) subscribe(cats []pb.Category) *subscriber {
-	s := &subscriber{ch: make(chan *pb.SubscribeResponse, subBuffer)}
-	if len(cats) > 0 {
-		s.filter = make(map[pb.Category]bool, len(cats))
-		for _, c := range cats {
-			s.filter[c] = true
-		}
-	}
+// AddSink registers a sink to receive subsequent events.
+func (h *Hub) AddSink(s Sink) {
 	h.mu.Lock()
-	h.subs[s] = struct{}{}
+	h.sinks[s] = struct{}{}
 	h.mu.Unlock()
+}
+
+// RemoveSink stops a sink from receiving events. After it returns, broadcast no
+// longer references the sink.
+func (h *Hub) RemoveSink(s Sink) {
+	h.mu.Lock()
+	delete(h.sinks, s)
+	h.mu.Unlock()
+}
+
+// subscribe registers a gRPC client (a grpcSink) with an optional category
+// filter and returns it. Thin helper over AddSink used by the service.
+func (h *Hub) subscribe(cats []pb.Category) *grpcSink {
+	s := newGRPCSink(cats)
+	h.AddSink(s)
 	return s
 }
 
-// unsubscribe removes a client. After this returns, broadcast no longer
-// references the subscriber, so its channel can be abandoned safely.
-func (h *Hub) unsubscribe(s *subscriber) {
-	h.mu.Lock()
-	delete(h.subs, s)
-	h.mu.Unlock()
-}
+func (h *Hub) unsubscribe(s *grpcSink) { h.RemoveSink(s) }
 
-func (h *Hub) subscriberCount() int {
+func (h *Hub) sinkCount() int {
 	h.mu.Lock()
 	defer h.mu.Unlock()
-	return len(h.subs)
+	return len(h.sinks)
 }

--- a/internal/serve/hub_test.go
+++ b/internal/serve/hub_test.go
@@ -109,11 +109,11 @@ func TestHubBackpressureDrops(t *testing.T) {
 func TestHubUnsubscribe(t *testing.T) {
 	h := NewHub(1)
 	sub := h.subscribe(nil)
-	if h.subscriberCount() != 1 {
-		t.Fatalf("count = %d, want 1", h.subscriberCount())
+	if h.sinkCount() != 1 {
+		t.Fatalf("count = %d, want 1", h.sinkCount())
 	}
 	h.unsubscribe(sub)
-	if h.subscriberCount() != 0 {
-		t.Fatalf("count = %d, want 0 after unsubscribe", h.subscriberCount())
+	if h.sinkCount() != 0 {
+		t.Fatalf("count = %d, want 0 after unsubscribe", h.sinkCount())
 	}
 }

--- a/internal/serve/serve.go
+++ b/internal/serve/serve.go
@@ -18,12 +18,20 @@ import (
 	pb "github.com/trentas/ptop/pkg/streampb"
 )
 
+// Options tunes a Run beyond the address/PID. The zero value is the plain
+// gRPC-only server.
+type Options struct {
+	// JSONLPath, if set, also writes every event as one protojson line to this
+	// file (an interchangeable sink alongside the gRPC subscribers).
+	JSONLPath string
+}
+
 // Run starts the gRPC server bound to addr, streaming events for the given
 // target pid from cols. It blocks until ctx is cancelled, then stops the server
 // and returns. The caller owns the collectors' lifecycle (typically
 // set.Collectors() here and set.Stop() after Run returns). addr is
 // "unix:///path" or "tcp://host:port".
-func Run(ctx context.Context, addr string, pid int, cols []collector.Collector) error {
+func Run(ctx context.Context, addr string, pid int, cols []collector.Collector, opts Options) error {
 	lis, cleanup, err := listen(addr)
 	if err != nil {
 		return err
@@ -32,6 +40,18 @@ func Run(ctx context.Context, addr string, pid int, cols []collector.Collector) 
 
 	hub := NewHub(pid)
 	hub.Start(ctx, cols)
+
+	// Optional JSONL sink: a non-gRPC consumer of the same event stream.
+	if opts.JSONLPath != "" {
+		js, err := newJSONLSink(opts.JSONLPath)
+		if err != nil {
+			return fmt.Errorf("serve: jsonl export: %w", err)
+		}
+		hub.AddSink(js)
+		// RemoveSink before Close so no Emit races the channel close.
+		defer func() { hub.RemoveSink(js); _ = js.Close() }()
+		fmt.Fprintf(os.Stderr, "[ptop] also exporting events to %s\n", opts.JSONLPath)
+	}
 
 	srv := grpc.NewServer()
 	pb.RegisterEventStreamServiceServer(srv, &eventStreamService{hub: hub})

--- a/internal/serve/serve_test.go
+++ b/internal/serve/serve_test.go
@@ -1,6 +1,7 @@
 package serve
 
 import (
+	"bufio"
 	"context"
 	"os"
 	"path/filepath"
@@ -9,6 +10,7 @@ import (
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/protobuf/encoding/protojson"
 
 	"github.com/trentas/ptop/pkg/collector"
 	pb "github.com/trentas/ptop/pkg/streampb"
@@ -40,7 +42,7 @@ func TestServeUnixEndToEnd(t *testing.T) {
 	}()
 
 	runErr := make(chan error, 1)
-	go func() { runErr <- Run(ctx, addr, 99, []collector.Collector{f}) }()
+	go func() { runErr <- Run(ctx, addr, 99, []collector.Collector{f}, Options{}) }()
 
 	// Wait for the listener socket to appear before dialing.
 	waitFor(t, func() bool { _, err := os.Stat(sock); return err == nil })
@@ -106,7 +108,7 @@ func TestServeBackpressureMetaOverGRPC(t *testing.T) {
 
 	f := newFake(8192) // holds the burst without blocking the producer
 	runErr := make(chan error, 1)
-	go func() { runErr <- Run(ctx, addr, 1, []collector.Collector{f}) }()
+	go func() { runErr <- Run(ctx, addr, 1, []collector.Collector{f}, Options{}) }()
 	waitFor(t, func() bool { _, err := os.Stat(sock); return err == nil })
 
 	conn, err := grpc.NewClient(addr, grpc.WithTransportCredentials(insecure.NewCredentials()))
@@ -145,6 +147,62 @@ func TestServeBackpressureMetaOverGRPC(t *testing.T) {
 
 	cancel()
 	<-runErr
+}
+
+// Run with Options{JSONLPath} writes an event-level JSONL alongside gRPC.
+func TestServeJSONLExport(t *testing.T) {
+	sock := shortSock(t)
+	jsonl := filepath.Join(t.TempDir(), "events.jsonl")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	f := newFake(64)
+	go func() {
+		tick := time.NewTicker(5 * time.Millisecond)
+		defer tick.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-tick.C:
+				select {
+				case f.ch <- collector.CpuSample{UsagePct: 1, Timestamp: time.Now()}:
+				default:
+				}
+			}
+		}
+	}()
+
+	runErr := make(chan error, 1)
+	go func() {
+		runErr <- Run(ctx, "unix://"+sock, 5, []collector.Collector{f}, Options{JSONLPath: jsonl})
+	}()
+	waitFor(t, func() bool { _, err := os.Stat(sock); return err == nil })
+
+	time.Sleep(200 * time.Millisecond) // let some events flow to the sink
+	cancel()
+	if err := <-runErr; err != nil { // Run returns → jsonlSink flushed + closed
+		t.Fatalf("Run: %v", err)
+	}
+
+	f2, err := os.Open(jsonl)
+	if err != nil {
+		t.Fatalf("open jsonl: %v", err)
+	}
+	defer f2.Close()
+	var lines int
+	sc := bufio.NewScanner(f2)
+	for sc.Scan() {
+		var ev pb.Event
+		if err := protojson.Unmarshal(sc.Bytes(), &ev); err != nil {
+			t.Fatalf("line %d not valid Event: %v", lines, err)
+		}
+		lines++
+	}
+	if lines == 0 {
+		t.Fatal("expected at least one event line in the JSONL export")
+	}
 }
 
 func TestListenRefusesAllInterfaces(t *testing.T) {

--- a/internal/serve/sink.go
+++ b/internal/serve/sink.go
@@ -1,0 +1,123 @@
+package serve
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"sync/atomic"
+
+	"google.golang.org/protobuf/encoding/protojson"
+
+	pb "github.com/trentas/ptop/pkg/streampb"
+)
+
+// subBuffer bounds each sink's queue. A sink that can't keep up has events
+// dropped (counted), never blocking the collector drain path or growing
+// unbounded.
+const subBuffer = 256
+
+// Sink is an interchangeable consumer of the event stream. The gRPC subscriber
+// and the JSONL writer are both Sinks. Emit MUST NOT block — sinks own their
+// own buffering and shed events when they fall behind — so the hub's broadcast
+// (and thus the collector drain) is never stalled by a slow consumer.
+type Sink interface {
+	Emit(ev *pb.Event)
+	Close() error
+}
+
+// grpcSink is one connected gRPC client. ch is its bounded queue; filter
+// (nil = all) restricts categories; dropped counts events shed under
+// backpressure (read atomically by the service goroutine to emit StreamMeta).
+type grpcSink struct {
+	ch      chan *pb.SubscribeResponse
+	filter  map[pb.Category]bool
+	dropped uint64
+}
+
+func newGRPCSink(cats []pb.Category) *grpcSink {
+	s := &grpcSink{ch: make(chan *pb.SubscribeResponse, subBuffer)}
+	if len(cats) > 0 {
+		s.filter = make(map[pb.Category]bool, len(cats))
+		for _, c := range cats {
+			s.filter[c] = true
+		}
+	}
+	return s
+}
+
+func (s *grpcSink) wants(c pb.Category) bool {
+	return s.filter == nil || s.filter[c]
+}
+
+func (s *grpcSink) Emit(ev *pb.Event) {
+	if !s.wants(ev.GetCategory()) {
+		return
+	}
+	resp := &pb.SubscribeResponse{Kind: &pb.SubscribeResponse_Event{Event: ev}}
+	select {
+	case s.ch <- resp:
+	default:
+		atomic.AddUint64(&s.dropped, 1)
+	}
+}
+
+func (s *grpcSink) Close() error { return nil }
+
+// jsonlSink writes every event as one protojson line to a file. A bounded
+// channel + writer goroutine keep disk I/O off the hub's broadcast path; on
+// overflow events are dropped and counted (reported on Close).
+type jsonlSink struct {
+	w       io.WriteCloser
+	ch      chan *pb.Event
+	done    chan struct{}
+	dropped uint64
+}
+
+func newJSONLSink(path string) (*jsonlSink, error) {
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0o644)
+	if err != nil {
+		return nil, err
+	}
+	return newJSONLSinkWriter(f), nil
+}
+
+// newJSONLSinkWriter is the testable core: it writes to any WriteCloser.
+func newJSONLSinkWriter(w io.WriteCloser) *jsonlSink {
+	s := &jsonlSink{w: w, ch: make(chan *pb.Event, subBuffer), done: make(chan struct{})}
+	go s.run()
+	return s
+}
+
+func (s *jsonlSink) Emit(ev *pb.Event) {
+	select {
+	case s.ch <- ev:
+	default:
+		atomic.AddUint64(&s.dropped, 1)
+	}
+}
+
+func (s *jsonlSink) run() {
+	defer close(s.done)
+	opts := protojson.MarshalOptions{} // compact, one object per line
+	for ev := range s.ch {
+		b, err := opts.Marshal(ev)
+		if err != nil {
+			continue
+		}
+		if _, err := s.w.Write(append(b, '\n')); err != nil {
+			fmt.Fprintf(os.Stderr, "warning: jsonl export write: %v\n", err)
+			return
+		}
+	}
+}
+
+// Close flushes the queued events and closes the writer. The caller must
+// RemoveSink this from the hub first, so no Emit races the channel close.
+func (s *jsonlSink) Close() error {
+	close(s.ch)
+	<-s.done
+	if d := atomic.LoadUint64(&s.dropped); d > 0 {
+		fmt.Fprintf(os.Stderr, "[ptop] jsonl export dropped %d events (slow disk)\n", d)
+	}
+	return s.w.Close()
+}

--- a/internal/serve/sink_test.go
+++ b/internal/serve/sink_test.go
@@ -1,0 +1,115 @@
+package serve
+
+import (
+	"bufio"
+	"os"
+	"path/filepath"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"google.golang.org/protobuf/encoding/protojson"
+
+	pb "github.com/trentas/ptop/pkg/streampb"
+)
+
+// jsonlSink writes one parseable protojson Event per line, and Close flushes
+// what's queued.
+func TestJSONLSinkRoundTrip(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "events.jsonl")
+	s, err := newJSONLSink(path)
+	if err != nil {
+		t.Fatalf("newJSONLSink: %v", err)
+	}
+
+	const n = 20
+	for i := 0; i < n; i++ {
+		s.Emit(&pb.Event{
+			Pid:      7,
+			Category: pb.Category_CATEGORY_CPU,
+			Payload:  &pb.Event_Cpu{Cpu: &pb.CpuSample{UsagePct: float64(i)}},
+		})
+	}
+	if err := s.Close(); err != nil { // flushes queued events
+		t.Fatalf("close: %v", err)
+	}
+
+	f, err := os.Open(path)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer f.Close()
+
+	var lines int
+	sc := bufio.NewScanner(f)
+	for sc.Scan() {
+		var ev pb.Event
+		if err := protojson.Unmarshal(sc.Bytes(), &ev); err != nil {
+			t.Fatalf("line %d not valid protojson Event: %v", lines, err)
+		}
+		if ev.GetPid() != 7 || ev.GetCategory() != pb.Category_CATEGORY_CPU {
+			t.Errorf("line %d: unexpected event %v", lines, &ev)
+		}
+		lines++
+	}
+	if lines != n {
+		t.Errorf("got %d lines, want %d", lines, n)
+	}
+}
+
+// blockingWriter blocks every Write until release is closed, so the sink's
+// writer goroutine stalls and the bounded channel overflows.
+type blockingWriter struct {
+	release chan struct{}
+	mu      sync.Mutex
+	written int
+}
+
+func (w *blockingWriter) Write(p []byte) (int, error) {
+	<-w.release
+	w.mu.Lock()
+	w.written += len(p)
+	w.mu.Unlock()
+	return len(p), nil
+}
+func (w *blockingWriter) Close() error { return nil }
+
+// A stalled writer must cause drops (counted), never block the Emit caller.
+func TestJSONLSinkDropsWhenWriterBlocked(t *testing.T) {
+	bw := &blockingWriter{release: make(chan struct{})}
+	s := newJSONLSinkWriter(bw)
+
+	// Emit far more than the buffer while the writer is blocked. Emit must never
+	// block, so this returns promptly.
+	const n = subBuffer + 200
+	done := make(chan struct{})
+	go func() {
+		for i := 0; i < n; i++ {
+			s.Emit(&pb.Event{Pid: 1, Category: pb.Category_CATEGORY_CPU,
+				Payload: &pb.Event_Cpu{Cpu: &pb.CpuSample{UsagePct: float64(i)}}})
+		}
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Emit blocked while writer stalled")
+	}
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if atomic.LoadUint64(&s.dropped) > 0 {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	if atomic.LoadUint64(&s.dropped) == 0 {
+		t.Fatal("expected drops while writer blocked, got 0")
+	}
+
+	close(bw.release) // unblock so Close can drain and return
+	if err := s.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+}


### PR DESCRIPTION
## Why

Final follow-up to **close #51**. Issue #51's last open checklist item (item 5, "refactor sink abstraction") asks that the event stream feed *interchangeable consumers*, and that a single `--serve` invocation can *also* export JSONL without duplicating collection.

**Scope (confirmed): headless sinks only.** The gRPC subscriber and a new JSONL writer become interchangeable `Sink`s. The TUI stays its own consumer (each collector's `Subscribe()` returns a single shared channel — full TUI-on-the-bus unification is low value / high regression risk). Multi-PID is out (separate enhancement).

## What

- **`internal/serve/sink.go`** — a `Sink` interface (`Emit` must never block the hub). `grpcSink` (moved from hub.go's `subscriber`) and a new `jsonlSink`: a bounded channel + writer goroutine that marshals each event with `protojson` (one `Event` per line) and **drops-and-counts** on a slow disk, so the collector drain path never blocks. Writes to an `io.WriteCloser` for testability.
- **`hub.go`** — now holds `sinks map[Sink]struct{}` with `AddSink`/`RemoveSink`; `broadcast` just `Emit`s to each. `subscribe`/`unsubscribe` remain thin `grpcSink` helpers, so `service.go` is unchanged.
- **`serve.Run`** gains `Options{JSONLPath}`; wires the JSONL sink (`RemoveSink` before `Close` so no `Emit` races the channel close). **`ptop --serve --export`** → `ptop-events-<ts>.jsonl` (event-level; distinct from the TUI's state-snapshot `ptop-export-<ts>.jsonl`).
- **CI** — enable the deferred **`buf breaking`** gate (PRs only) now that a schema baseline exists on main, with `fetch-depth: 0` (checkout is shallow by default, which `buf breaking` needs history for).
- `.gitignore` — runtime export artifacts; `CLAUDE.md` updated.

## Test plan

- `go build`/`vet`/`test -race` green on **darwin**, **linux** (`CGO_ENABLED=0`), **linux+ebpf**.
- New tests: `jsonlSink` round-trip (each line `protojson.Unmarshal`s back to an `Event`) + drop-when-writer-blocked; serve JSONL e2e (`Options{JSONLPath}` → file has parseable `Event` lines); hub tests adapted to the `Sink` API. All under `-race`, ran 5× (non-flaky).
- `buf lint`/`generate` clean; `buf breaking` passes (this PR doesn't touch the schema).
- Manual smoke: `ptop --pid <PID> --serve unix:///tmp/p.sock --export --no-ebpf` → `ptop-events-*.jsonl` appears with one JSON `Event` per line, gRPC stream works concurrently, SIGTERM flushes the file + removes the socket.

## #51 status
With this merged, all #51 scope items are done: public package, versioned schema, headless gRPC server (multi-subscriber + backpressure + privilege boundary), and the sink abstraction with JSONL-while-serving.

Closes #51.

🤖 Generated with [Claude Code](https://claude.com/claude-code)