### PR TITLE
heap: libc malloc/free pairing, live-heap + leak signal (#53)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,6 +76,7 @@ ptop/
 │   │   │   ├── network.bpf.c      sock tracepoints + tcp kprobes
 │   │   │   ├── threads.bpf.c      sched_switch
 │   │   │   ├── memory.bpf.c       mmap/brk/page-fault
+│   │   │   ├── heap.bpf.c         libc malloc/free uprobes → lifetime + leak
 │   │   │   └── futex.bpf.c        futex wait/wake → lock graph
 │   │   ├── available.go           runtime feature flag (build-tag based)
 │   │   ├── target.go              pid-namespace target resolver (shared)
@@ -87,6 +88,7 @@ ptop/
 │   │   ├── network.go             sock tracepoints + connection seeding
 │   │   ├── io.go                  VFS syscall tracker loader
 │   │   ├── memory.go              memory counter loader
+│   │   ├── heap.go                libc allocator uprobe loader (#53)
 │   │   ├── threads.go             sched_switch loader
 │   │   ├── futex.go               futex wait/wake loader
 │   │   └── *_stub.go              stubs for non-Linux / no-ebpf builds
@@ -133,6 +135,7 @@ ptop/
 │       ├── threads_ebpf.go        sched_switch → CPU% real-time
 │       ├── mem_proc.go            /proc/<pid>/statm + faults
 │       ├── mem_ebpf.go            kprobe + syscall tracepoints
+│       ├── heap_ebpf.go           libc malloc/free pairing → live-heap + leak (#53)
 │       ├── iowait_proc.go         /proc/<pid>/stat field 42
 │       ├── io_proc.go             /proc/<pid>/io throughput
 │       ├── io_ebpf.go             top files + per-op latency

--- a/Makefile
+++ b/Makefile
@@ -54,6 +54,7 @@ BPF_SRCS := \
 	internal/bpf/programs/network.bpf.c \
 	internal/bpf/programs/threads.bpf.c \
 	internal/bpf/programs/memory.bpf.c \
+	internal/bpf/programs/heap.bpf.c \
 	internal/bpf/programs/futex.bpf.c
 
 BPF_OBJS := $(BPF_SRCS:.c=.o)

--- a/internal/bpf/heap.go
+++ b/internal/bpf/heap.go
@@ -1,0 +1,412 @@
+//go:build linux && ebpf
+
+package bpf
+
+import (
+	"bufio"
+	"bytes"
+	_ "embed"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/cilium/ebpf"
+	"github.com/cilium/ebpf/link"
+	"github.com/cilium/ebpf/ringbuf"
+	"github.com/cilium/ebpf/rlimit"
+	"golang.org/x/sys/unix"
+)
+
+//go:embed programs/heap.bpf.o
+var heapBPFObj []byte
+
+// heapStackDepth mirrors HEAP_STACK_DEPTH in programs/heap.bpf.c — the user
+// stack depth captured per call site.
+const heapStackDepth = 32
+
+// Op codes — mirror the OP_* defines in programs/heap.bpf.c.
+const (
+	HeapOpMalloc  uint32 = 0
+	HeapOpCalloc  uint32 = 1
+	HeapOpRealloc uint32 = 2
+	HeapOpFree    uint32 = 3
+)
+
+// HeapFlagLarge mirrors HEAP_FLAG_LARGE: the allocation is ≥ 128KB.
+const HeapFlagLarge uint32 = 1
+
+// HeapEvent is the 1:1 layout of struct heap_event in programs/heap.bpf.c.
+// Fixed 48 bytes; binary.LittleEndian.Read parses it from the ring buffer.
+type HeapEvent struct {
+	TsNs       uint64
+	Size       uint64
+	Addr       uint64
+	LifetimeNs uint64
+	StackID    int32
+	Op         uint32
+	Flags      uint32
+	TGID       uint32
+}
+
+// allocInfo mirrors struct alloc_info — the per-pointer live record iterated
+// during the leak scan.
+type allocInfo struct {
+	Size    uint64
+	TsNs    uint64
+	StackID int32
+	_       uint32
+}
+
+// HeapCallSiteRaw mirrors struct callsite_stat — the kernel-maintained
+// per-call-site aggregate. live_bytes/live_count are signed (a free decrements
+// them); the collector clamps to ≥ 0 defensively.
+type HeapCallSiteRaw struct {
+	LiveBytes     int64
+	LiveCount     int64
+	AllocCount    uint64
+	LifetimeSumNs uint64
+	LifetimeCount uint64
+	LargeCount    uint64
+}
+
+// HeapLeak is one live allocation whose age exceeds the leak threshold.
+type HeapLeak struct {
+	Size    uint64
+	StackID int32
+	AgeNs   uint64
+}
+
+// maxLeakScan bounds the per-pointer iteration so a pathological live set can't
+// stall the publish loop. Equals heap_allocs' max_entries.
+const maxLeakScan = 1 << 17
+
+// HeapTracer loads heap.bpf.o, attaches uprobes/uretprobes on the target's
+// libc allocator, opens the event ring buffer, and exposes the per-call-site
+// aggregate, the leak scan, and stack resolution.
+type HeapTracer struct {
+	coll        *ebpf.Collection
+	links       []link.Link
+	rb          *ringbuf.Reader
+	allocsMap   *ebpf.Map
+	callsiteMap *ebpf.Map
+	stacksMap   *ebpf.Map
+
+	libcLo, libcHi uint64 // target VA range of the mapped libc
+}
+
+func OpenHeapTracer(pid int) (*HeapTracer, error) {
+	if pid <= 0 {
+		return nil, errors.New("invalid pid")
+	}
+	if err := rlimit.RemoveMemlock(); err != nil {
+		return nil, fmt.Errorf("rlimit: %w", err)
+	}
+
+	libcPath, lo, hi, err := resolveLibc(pid)
+	if err != nil {
+		return nil, err
+	}
+
+	spec, err := ebpf.LoadCollectionSpecFromReader(bytes.NewReader(heapBPFObj))
+	if err != nil {
+		return nil, fmt.Errorf("parse heap BPF object: %w", err)
+	}
+	coll, err := ebpf.NewCollection(spec)
+	if err != nil {
+		return nil, fmt.Errorf("load heap collection: %w", err)
+	}
+	t := &HeapTracer{coll: coll, libcLo: lo, libcHi: hi}
+
+	targetMap := coll.Maps["heap_target_pid"]
+	if targetMap == nil {
+		t.Close()
+		return nil, errors.New("heap_target_pid map missing")
+	}
+	tf, err := resolveTarget(pid)
+	if err != nil {
+		t.Close()
+		return nil, err
+	}
+	if err := writeTargetFilter(targetMap, tf); err != nil {
+		t.Close()
+		return nil, fmt.Errorf("set heap_target_pid: %w", err)
+	}
+
+	t.allocsMap = coll.Maps["heap_allocs"]
+	t.callsiteMap = coll.Maps["heap_callsite_live"]
+	t.stacksMap = coll.Maps["heap_stacks"]
+	if t.allocsMap == nil || t.callsiteMap == nil || t.stacksMap == nil {
+		t.Close()
+		return nil, errors.New("heap maps missing")
+	}
+
+	ex, err := link.OpenExecutable(libcPath)
+	if err != nil {
+		t.Close()
+		return nil, fmt.Errorf("open libc %s: %w", libcPath, err)
+	}
+
+	// Scope the uprobes to the target process so siblings sharing libc don't
+	// fire them; the in-kernel pid-namespace filter is defense-in-depth.
+	opts := &link.UprobeOptions{PID: pid}
+	probes := []struct {
+		sym, prog string
+		ret       bool
+	}{
+		{"malloc", "uprobe_malloc", false},
+		{"malloc", "uretprobe_malloc", true},
+		{"calloc", "uprobe_calloc", false},
+		{"calloc", "uretprobe_calloc", true},
+		{"realloc", "uprobe_realloc", false},
+		{"realloc", "uretprobe_realloc", true},
+		{"free", "uprobe_free", false},
+	}
+	var mallocEntry, mallocRet bool
+	for _, p := range probes {
+		prog := coll.Programs[p.prog]
+		if prog == nil {
+			t.Close()
+			return nil, fmt.Errorf("program %s missing", p.prog)
+		}
+		var l link.Link
+		if p.ret {
+			l, err = ex.Uretprobe(p.sym, prog, opts)
+		} else {
+			l, err = ex.Uprobe(p.sym, prog, opts)
+		}
+		if err != nil {
+			// Tolerate a missing symbol (rare for libc); malloc is required.
+			fmt.Fprintf(os.Stderr, "warning: heap uprobe %s (%s): %v\n", p.sym, p.prog, err)
+			continue
+		}
+		t.links = append(t.links, l)
+		if p.sym == "malloc" {
+			if p.ret {
+				mallocRet = true
+			} else {
+				mallocEntry = true
+			}
+		}
+	}
+	if !mallocEntry || !mallocRet {
+		t.Close()
+		return nil, fmt.Errorf("could not attach malloc uprobes on %s", libcPath)
+	}
+
+	eventsMap := coll.Maps["heap_events"]
+	if eventsMap == nil {
+		t.Close()
+		return nil, errors.New("heap_events ringbuf missing")
+	}
+	rb, err := ringbuf.NewReader(eventsMap)
+	if err != nil {
+		t.Close()
+		return nil, fmt.Errorf("ringbuf reader: %w", err)
+	}
+	t.rb = rb
+
+	return t, nil
+}
+
+// Next blocks until the next heap event arrives. Returns io.EOF when the
+// tracer is closed.
+func (t *HeapTracer) Next() (HeapEvent, error) {
+	var ev HeapEvent
+	if t == nil || t.rb == nil {
+		return ev, errors.New("tracer not initialized")
+	}
+	rec, err := t.rb.Read()
+	if err != nil {
+		if errors.Is(err, ringbuf.ErrClosed) {
+			return ev, io.EOF
+		}
+		return ev, err
+	}
+	if len(rec.RawSample) < 48 {
+		return ev, fmt.Errorf("short event: %d bytes", len(rec.RawSample))
+	}
+	if err := binary.Read(bytes.NewReader(rec.RawSample), binary.LittleEndian, &ev); err != nil {
+		return ev, fmt.Errorf("decode event: %w", err)
+	}
+	return ev, nil
+}
+
+// LiveCallSites snapshots heap_callsite_live: stack_id → running aggregate.
+func (t *HeapTracer) LiveCallSites() (map[int32]HeapCallSiteRaw, error) {
+	if t == nil || t.callsiteMap == nil {
+		return nil, errors.New("tracer not initialized")
+	}
+	out := make(map[int32]HeapCallSiteRaw, 64)
+	var k int32
+	var v HeapCallSiteRaw
+	iter := t.callsiteMap.Iterate()
+	for iter.Next(&k, &v) {
+		out[k] = v
+	}
+	return out, iter.Err()
+}
+
+// LeakScan walks heap_allocs and returns every live allocation whose age
+// exceeds thresholdNs. Bounded by maxLeakScan to cap the work per tick.
+func (t *HeapTracer) LeakScan(thresholdNs uint64) ([]HeapLeak, error) {
+	if t == nil || t.allocsMap == nil {
+		return nil, errors.New("tracer not initialized")
+	}
+	now, err := monotonicNs()
+	if err != nil {
+		return nil, err
+	}
+	var leaks []HeapLeak
+	var ptr uint64
+	var ai allocInfo
+	iter := t.allocsMap.Iterate()
+	scanned := 0
+	for iter.Next(&ptr, &ai) {
+		scanned++
+		if scanned > maxLeakScan {
+			break
+		}
+		if now < ai.TsNs {
+			continue
+		}
+		age := now - ai.TsNs
+		if age > thresholdNs {
+			leaks = append(leaks, HeapLeak{Size: ai.Size, StackID: ai.StackID, AgeNs: age})
+		}
+	}
+	return leaks, iter.Err()
+}
+
+// ResolveStack returns the user-stack frames captured for stackID (leaf first),
+// trailing zero slots trimmed. A negative id (capture failed) yields nil.
+func (t *HeapTracer) ResolveStack(stackID int32) ([]uint64, error) {
+	if stackID < 0 {
+		return nil, nil
+	}
+	if t == nil || t.stacksMap == nil {
+		return nil, errors.New("tracer not initialized")
+	}
+	var frames [heapStackDepth]uint64
+	if err := t.stacksMap.Lookup(uint32(stackID), &frames); err != nil {
+		return nil, err
+	}
+	n := len(frames)
+	for n > 0 && frames[n-1] == 0 {
+		n--
+	}
+	return frames[:n], nil
+}
+
+// LibcRange returns the target VA range of the mapped libc, used to skip libc
+// frames when picking the application call site.
+func (t *HeapTracer) LibcRange() (lo, hi uint64) {
+	if t == nil {
+		return 0, 0
+	}
+	return t.libcLo, t.libcHi
+}
+
+func (t *HeapTracer) Close() error {
+	if t == nil {
+		return nil
+	}
+	if t.rb != nil {
+		_ = t.rb.Close()
+		t.rb = nil
+	}
+	for _, l := range t.links {
+		_ = l.Close()
+	}
+	t.links = nil
+	if t.coll != nil {
+		t.coll.Close()
+		t.coll = nil
+		t.allocsMap = nil
+		t.callsiteMap = nil
+		t.stacksMap = nil
+	}
+	return nil
+}
+
+// monotonicNs reads CLOCK_MONOTONIC in nanoseconds — the same clock
+// bpf_ktime_get_ns() stamps allocations with, so ages compare directly.
+func monotonicNs() (uint64, error) {
+	var ts unix.Timespec
+	if err := unix.ClockGettime(unix.CLOCK_MONOTONIC, &ts); err != nil {
+		return 0, err
+	}
+	return uint64(ts.Sec)*1_000_000_000 + uint64(ts.Nsec), nil
+}
+
+// resolveLibc finds the libc mapped into pid and returns the file path to
+// attach uprobes against plus the [lo,hi) virtual address range of its
+// mappings. Returns an error when no libc is mapped (static / Go binaries) —
+// the caller then leaves the heap collector inactive.
+func resolveLibc(pid int) (path string, lo, hi uint64, err error) {
+	f, err := os.Open(fmt.Sprintf("/proc/%d/maps", pid))
+	if err != nil {
+		return "", 0, 0, fmt.Errorf("open maps of %d: %w", pid, err)
+	}
+	defer f.Close()
+
+	var libcPath string
+	sc := bufio.NewScanner(f)
+	for sc.Scan() {
+		line := sc.Text()
+		// Format: "<lo>-<hi> perms offset dev inode   pathname"
+		fields := strings.Fields(line)
+		if len(fields) < 6 {
+			continue
+		}
+		p := strings.Join(fields[5:], " ")
+		if !isLibc(filepath.Base(p)) {
+			continue
+		}
+		if libcPath == "" {
+			libcPath = p
+		} else if p != libcPath {
+			continue // a different libc-ish file; stick with the first
+		}
+		dash := strings.IndexByte(fields[0], '-')
+		if dash < 0 {
+			continue
+		}
+		start, e1 := strconv.ParseUint(fields[0][:dash], 16, 64)
+		end, e2 := strconv.ParseUint(fields[0][dash+1:], 16, 64)
+		if e1 != nil || e2 != nil {
+			continue
+		}
+		if lo == 0 || start < lo {
+			lo = start
+		}
+		if end > hi {
+			hi = end
+		}
+	}
+	if err := sc.Err(); err != nil {
+		return "", 0, 0, err
+	}
+	if libcPath == "" {
+		return "", 0, 0, errors.New("no libc mapped (static or non-libc binary)")
+	}
+
+	// Prefer the file as seen from the target's mount namespace so the symbol
+	// offsets match the running libc exactly; fall back to the bare path.
+	rooted := fmt.Sprintf("/proc/%d/root%s", pid, libcPath)
+	if _, e := os.Stat(rooted); e == nil {
+		return rooted, lo, hi, nil
+	}
+	return libcPath, lo, hi, nil
+}
+
+// isLibc matches the basename of a glibc or musl C library mapping.
+func isLibc(base string) bool {
+	return strings.HasPrefix(base, "libc.so") ||
+		strings.HasPrefix(base, "libc-") ||
+		strings.Contains(base, "musl")
+}

--- a/internal/bpf/heap_stub.go
+++ b/internal/bpf/heap_stub.go
@@ -1,0 +1,60 @@
+//go:build !linux || !ebpf
+
+package bpf
+
+import (
+	"errors"
+	"io"
+)
+
+var errHeapStub = errors.New("eBPF heap tracer not available in this build")
+
+// Op codes — mirror the OP_* defines in programs/heap.bpf.c.
+const (
+	HeapOpMalloc  uint32 = 0
+	HeapOpCalloc  uint32 = 1
+	HeapOpRealloc uint32 = 2
+	HeapOpFree    uint32 = 3
+)
+
+// HeapFlagLarge mirrors HEAP_FLAG_LARGE: the allocation is ≥ 128KB.
+const HeapFlagLarge uint32 = 1
+
+type HeapEvent struct {
+	TsNs       uint64
+	Size       uint64
+	Addr       uint64
+	LifetimeNs uint64
+	StackID    int32
+	Op         uint32
+	Flags      uint32
+	TGID       uint32
+}
+
+type HeapCallSiteRaw struct {
+	LiveBytes     int64
+	LiveCount     int64
+	AllocCount    uint64
+	LifetimeSumNs uint64
+	LifetimeCount uint64
+	LargeCount    uint64
+}
+
+type HeapLeak struct {
+	Size    uint64
+	StackID int32
+	AgeNs   uint64
+}
+
+type HeapTracer struct{}
+
+func OpenHeapTracer(int) (*HeapTracer, error) { return nil, errHeapStub }
+
+func (*HeapTracer) Next() (HeapEvent, error) { return HeapEvent{}, io.EOF }
+func (*HeapTracer) LiveCallSites() (map[int32]HeapCallSiteRaw, error) {
+	return nil, errHeapStub
+}
+func (*HeapTracer) LeakScan(uint64) ([]HeapLeak, error)  { return nil, errHeapStub }
+func (*HeapTracer) ResolveStack(int32) ([]uint64, error) { return nil, errHeapStub }
+func (*HeapTracer) LibcRange() (uint64, uint64)          { return 0, 0 }
+func (*HeapTracer) Close() error                         { return nil }

--- a/internal/bpf/programs/heap.bpf.c
+++ b/internal/bpf/programs/heap.bpf.c
@@ -1,0 +1,343 @@
+// SPDX-License-Identifier: GPL-2.0
+//
+// heap.bpf.c — libc heap allocation tracking for the target PID (#53).
+//
+// Attaches uprobes/uretprobes to the libc allocator entry points and pairs
+// each allocation with its free by the returned pointer, deriving:
+//   - per-call-site live bytes / alloc count / average lifetime
+//   - allocation lifetime (free.ts − alloc.ts), emitted per event
+//   - a "large allocation" tag for sizes ≥ 128KB (glibc's M_MMAP_THRESHOLD —
+//     the allocations glibc services with a direct mmap rather than the heap)
+//
+// Probes (attached by the Go loader against the target's mapped libc — see
+// internal/bpf/heap.go):
+//   uprobe/uretprobe malloc(size)
+//   uprobe/uretprobe calloc(nmemb, size)
+//   uprobe/uretprobe realloc(ptr, size)   → free(old) + alloc(new)
+//   uprobe           free(ptr)
+//
+// Maps:
+//   heap_target_pid     ARRAY[1]     struct target_filter (Go loader writes it)
+//   heap_inflight       HASH         pid_tgid → in-flight alloc request; carries
+//                                    size+stack from the uprobe entry to the
+//                                    uretprobe exit (the public allocator
+//                                    symbols never recurse on one thread, so a
+//                                    single slot per thread is enough — same
+//                                    trick as io.bpf.c).
+//   heap_allocs         LRU_HASH     ptr → {size, ts_ns, stack_id}; the live set
+//                                    and the pairing/lifetime source. LRU-bounded
+//                                    so a long-lived target can't grow it without
+//                                    limit — eviction silently drops the oldest
+//                                    live allocation, so live-heap UNDERCOUNTS on
+//                                    alloc-heavy targets (a documented fidelity
+//                                    limit, never claimed exact).
+//   heap_callsite_live  HASH         stack_id → aggregate (live bytes/count,
+//                                    alloc count, lifetime sum, large count),
+//                                    updated in the kernel so userspace iterates
+//                                    only this small map (one entry per distinct
+//                                    call site) rather than the per-pointer map.
+//   heap_stacks         STACK_TRACE  user stacks captured at alloc time; the Go
+//                                    side resolves a stack_id to its application
+//                                    call-site address (shown in hex until #54
+//                                    symbolizes it).
+//   heap_events         RINGBUF      per-event stream to userspace (struct
+//                                    heap_event, fixed layout, LittleEndian).
+//
+// Why kernel-side call-site aggregation? Summing live bytes by walking the
+// per-pointer map from userspace every tick would cost O(live allocations)
+// syscalls. Instead each alloc/free updates heap_callsite_live in place, and a
+// free attributes its bytes to the ALLOC site (the stack_id stored in
+// heap_allocs[ptr]), not the free site, so per-site live_bytes stays consistent
+// regardless of where free() is called from.
+
+#include <linux/bpf.h>
+#include <linux/ptrace.h>
+#include <bpf/bpf_helpers.h>
+#include <bpf/bpf_tracing.h>
+#include "target.bpf.h"
+
+char LICENSE[] SEC("license") = "GPL";
+
+// Op codes — shared with the Go side (collector/heap_ebpf.go). For the inflight
+// record they identify which allocator is in flight; on the ring-buffer event
+// they identify the operation.
+#define OP_MALLOC  0
+#define OP_CALLOC  1
+#define OP_REALLOC 2
+#define OP_FREE    3
+
+// glibc's default M_MMAP_THRESHOLD: requests at/above this are serviced with a
+// direct mmap. We tag them from the request size alone — no extra probe.
+#define HEAP_LARGE_THRESHOLD (128 * 1024)
+#define HEAP_FLAG_LARGE 1
+
+// User-stack depth captured per call site. 32 frames is plenty to step over the
+// libc allocator internals and reach the application caller.
+#define HEAP_STACK_DEPTH 32
+
+// In-flight allocation request, keyed by pid_tgid between entry and exit.
+struct inflight {
+    __u64 size;     // requested bytes (calloc: nmemb*size)
+    __u64 old_ptr;  // realloc's first arg; 0 otherwise
+    __s32 stack_id; // bpf_get_stackid result (<0 → unknown)
+    __u32 op;
+};
+
+// Per-pointer live allocation record. 24 bytes — mirrored by allocInfo in
+// internal/bpf/heap.go for the leak scan.
+struct alloc_info {
+    __u64 size;
+    __u64 ts_ns;
+    __s32 stack_id;
+    __u32 _pad;
+};
+
+// Per-call-site running aggregate. Mirrored by HeapCallSiteRaw in heap.go.
+// live_bytes/live_count are signed: a free only decrements when its alloc was
+// tracked, so they stay ≥ 0 in practice, but signed keeps atomic subtraction
+// well-defined and lets the Go side clamp defensively.
+struct callsite_stat {
+    __s64 live_bytes;
+    __s64 live_count;
+    __u64 alloc_count;
+    __u64 lifetime_sum_ns;
+    __u64 lifetime_count;
+    __u64 large_count;
+};
+
+// Event published to userspace via ring buffer. Fixed 48-byte layout, read with
+// binary.LittleEndian on the Go side — keep in sync with HeapEvent in heap.go.
+struct heap_event {
+    __u64 ts_ns;
+    __u64 size;
+    __u64 addr;
+    __u64 lifetime_ns; // free.ts − alloc.ts; 0 for alloc events
+    __s32 stack_id;    // alloc-site stack (<0 → unknown)
+    __u32 op;
+    __u32 flags;       // bit0 = large (size ≥ HEAP_LARGE_THRESHOLD)
+    __u32 tgid;
+};
+
+struct {
+    __uint(type, BPF_MAP_TYPE_ARRAY);
+    __type(key, __u32);
+    __type(value, struct target_filter);
+    __uint(max_entries, 1);
+} heap_target_pid SEC(".maps");
+
+struct {
+    __uint(type, BPF_MAP_TYPE_HASH);
+    __type(key, __u64);
+    __type(value, struct inflight);
+    __uint(max_entries, 10240);
+} heap_inflight SEC(".maps");
+
+struct {
+    __uint(type, BPF_MAP_TYPE_LRU_HASH);
+    __type(key, __u64);
+    __type(value, struct alloc_info);
+    __uint(max_entries, 1 << 17); // 131072 live allocations before eviction
+} heap_allocs SEC(".maps");
+
+struct {
+    __uint(type, BPF_MAP_TYPE_HASH);
+    __type(key, __s32);
+    __type(value, struct callsite_stat);
+    __uint(max_entries, 8192);
+} heap_callsite_live SEC(".maps");
+
+struct {
+    __uint(type, BPF_MAP_TYPE_STACK_TRACE);
+    __uint(key_size, sizeof(__u32));
+    __uint(value_size, HEAP_STACK_DEPTH * sizeof(__u64));
+    __uint(max_entries, 16384);
+} heap_stacks SEC(".maps");
+
+struct {
+    __uint(type, BPF_MAP_TYPE_RINGBUF);
+    __uint(max_entries, 1 << 20); // 1MB
+} heap_events SEC(".maps");
+
+static __always_inline int is_heap_target(void)
+{
+    return pid_is_target(&heap_target_pid);
+}
+
+static __always_inline struct callsite_stat *get_or_init_callsite(__s32 sid)
+{
+    struct callsite_stat *cs = bpf_map_lookup_elem(&heap_callsite_live, &sid);
+    if (cs)
+        return cs;
+    struct callsite_stat zero = {};
+    bpf_map_update_elem(&heap_callsite_live, &sid, &zero, BPF_NOEXIST);
+    return bpf_map_lookup_elem(&heap_callsite_live, &sid);
+}
+
+static __always_inline void emit(__u64 ts, __u64 size, __u64 addr,
+                                 __u64 lifetime, __s32 sid, __u32 op,
+                                 __u32 flags, __u32 tgid)
+{
+    struct heap_event *e = bpf_ringbuf_reserve(&heap_events, sizeof(*e), 0);
+    if (!e)
+        return;
+    e->ts_ns       = ts;
+    e->size        = size;
+    e->addr        = addr;
+    e->lifetime_ns = lifetime;
+    e->stack_id    = sid;
+    e->op          = op;
+    e->flags       = flags;
+    e->tgid        = tgid;
+    bpf_ringbuf_submit(e, 0);
+}
+
+static __always_inline void do_alloc(__u64 ptr, __u64 size, __s32 sid,
+                                     __u32 op, __u32 tgid)
+{
+    __u64 now = bpf_ktime_get_ns();
+    struct alloc_info ai = {
+        .size     = size,
+        .ts_ns    = now,
+        .stack_id = sid,
+    };
+    bpf_map_update_elem(&heap_allocs, &ptr, &ai, BPF_ANY);
+
+    struct callsite_stat *cs = get_or_init_callsite(sid);
+    if (cs) {
+        __sync_fetch_and_add(&cs->live_bytes, (__s64)size);
+        __sync_fetch_and_add(&cs->live_count, 1);
+        __sync_fetch_and_add(&cs->alloc_count, 1);
+        if (size >= HEAP_LARGE_THRESHOLD)
+            __sync_fetch_and_add(&cs->large_count, 1);
+    }
+
+    __u32 flags = (size >= HEAP_LARGE_THRESHOLD) ? HEAP_FLAG_LARGE : 0;
+    emit(now, size, ptr, 0, sid, op, flags, tgid);
+}
+
+static __always_inline void do_free(__u64 ptr, __u32 tgid)
+{
+    if (ptr == 0)
+        return; // free(NULL) is a no-op
+    struct alloc_info *ai = bpf_map_lookup_elem(&heap_allocs, &ptr);
+    if (!ai)
+        return; // untracked: pre-existing block or LRU-evicted — skip
+
+    __u64 now      = bpf_ktime_get_ns();
+    __u64 size     = ai->size;
+    __s32 sid      = ai->stack_id;
+    __u64 lifetime = now - ai->ts_ns;
+
+    // Attribute the freed bytes back to the ALLOC site, not the free site.
+    struct callsite_stat *cs = bpf_map_lookup_elem(&heap_callsite_live, &sid);
+    if (cs) {
+        __sync_fetch_and_add(&cs->live_bytes, -(__s64)size);
+        __sync_fetch_and_add(&cs->live_count, -1);
+        __sync_fetch_and_add(&cs->lifetime_sum_ns, lifetime);
+        __sync_fetch_and_add(&cs->lifetime_count, 1);
+    }
+
+    __u32 flags = (size >= HEAP_LARGE_THRESHOLD) ? HEAP_FLAG_LARGE : 0;
+    emit(now, size, ptr, lifetime, sid, OP_FREE, flags, tgid);
+
+    bpf_map_delete_elem(&heap_allocs, &ptr);
+}
+
+static __always_inline void enter_alloc(void *ctx, __u64 size, __u64 old_ptr,
+                                        __u32 op)
+{
+    if (!is_heap_target())
+        return;
+    __u64 pt = bpf_get_current_pid_tgid();
+    struct inflight inf = {
+        .size     = size,
+        .old_ptr  = old_ptr,
+        .stack_id = (__s32)bpf_get_stackid(ctx, &heap_stacks, BPF_F_USER_STACK),
+        .op       = op,
+    };
+    bpf_map_update_elem(&heap_inflight, &pt, &inf, BPF_ANY);
+}
+
+static __always_inline void exit_alloc(__u64 ret)
+{
+    __u64 pt = bpf_get_current_pid_tgid();
+    struct inflight *inf = bpf_map_lookup_elem(&heap_inflight, &pt);
+    if (!inf)
+        return;
+    __u32 op      = inf->op;
+    __u64 size    = inf->size;
+    __u64 old_ptr = inf->old_ptr;
+    __s32 sid     = inf->stack_id;
+    __u32 tgid    = (__u32)(pt >> 32);
+    bpf_map_delete_elem(&heap_inflight, &pt);
+
+    if (op == OP_REALLOC) {
+        // realloc(p, n): the old block is released iff realloc returned a
+        // (possibly new) pointer, or n==0 (shrink-to-free). On OOM
+        // (ret==0 && n>0) the old block stays live — release nothing.
+        if (old_ptr != 0 && (ret != 0 || size == 0))
+            do_free(old_ptr, tgid);
+        if (ret != 0)
+            do_alloc(ret, size, sid, OP_REALLOC, tgid);
+        return;
+    }
+
+    // malloc / calloc — ret==0 is OOM, emit nothing.
+    if (ret != 0)
+        do_alloc(ret, size, sid, op, tgid);
+}
+
+SEC("uprobe/malloc")
+int BPF_KPROBE(uprobe_malloc, __u64 size)
+{
+    enter_alloc(ctx, size, 0, OP_MALLOC);
+    return 0;
+}
+
+SEC("uretprobe/malloc")
+int BPF_KRETPROBE(uretprobe_malloc, void *ret)
+{
+    exit_alloc((__u64)ret);
+    return 0;
+}
+
+SEC("uprobe/calloc")
+int BPF_KPROBE(uprobe_calloc, __u64 nmemb, __u64 size)
+{
+    // A truncating 64-bit product is fine: a real overflow makes calloc return
+    // NULL, so the uretprobe sees ret==0 and records nothing — the bogus total
+    // is never used. (A manual overflow check via the division idiom makes
+    // clang emit a 128-bit __multi3, which the BPF target rejects.)
+    enter_alloc(ctx, nmemb * size, 0, OP_CALLOC);
+    return 0;
+}
+
+SEC("uretprobe/calloc")
+int BPF_KRETPROBE(uretprobe_calloc, void *ret)
+{
+    exit_alloc((__u64)ret);
+    return 0;
+}
+
+SEC("uprobe/realloc")
+int BPF_KPROBE(uprobe_realloc, void *ptr, __u64 size)
+{
+    enter_alloc(ctx, size, (__u64)ptr, OP_REALLOC);
+    return 0;
+}
+
+SEC("uretprobe/realloc")
+int BPF_KRETPROBE(uretprobe_realloc, void *ret)
+{
+    exit_alloc((__u64)ret);
+    return 0;
+}
+
+SEC("uprobe/free")
+int BPF_KPROBE(uprobe_free, void *ptr)
+{
+    if (!is_heap_target())
+        return 0;
+    do_free((__u64)ptr, (__u32)(bpf_get_current_pid_tgid() >> 32));
+    return 0;
+}

--- a/internal/serve/mapper.go
+++ b/internal/serve/mapper.go
@@ -53,6 +53,24 @@ func toEvent(pid int, v interface{}) *pb.Event {
 			PageFaults: x.PageFaults, AllocsPerS: x.AllocsPerS,
 		}}
 
+	case collector.HeapStats:
+		ev.TsUnixNano = tsNano(x.Timestamp)
+		ev.Category = pb.Category_CATEGORY_MEMORY
+		ev.Payload = &pb.Event_Heap{Heap: &pb.HeapSnapshot{
+			LiveHeapBytes:      x.LiveHeapBytes,
+			AllocRate:          x.AllocRate,
+			SuspectedLeakBytes: x.SuspectedLeakBytes,
+			TopCallSites:       heapCallSites(x.TopCallSites),
+		}}
+
+	case collector.HeapEvent:
+		ev.TsUnixNano = nowNano()
+		ev.Category = pb.Category_CATEGORY_MEMORY
+		ev.Payload = &pb.Event_HeapEvent{HeapEvent: &pb.HeapEvent{
+			Op: x.Op, Size: x.Size, Addr: x.Addr,
+			LifetimeMs: x.LifetimeMs, CallSite: x.CallSite, Large: x.Large,
+		}}
+
 	case []collector.ThreadInfo:
 		ev.TsUnixNano = nowNano()
 		ev.Category = pb.Category_CATEGORY_THREAD
@@ -126,6 +144,17 @@ func toEvent(pid int, v interface{}) *pb.Event {
 	}
 
 	return ev
+}
+
+func heapCallSites(in []collector.HeapCallSite) []*pb.HeapCallSite {
+	out := make([]*pb.HeapCallSite, len(in))
+	for i, s := range in {
+		out[i] = &pb.HeapCallSite{
+			CallSite: s.CallSite, AddrHex: s.AddrHex, LiveBytes: s.LiveBytes,
+			AllocCount: s.AllocCount, AvgLifetimeMs: s.AvgLifetimeMs, Suspected: s.Suspected,
+		}
+	}
+	return out
 }
 
 func fileStats(in []collector.IOFileStats) []*pb.IoFileStats {

--- a/internal/serve/mapper_test.go
+++ b/internal/serve/mapper_test.go
@@ -27,6 +27,20 @@ func TestToEventCategoriesAndPayloads(t *testing.T) {
 			}},
 		{"memory", collector.MemStats{RSSBytes: 1000, AllocsPerS: 9},
 			pb.Category_CATEGORY_MEMORY, func(e *pb.Event) bool { return e.GetMemory().GetRssBytes() == 1000 }},
+		{"heap_snapshot", collector.HeapStats{
+			LiveHeapBytes: 4096, AllocRate: 12.5, SuspectedLeakBytes: 1024,
+			TopCallSites: []collector.HeapCallSite{{CallSite: 0xabc, AddrHex: "0xabc", LiveBytes: 4096, Suspected: true}},
+			Timestamp:    time.Unix(6, 0),
+		}, pb.Category_CATEGORY_MEMORY, func(e *pb.Event) bool {
+			h := e.GetHeap()
+			return h.GetLiveHeapBytes() == 4096 && h.GetSuspectedLeakBytes() == 1024 &&
+				len(h.GetTopCallSites()) == 1 && h.GetTopCallSites()[0].GetAddrHex() == "0xabc"
+		}},
+		{"heap_event", collector.HeapEvent{Op: "free", Size: 256, Addr: 0xdead, LifetimeMs: 7.5, CallSite: 0xabc, Large: false},
+			pb.Category_CATEGORY_MEMORY, func(e *pb.Event) bool {
+				he := e.GetHeapEvent()
+				return he.GetOp() == "free" && he.GetSize() == 256 && he.GetLifetimeMs() == 7.5
+			}},
 		{"threads", []collector.ThreadInfo{{TID: 11, Name: "main", CtxSwitches: 4}},
 			pb.Category_CATEGORY_THREAD, func(e *pb.Event) bool {
 				th := e.GetThreads().GetThreads()

--- a/pkg/collector/heap_agg.go
+++ b/pkg/collector/heap_agg.go
@@ -1,0 +1,85 @@
+package collector
+
+import (
+	"fmt"
+	"sort"
+
+	"github.com/trentas/ptop/internal/bpf"
+)
+
+// Pure aggregation/formatting helpers for the heap collector (#53), kept free
+// of any kernel/eBPF dependency so they unit-test on every platform. The real
+// collector (heap_ebpf.go) feeds these from the BPF maps.
+
+// isSuspectedLeak reports whether an allocation of the given age has outlived
+// the leak threshold. It is a stateless property of the current live set — a
+// suspicion, not a proof (a long-lived cache looks identical to a leak).
+func isSuspectedLeak(ageNs, thresholdNs uint64) bool {
+	return ageNs > thresholdNs
+}
+
+// chooseTopCallSites returns the n call sites with the most live bytes,
+// descending. Ties break by AllocCount then CallSite for a deterministic order.
+// n < 0 keeps all.
+func chooseTopCallSites(sites []HeapCallSite, n int) []HeapCallSite {
+	out := make([]HeapCallSite, len(sites))
+	copy(out, sites)
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].LiveBytes != out[j].LiveBytes {
+			return out[i].LiveBytes > out[j].LiveBytes
+		}
+		if out[i].AllocCount != out[j].AllocCount {
+			return out[i].AllocCount > out[j].AllocCount
+		}
+		return out[i].CallSite < out[j].CallSite
+	})
+	if n >= 0 && len(out) > n {
+		out = out[:n]
+	}
+	return out
+}
+
+// pickAppFrame returns the first stack frame outside the libc address range —
+// the application site that called the allocator. Frames are leaf-first (libc
+// internals first). Falls back to the leaf frame when every frame is inside
+// libc, and to 0 when there are no frames.
+func pickAppFrame(frames []uint64, libcLo, libcHi uint64) uint64 {
+	for _, f := range frames {
+		if f == 0 {
+			continue
+		}
+		if libcHi > libcLo && f >= libcLo && f < libcHi {
+			continue // inside libc — keep walking toward the caller
+		}
+		return f
+	}
+	if len(frames) > 0 {
+		return frames[0]
+	}
+	return 0
+}
+
+// heapAddrHex formats a call-site address for display; 0 means the stack walk
+// failed (no frame pointers) and renders as "unknown".
+func heapAddrHex(addr uint64) string {
+	if addr == 0 {
+		return "unknown"
+	}
+	return fmt.Sprintf("0x%x", addr)
+}
+
+// heapOpName maps a kernel op code to its event-stream string.
+func heapOpName(op uint32) string {
+	switch op {
+	case bpf.HeapOpMalloc:
+		return "malloc"
+	case bpf.HeapOpCalloc:
+		return "calloc"
+	case bpf.HeapOpRealloc:
+		return "realloc"
+	case bpf.HeapOpFree:
+		return "free"
+	default:
+		return "?"
+	}
+}

--- a/pkg/collector/heap_agg_test.go
+++ b/pkg/collector/heap_agg_test.go
@@ -1,0 +1,90 @@
+package collector
+
+import "testing"
+
+func TestIsSuspectedLeak(t *testing.T) {
+	const thresh = 10 * 1e9 // 10s in ns
+	cases := []struct {
+		age  uint64
+		want bool
+	}{
+		{0, false},
+		{thresh - 1, false},
+		{thresh, false}, // boundary: must strictly exceed
+		{thresh + 1, true},
+		{thresh * 3, true},
+	}
+	for _, c := range cases {
+		if got := isSuspectedLeak(c.age, thresh); got != c.want {
+			t.Errorf("isSuspectedLeak(%d, %d) = %v, want %v", c.age, uint64(thresh), got, c.want)
+		}
+	}
+}
+
+func TestChooseTopCallSites(t *testing.T) {
+	sites := []HeapCallSite{
+		{CallSite: 1, LiveBytes: 100, AllocCount: 5},
+		{CallSite: 2, LiveBytes: 500, AllocCount: 1},
+		{CallSite: 3, LiveBytes: 300, AllocCount: 9},
+		{CallSite: 4, LiveBytes: 100, AllocCount: 8}, // ties LiveBytes with #1, more allocs
+	}
+	got := chooseTopCallSites(sites, 3)
+	if len(got) != 3 {
+		t.Fatalf("len = %d, want 3", len(got))
+	}
+	wantOrder := []uint64{2, 3, 4} // 500, 300, then 100/allocs=8 beats 100/allocs=5
+	for i, cs := range wantOrder {
+		if got[i].CallSite != cs {
+			t.Errorf("position %d: CallSite = %d, want %d (order: %+v)", i, got[i].CallSite, cs, got)
+		}
+	}
+
+	// n larger than the slice keeps everything; original is not mutated.
+	all := chooseTopCallSites(sites, 10)
+	if len(all) != 4 {
+		t.Errorf("len = %d, want 4", len(all))
+	}
+	if sites[0].CallSite != 1 {
+		t.Errorf("input slice was mutated: %+v", sites)
+	}
+}
+
+func TestPickAppFrame(t *testing.T) {
+	const lo, hi = 0x7f000000, 0x7f001000
+	cases := []struct {
+		name   string
+		frames []uint64
+		want   uint64
+	}{
+		{"first frame in libc, second in app", []uint64{0x7f000500, 0x400123}, 0x400123},
+		{"skip zero and libc frames", []uint64{0, 0x7f000800, 0x401000}, 0x401000},
+		{"all libc → fall back to leaf", []uint64{0x7f000100, 0x7f000900}, 0x7f000100},
+		{"no range info → first non-zero", []uint64{0x12345}, 0x12345},
+		{"empty → 0", nil, 0},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := pickAppFrame(c.frames, lo, hi); got != c.want {
+				t.Errorf("pickAppFrame(%x) = %#x, want %#x", c.frames, got, c.want)
+			}
+		})
+	}
+}
+
+func TestHeapAddrHex(t *testing.T) {
+	if got := heapAddrHex(0); got != "unknown" {
+		t.Errorf("heapAddrHex(0) = %q, want \"unknown\"", got)
+	}
+	if got := heapAddrHex(0xdeadbeef); got != "0xdeadbeef" {
+		t.Errorf("heapAddrHex(0xdeadbeef) = %q", got)
+	}
+}
+
+func TestHeapOpName(t *testing.T) {
+	cases := map[uint32]string{0: "malloc", 1: "calloc", 2: "realloc", 3: "free", 99: "?"}
+	for op, want := range cases {
+		if got := heapOpName(op); got != want {
+			t.Errorf("heapOpName(%d) = %q, want %q", op, got, want)
+		}
+	}
+}

--- a/pkg/collector/heap_ebpf.go
+++ b/pkg/collector/heap_ebpf.go
@@ -1,0 +1,211 @@
+//go:build linux && ebpf
+
+package collector
+
+import (
+	"fmt"
+	"io"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/trentas/ptop/internal/bpf"
+)
+
+// HeapEBPFCollector tracks libc heap allocations via the uprobe-based eBPF
+// tracer (#53). Two goroutines:
+//
+//   - readLoop drains the per-event ring buffer, forwarding each alloc/free as
+//     a HeapEvent (best-effort, dropped under backpressure like every other
+//     collector) and counting allocations for the rate.
+//   - publishLoop, every 500ms, reads the kernel's per-call-site aggregate and
+//     runs a bounded leak scan over the live set, publishing a HeapStats
+//     snapshot.
+//
+// Live-heap and leak figures come from the kernel's LRU-bounded live set, so
+// they UNDERCOUNT on alloc-heavy targets (documented in heap.bpf.c) — never
+// presented as exact.
+type HeapEBPFCollector struct {
+	tracer *bpf.HeapTracer
+	ch     chan interface{}
+	stop   chan struct{}
+	pid    int
+
+	leakThreshold time.Duration
+
+	allocCount uint64 // atomic; allocations since the last publish (rate)
+
+	mu       sync.Mutex
+	siteAddr map[int32]uint64 // stack_id → resolved app call-site (cache)
+	lastAt   time.Time        // publishLoop-only; rate baseline
+}
+
+const (
+	heapDefaultLeakThreshold = 10 * time.Second
+	heapTopCallSites         = 8
+	heapPublishInterval      = 500 * time.Millisecond
+)
+
+func NewHeapEBPFCollector() *HeapEBPFCollector {
+	return &HeapEBPFCollector{
+		ch:            make(chan interface{}, 64),
+		stop:          make(chan struct{}),
+		leakThreshold: heapDefaultLeakThreshold,
+		siteAddr:      make(map[int32]uint64),
+	}
+}
+
+func (c *HeapEBPFCollector) Start(pid int) error {
+	tracer, err := bpf.OpenHeapTracer(pid)
+	if err != nil {
+		return fmt.Errorf("heap eBPF: %w", err)
+	}
+	c.tracer = tracer
+	c.pid = pid
+	go c.readLoop()
+	go c.publishLoop()
+	return nil
+}
+
+func (c *HeapEBPFCollector) Stop() {
+	close(c.stop)
+	if c.tracer != nil {
+		_ = c.tracer.Close()
+		c.tracer = nil
+	}
+}
+
+func (c *HeapEBPFCollector) Subscribe() <-chan interface{} { return c.ch }
+
+func (c *HeapEBPFCollector) readLoop() {
+	for {
+		ev, err := c.tracer.Next()
+		if err != nil {
+			if err == io.EOF {
+				return
+			}
+			continue // transient; keep reading
+		}
+		if ev.Op != bpf.HeapOpFree {
+			atomic.AddUint64(&c.allocCount, 1)
+		}
+		he := HeapEvent{
+			Op:         heapOpName(ev.Op),
+			Size:       ev.Size,
+			Addr:       ev.Addr,
+			LifetimeMs: float64(ev.LifetimeNs) / 1e6,
+			CallSite:   c.resolveSite(ev.StackID),
+			Large:      ev.Flags&bpf.HeapFlagLarge != 0,
+		}
+		select {
+		case c.ch <- he:
+		default:
+		}
+	}
+}
+
+// resolveSite maps a stack_id to the application call-site address, caching it
+// (stacks are stable for the process lifetime).
+func (c *HeapEBPFCollector) resolveSite(stackID int32) uint64 {
+	if stackID < 0 {
+		return 0
+	}
+	c.mu.Lock()
+	if a, ok := c.siteAddr[stackID]; ok {
+		c.mu.Unlock()
+		return a
+	}
+	c.mu.Unlock()
+
+	frames, err := c.tracer.ResolveStack(stackID)
+	if err != nil {
+		return 0
+	}
+	lo, hi := c.tracer.LibcRange()
+	addr := pickAppFrame(frames, lo, hi)
+
+	c.mu.Lock()
+	c.siteAddr[stackID] = addr
+	c.mu.Unlock()
+	return addr
+}
+
+func (c *HeapEBPFCollector) publishLoop() {
+	t := time.NewTicker(heapPublishInterval)
+	defer t.Stop()
+	for {
+		select {
+		case <-c.stop:
+			return
+		case <-t.C:
+			if s, err := c.snapshot(); err == nil {
+				select {
+				case c.ch <- s:
+				default:
+				}
+			}
+		}
+	}
+}
+
+func (c *HeapEBPFCollector) snapshot() (HeapStats, error) {
+	live, err := c.tracer.LiveCallSites()
+	if err != nil {
+		return HeapStats{}, err
+	}
+	leaks, err := c.tracer.LeakScan(uint64(c.leakThreshold.Nanoseconds()))
+	if err != nil {
+		return HeapStats{}, err
+	}
+
+	// Sum suspected-leak bytes by the alloc-site stack (same key the live
+	// aggregate uses), so a call site can be flagged as leaking.
+	leakBytes := make(map[int32]uint64, len(leaks))
+	var suspectedTotal uint64
+	for _, lk := range leaks {
+		leakBytes[lk.StackID] += lk.Size
+		suspectedTotal += lk.Size
+	}
+
+	sites := make([]HeapCallSite, 0, len(live))
+	var liveTotal uint64
+	for sid, raw := range live {
+		lb := raw.LiveBytes
+		if lb < 0 {
+			lb = 0 // defensive: never present negative live bytes
+		}
+		liveTotal += uint64(lb)
+		avgLifeMs := 0.0
+		if raw.LifetimeCount > 0 {
+			avgLifeMs = float64(raw.LifetimeSumNs) / float64(raw.LifetimeCount) / 1e6
+		}
+		addr := c.resolveSite(sid)
+		sites = append(sites, HeapCallSite{
+			CallSite:      addr,
+			AddrHex:       heapAddrHex(addr),
+			LiveBytes:     uint64(lb),
+			AllocCount:    raw.AllocCount,
+			AvgLifetimeMs: avgLifeMs,
+			Suspected:     leakBytes[sid] > 0,
+		})
+	}
+
+	now := time.Now()
+	var rate float64
+	if !c.lastAt.IsZero() {
+		if elapsed := now.Sub(c.lastAt).Seconds(); elapsed > 0 {
+			rate = float64(atomic.SwapUint64(&c.allocCount, 0)) / elapsed
+		}
+	} else {
+		atomic.StoreUint64(&c.allocCount, 0) // discard the warm-up interval
+	}
+	c.lastAt = now
+
+	return HeapStats{
+		Timestamp:          now,
+		LiveHeapBytes:      liveTotal,
+		AllocRate:          rate,
+		TopCallSites:       chooseTopCallSites(sites, heapTopCallSites),
+		SuspectedLeakBytes: suspectedTotal,
+	}, nil
+}

--- a/pkg/collector/heap_ebpf_stub.go
+++ b/pkg/collector/heap_ebpf_stub.go
@@ -1,0 +1,14 @@
+//go:build !linux || !ebpf
+
+package collector
+
+import "errors"
+
+type HeapEBPFCollector struct{}
+
+func NewHeapEBPFCollector() *HeapEBPFCollector { return &HeapEBPFCollector{} }
+func (*HeapEBPFCollector) Start(int) error {
+	return errors.New("eBPF heap collector not available in this build")
+}
+func (*HeapEBPFCollector) Stop()                         {}
+func (*HeapEBPFCollector) Subscribe() <-chan interface{} { return nil }

--- a/pkg/collector/set.go
+++ b/pkg/collector/set.go
@@ -21,6 +21,7 @@ type Sources struct {
 	CPU      string
 	Threads  string
 	Mem      string
+	Heap     string
 	Syscalls string
 	IOFiles  string
 	Net      string
@@ -39,6 +40,7 @@ type Set struct {
 	ThreadsEBPF  *ThreadsEBPFCollector
 	MemProc      *MemCollector
 	MemEBPF      *MemEBPFCollector
+	HeapEBPF     *HeapEBPFCollector
 	IOWait       *IOWaitCollector
 	IOThroughput *IOThroughputCollector
 	SyscallsEBPF *SyscallsEBPFCollector
@@ -162,6 +164,17 @@ func NewSet(cfg SetConfig) *Set {
 		} else {
 			warnEBPFFailure("futex", err)
 		}
+
+		// Heap (libc malloc/free pairing) augments the memory subsystem. No
+		// /proc fallback and no simulation — absent unless eBPF can attach the
+		// libc uprobes (so static / non-libc targets simply have no heap data).
+		c5 := NewHeapEBPFCollector()
+		if err := c5.Start(cfg.PID); err == nil {
+			s.HeapEBPF = c5
+			s.Sources.Heap = "eBPF"
+		} else {
+			warnEBPFFailure("heap", err)
+		}
 	}
 
 	return s
@@ -195,6 +208,9 @@ func (s *Set) Stop() {
 	}
 	if s.MemEBPF != nil {
 		s.MemEBPF.Stop()
+	}
+	if s.HeapEBPF != nil {
+		s.HeapEBPF.Stop()
 	}
 	if s.IOWait != nil {
 		s.IOWait.Stop()
@@ -237,6 +253,7 @@ func (s *Set) Collectors() []Collector {
 	add(s.ThreadsEBPF, s.ThreadsEBPF != nil)
 	add(s.MemProc, s.MemProc != nil)
 	add(s.MemEBPF, s.MemEBPF != nil)
+	add(s.HeapEBPF, s.HeapEBPF != nil)
 	add(s.IOWait, s.IOWait != nil)
 	add(s.IOThroughput, s.IOThroughput != nil)
 	add(s.SyscallsEBPF, s.SyscallsEBPF != nil)
@@ -253,6 +270,7 @@ func (s *Set) MockFDs() bool          { return s.FD == nil }
 func (s *Set) MockCPU() bool          { return s.CPUEBPF == nil && s.CPUProc == nil }
 func (s *Set) MockThreads() bool      { return s.ThreadsEBPF == nil && s.ThreadsProc == nil }
 func (s *Set) MockMem() bool          { return s.MemEBPF == nil && s.MemProc == nil }
+func (s *Set) MockHeap() bool         { return s.HeapEBPF == nil }
 func (s *Set) MockIOWait() bool       { return s.IOWait == nil }
 func (s *Set) MockIOThroughput() bool { return s.IOThroughput == nil }
 func (s *Set) MockSyscalls() bool     { return s.SyscallsEBPF == nil }

--- a/pkg/collector/types.go
+++ b/pkg/collector/types.go
@@ -39,14 +39,53 @@ type MemStats struct {
 	AllocsPerS uint64
 }
 
+// ─── Heap allocations (eBPF libc malloc/free pairing — #53) ───────────────────
+
+// HeapEvent is a single allocation or free observed via libc uprobes.
+// Op is "malloc"|"calloc"|"realloc"|"free". LifetimeMs is set on free
+// (free.ts − alloc.ts). CallSite is the application call-site address (shown in
+// hex; #54 will symbolize it). Large flags allocations ≥ 128KB.
+type HeapEvent struct {
+	Op         string
+	Size       uint64
+	Addr       uint64
+	LifetimeMs float64
+	CallSite   uint64
+	Large      bool
+}
+
+// HeapCallSite aggregates the currently-live allocations attributed to one
+// application call site (by the alloc-site stack, so a free decrements the site
+// it was allocated from).
+type HeapCallSite struct {
+	CallSite      uint64  // raw application instruction pointer
+	AddrHex       string  // "0x…" display form ("unknown" when unresolved)
+	LiveBytes     uint64  // bytes still live from this site
+	AllocCount    uint64  // total allocations ever from this site
+	AvgLifetimeMs float64 // mean lifetime of freed allocations from this site
+	Suspected     bool    // has live allocations older than the leak threshold
+}
+
+// HeapStats is the periodic snapshot of heap behavior. LiveHeapBytes and
+// SuspectedLeakBytes derive from the kernel's live set, which LRU-evicts under
+// pressure — so both UNDERCOUNT on alloc-heavy targets (see heap.bpf.c); never
+// presented as exact. AllocRate is allocations per second over the last window.
+type HeapStats struct {
+	Timestamp          time.Time
+	LiveHeapBytes      uint64
+	AllocRate          float64
+	TopCallSites       []HeapCallSite
+	SuspectedLeakBytes uint64
+}
+
 // ─── Threads ─────────────────────────────────────────────────────────────────
 
 type ThreadInfo struct {
 	TID     int
 	Name    string
-	State   string  // "running" | "blocked" | "sleeping"
+	State   string // "running" | "blocked" | "sleeping"
 	CPUPct  float64
-	Waiting string  // name of the blocking lock/syscall, empty if none
+	Waiting string // name of the blocking lock/syscall, empty if none
 	// CtxSwitches: total context switches for the thread within the current
 	// window (interval between collector publishes). Only populated when the
 	// eBPF threads collector is active; via /proc this stays zero.
@@ -146,7 +185,7 @@ type FDEntry struct {
 	Flags  string // "O_RDONLY" | "O_WRONLY" | "O_RDWR"
 	Bytes  uint64
 	AgeMs  int64
-	Active bool   // had activity in the last cycle
+	Active bool // had activity in the last cycle
 }
 
 // ─── Timeline ────────────────────────────────────────────────────────────────

--- a/pkg/streampb/event.pb.go
+++ b/pkg/streampb/event.pb.go
@@ -178,6 +178,8 @@ type Event struct {
 	//	*Event_FdEvent
 	//	*Event_Locks
 	//	*Event_Timeline
+	//	*Event_Heap
+	//	*Event_HeapEvent
 	Payload       isEvent_Payload `protobuf_oneof:"payload"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
@@ -363,6 +365,24 @@ func (x *Event) GetTimeline() *TimelineEvent {
 	return nil
 }
 
+func (x *Event) GetHeap() *HeapSnapshot {
+	if x != nil {
+		if x, ok := x.Payload.(*Event_Heap); ok {
+			return x.Heap
+		}
+	}
+	return nil
+}
+
+func (x *Event) GetHeapEvent() *HeapEvent {
+	if x != nil {
+		if x, ok := x.Payload.(*Event_HeapEvent); ok {
+			return x.HeapEvent
+		}
+	}
+	return nil
+}
+
 type isEvent_Payload interface {
 	isEvent_Payload()
 }
@@ -415,6 +435,15 @@ type Event_Timeline struct {
 	Timeline *TimelineEvent `protobuf:"bytes,21,opt,name=timeline,proto3,oneof"`
 }
 
+type Event_Heap struct {
+	// #52 capabilities:
+	Heap *HeapSnapshot `protobuf:"bytes,22,opt,name=heap,proto3,oneof"` // #53 — periodic heap aggregate
+}
+
+type Event_HeapEvent struct {
+	HeapEvent *HeapEvent `protobuf:"bytes,23,opt,name=heap_event,json=heapEvent,proto3,oneof"` // #53 — per alloc/free
+}
+
 func (*Event_Cpu) isEvent_Payload() {}
 
 func (*Event_Syscalls) isEvent_Payload() {}
@@ -438,6 +467,10 @@ func (*Event_FdEvent) isEvent_Payload() {}
 func (*Event_Locks) isEvent_Payload() {}
 
 func (*Event_Timeline) isEvent_Payload() {}
+
+func (*Event_Heap) isEvent_Payload() {}
+
+func (*Event_HeapEvent) isEvent_Payload() {}
 
 // ─── CPU ──────────────────────────────────────────────────────────────────
 type CpuSample struct {
@@ -803,6 +836,252 @@ func (x *MemStats) GetAllocsPerS() uint64 {
 	return 0
 }
 
+// ─── Heap allocations (#53 — libc malloc/free pairing) ──────────────────────
+// HeapEvent is a single allocation or free observed via libc uprobes. op is
+// "malloc"|"calloc"|"realloc"|"free"; lifetime_ms is set on free; call_site is
+// the application call-site address (resolved to a symbol out-of-band by #54).
+type HeapEvent struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Op            string                 `protobuf:"bytes,1,opt,name=op,proto3" json:"op,omitempty"`
+	Size          uint64                 `protobuf:"varint,2,opt,name=size,proto3" json:"size,omitempty"`
+	Addr          uint64                 `protobuf:"varint,3,opt,name=addr,proto3" json:"addr,omitempty"`
+	LifetimeMs    float64                `protobuf:"fixed64,4,opt,name=lifetime_ms,json=lifetimeMs,proto3" json:"lifetime_ms,omitempty"`
+	CallSite      uint64                 `protobuf:"varint,5,opt,name=call_site,json=callSite,proto3" json:"call_site,omitempty"`
+	Large         bool                   `protobuf:"varint,6,opt,name=large,proto3" json:"large,omitempty"` // allocation ≥ 128KB
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *HeapEvent) Reset() {
+	*x = HeapEvent{}
+	mi := &file_event_proto_msgTypes[8]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *HeapEvent) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*HeapEvent) ProtoMessage() {}
+
+func (x *HeapEvent) ProtoReflect() protoreflect.Message {
+	mi := &file_event_proto_msgTypes[8]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use HeapEvent.ProtoReflect.Descriptor instead.
+func (*HeapEvent) Descriptor() ([]byte, []int) {
+	return file_event_proto_rawDescGZIP(), []int{8}
+}
+
+func (x *HeapEvent) GetOp() string {
+	if x != nil {
+		return x.Op
+	}
+	return ""
+}
+
+func (x *HeapEvent) GetSize() uint64 {
+	if x != nil {
+		return x.Size
+	}
+	return 0
+}
+
+func (x *HeapEvent) GetAddr() uint64 {
+	if x != nil {
+		return x.Addr
+	}
+	return 0
+}
+
+func (x *HeapEvent) GetLifetimeMs() float64 {
+	if x != nil {
+		return x.LifetimeMs
+	}
+	return 0
+}
+
+func (x *HeapEvent) GetCallSite() uint64 {
+	if x != nil {
+		return x.CallSite
+	}
+	return 0
+}
+
+func (x *HeapEvent) GetLarge() bool {
+	if x != nil {
+		return x.Large
+	}
+	return false
+}
+
+// HeapCallSite aggregates the live allocations attributed to one application
+// call site (by the alloc site, so a free decrements where it was allocated).
+type HeapCallSite struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	CallSite      uint64                 `protobuf:"varint,1,opt,name=call_site,json=callSite,proto3" json:"call_site,omitempty"`
+	AddrHex       string                 `protobuf:"bytes,2,opt,name=addr_hex,json=addrHex,proto3" json:"addr_hex,omitempty"` // "0x…" display form ("unknown" when unresolved)
+	LiveBytes     uint64                 `protobuf:"varint,3,opt,name=live_bytes,json=liveBytes,proto3" json:"live_bytes,omitempty"`
+	AllocCount    uint64                 `protobuf:"varint,4,opt,name=alloc_count,json=allocCount,proto3" json:"alloc_count,omitempty"`
+	AvgLifetimeMs float64                `protobuf:"fixed64,5,opt,name=avg_lifetime_ms,json=avgLifetimeMs,proto3" json:"avg_lifetime_ms,omitempty"`
+	Suspected     bool                   `protobuf:"varint,6,opt,name=suspected,proto3" json:"suspected,omitempty"` // has live allocations older than the leak threshold
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *HeapCallSite) Reset() {
+	*x = HeapCallSite{}
+	mi := &file_event_proto_msgTypes[9]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *HeapCallSite) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*HeapCallSite) ProtoMessage() {}
+
+func (x *HeapCallSite) ProtoReflect() protoreflect.Message {
+	mi := &file_event_proto_msgTypes[9]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use HeapCallSite.ProtoReflect.Descriptor instead.
+func (*HeapCallSite) Descriptor() ([]byte, []int) {
+	return file_event_proto_rawDescGZIP(), []int{9}
+}
+
+func (x *HeapCallSite) GetCallSite() uint64 {
+	if x != nil {
+		return x.CallSite
+	}
+	return 0
+}
+
+func (x *HeapCallSite) GetAddrHex() string {
+	if x != nil {
+		return x.AddrHex
+	}
+	return ""
+}
+
+func (x *HeapCallSite) GetLiveBytes() uint64 {
+	if x != nil {
+		return x.LiveBytes
+	}
+	return 0
+}
+
+func (x *HeapCallSite) GetAllocCount() uint64 {
+	if x != nil {
+		return x.AllocCount
+	}
+	return 0
+}
+
+func (x *HeapCallSite) GetAvgLifetimeMs() float64 {
+	if x != nil {
+		return x.AvgLifetimeMs
+	}
+	return 0
+}
+
+func (x *HeapCallSite) GetSuspected() bool {
+	if x != nil {
+		return x.Suspected
+	}
+	return false
+}
+
+// HeapSnapshot is the periodic heap aggregate. live_heap_bytes and
+// suspected_leak_bytes derive from the kernel's LRU-bounded live set, so they
+// undercount on alloc-heavy targets — never exact. alloc_rate is allocations
+// per second over the last window.
+type HeapSnapshot struct {
+	state              protoimpl.MessageState `protogen:"open.v1"`
+	LiveHeapBytes      uint64                 `protobuf:"varint,1,opt,name=live_heap_bytes,json=liveHeapBytes,proto3" json:"live_heap_bytes,omitempty"`
+	AllocRate          float64                `protobuf:"fixed64,2,opt,name=alloc_rate,json=allocRate,proto3" json:"alloc_rate,omitempty"`
+	SuspectedLeakBytes uint64                 `protobuf:"varint,3,opt,name=suspected_leak_bytes,json=suspectedLeakBytes,proto3" json:"suspected_leak_bytes,omitempty"`
+	TopCallSites       []*HeapCallSite        `protobuf:"bytes,4,rep,name=top_call_sites,json=topCallSites,proto3" json:"top_call_sites,omitempty"`
+	unknownFields      protoimpl.UnknownFields
+	sizeCache          protoimpl.SizeCache
+}
+
+func (x *HeapSnapshot) Reset() {
+	*x = HeapSnapshot{}
+	mi := &file_event_proto_msgTypes[10]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *HeapSnapshot) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*HeapSnapshot) ProtoMessage() {}
+
+func (x *HeapSnapshot) ProtoReflect() protoreflect.Message {
+	mi := &file_event_proto_msgTypes[10]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use HeapSnapshot.ProtoReflect.Descriptor instead.
+func (*HeapSnapshot) Descriptor() ([]byte, []int) {
+	return file_event_proto_rawDescGZIP(), []int{10}
+}
+
+func (x *HeapSnapshot) GetLiveHeapBytes() uint64 {
+	if x != nil {
+		return x.LiveHeapBytes
+	}
+	return 0
+}
+
+func (x *HeapSnapshot) GetAllocRate() float64 {
+	if x != nil {
+		return x.AllocRate
+	}
+	return 0
+}
+
+func (x *HeapSnapshot) GetSuspectedLeakBytes() uint64 {
+	if x != nil {
+		return x.SuspectedLeakBytes
+	}
+	return 0
+}
+
+func (x *HeapSnapshot) GetTopCallSites() []*HeapCallSite {
+	if x != nil {
+		return x.TopCallSites
+	}
+	return nil
+}
+
 // ─── Threads ────────────────────────────────────────────────────────────────
 type ThreadInfo struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
@@ -818,7 +1097,7 @@ type ThreadInfo struct {
 
 func (x *ThreadInfo) Reset() {
 	*x = ThreadInfo{}
-	mi := &file_event_proto_msgTypes[8]
+	mi := &file_event_proto_msgTypes[11]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -830,7 +1109,7 @@ func (x *ThreadInfo) String() string {
 func (*ThreadInfo) ProtoMessage() {}
 
 func (x *ThreadInfo) ProtoReflect() protoreflect.Message {
-	mi := &file_event_proto_msgTypes[8]
+	mi := &file_event_proto_msgTypes[11]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -843,7 +1122,7 @@ func (x *ThreadInfo) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ThreadInfo.ProtoReflect.Descriptor instead.
 func (*ThreadInfo) Descriptor() ([]byte, []int) {
-	return file_event_proto_rawDescGZIP(), []int{8}
+	return file_event_proto_rawDescGZIP(), []int{11}
 }
 
 func (x *ThreadInfo) GetTid() int32 {
@@ -897,7 +1176,7 @@ type ThreadSnapshot struct {
 
 func (x *ThreadSnapshot) Reset() {
 	*x = ThreadSnapshot{}
-	mi := &file_event_proto_msgTypes[9]
+	mi := &file_event_proto_msgTypes[12]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -909,7 +1188,7 @@ func (x *ThreadSnapshot) String() string {
 func (*ThreadSnapshot) ProtoMessage() {}
 
 func (x *ThreadSnapshot) ProtoReflect() protoreflect.Message {
-	mi := &file_event_proto_msgTypes[9]
+	mi := &file_event_proto_msgTypes[12]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -922,7 +1201,7 @@ func (x *ThreadSnapshot) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ThreadSnapshot.ProtoReflect.Descriptor instead.
 func (*ThreadSnapshot) Descriptor() ([]byte, []int) {
-	return file_event_proto_rawDescGZIP(), []int{9}
+	return file_event_proto_rawDescGZIP(), []int{12}
 }
 
 func (x *ThreadSnapshot) GetThreads() []*ThreadInfo {
@@ -942,7 +1221,7 @@ type IoWaitSample struct {
 
 func (x *IoWaitSample) Reset() {
 	*x = IoWaitSample{}
-	mi := &file_event_proto_msgTypes[10]
+	mi := &file_event_proto_msgTypes[13]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -954,7 +1233,7 @@ func (x *IoWaitSample) String() string {
 func (*IoWaitSample) ProtoMessage() {}
 
 func (x *IoWaitSample) ProtoReflect() protoreflect.Message {
-	mi := &file_event_proto_msgTypes[10]
+	mi := &file_event_proto_msgTypes[13]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -967,7 +1246,7 @@ func (x *IoWaitSample) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use IoWaitSample.ProtoReflect.Descriptor instead.
 func (*IoWaitSample) Descriptor() ([]byte, []int) {
-	return file_event_proto_rawDescGZIP(), []int{10}
+	return file_event_proto_rawDescGZIP(), []int{13}
 }
 
 func (x *IoWaitSample) GetPct() float64 {
@@ -989,7 +1268,7 @@ type IoThroughputSample struct {
 
 func (x *IoThroughputSample) Reset() {
 	*x = IoThroughputSample{}
-	mi := &file_event_proto_msgTypes[11]
+	mi := &file_event_proto_msgTypes[14]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1001,7 +1280,7 @@ func (x *IoThroughputSample) String() string {
 func (*IoThroughputSample) ProtoMessage() {}
 
 func (x *IoThroughputSample) ProtoReflect() protoreflect.Message {
-	mi := &file_event_proto_msgTypes[11]
+	mi := &file_event_proto_msgTypes[14]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1014,7 +1293,7 @@ func (x *IoThroughputSample) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use IoThroughputSample.ProtoReflect.Descriptor instead.
 func (*IoThroughputSample) Descriptor() ([]byte, []int) {
-	return file_event_proto_rawDescGZIP(), []int{11}
+	return file_event_proto_rawDescGZIP(), []int{14}
 }
 
 func (x *IoThroughputSample) GetReadBytesPerS() float64 {
@@ -1060,7 +1339,7 @@ type IoFileStats struct {
 
 func (x *IoFileStats) Reset() {
 	*x = IoFileStats{}
-	mi := &file_event_proto_msgTypes[12]
+	mi := &file_event_proto_msgTypes[15]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1072,7 +1351,7 @@ func (x *IoFileStats) String() string {
 func (*IoFileStats) ProtoMessage() {}
 
 func (x *IoFileStats) ProtoReflect() protoreflect.Message {
-	mi := &file_event_proto_msgTypes[12]
+	mi := &file_event_proto_msgTypes[15]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1085,7 +1364,7 @@ func (x *IoFileStats) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use IoFileStats.ProtoReflect.Descriptor instead.
 func (*IoFileStats) Descriptor() ([]byte, []int) {
-	return file_event_proto_rawDescGZIP(), []int{12}
+	return file_event_proto_rawDescGZIP(), []int{15}
 }
 
 func (x *IoFileStats) GetPath() string {
@@ -1148,7 +1427,7 @@ type LatencyBucket struct {
 
 func (x *LatencyBucket) Reset() {
 	*x = LatencyBucket{}
-	mi := &file_event_proto_msgTypes[13]
+	mi := &file_event_proto_msgTypes[16]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1160,7 +1439,7 @@ func (x *LatencyBucket) String() string {
 func (*LatencyBucket) ProtoMessage() {}
 
 func (x *LatencyBucket) ProtoReflect() protoreflect.Message {
-	mi := &file_event_proto_msgTypes[13]
+	mi := &file_event_proto_msgTypes[16]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1173,7 +1452,7 @@ func (x *LatencyBucket) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LatencyBucket.ProtoReflect.Descriptor instead.
 func (*LatencyBucket) Descriptor() ([]byte, []int) {
-	return file_event_proto_rawDescGZIP(), []int{13}
+	return file_event_proto_rawDescGZIP(), []int{16}
 }
 
 func (x *LatencyBucket) GetLabel() string {
@@ -1214,7 +1493,7 @@ type IoSnapshot struct {
 
 func (x *IoSnapshot) Reset() {
 	*x = IoSnapshot{}
-	mi := &file_event_proto_msgTypes[14]
+	mi := &file_event_proto_msgTypes[17]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1226,7 +1505,7 @@ func (x *IoSnapshot) String() string {
 func (*IoSnapshot) ProtoMessage() {}
 
 func (x *IoSnapshot) ProtoReflect() protoreflect.Message {
-	mi := &file_event_proto_msgTypes[14]
+	mi := &file_event_proto_msgTypes[17]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1239,7 +1518,7 @@ func (x *IoSnapshot) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use IoSnapshot.ProtoReflect.Descriptor instead.
 func (*IoSnapshot) Descriptor() ([]byte, []int) {
-	return file_event_proto_rawDescGZIP(), []int{14}
+	return file_event_proto_rawDescGZIP(), []int{17}
 }
 
 func (x *IoSnapshot) GetReadBytesPerS() float64 {
@@ -1321,7 +1600,7 @@ type FdEntry struct {
 
 func (x *FdEntry) Reset() {
 	*x = FdEntry{}
-	mi := &file_event_proto_msgTypes[15]
+	mi := &file_event_proto_msgTypes[18]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1333,7 +1612,7 @@ func (x *FdEntry) String() string {
 func (*FdEntry) ProtoMessage() {}
 
 func (x *FdEntry) ProtoReflect() protoreflect.Message {
-	mi := &file_event_proto_msgTypes[15]
+	mi := &file_event_proto_msgTypes[18]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1346,7 +1625,7 @@ func (x *FdEntry) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use FdEntry.ProtoReflect.Descriptor instead.
 func (*FdEntry) Descriptor() ([]byte, []int) {
-	return file_event_proto_rawDescGZIP(), []int{15}
+	return file_event_proto_rawDescGZIP(), []int{18}
 }
 
 func (x *FdEntry) GetFd() int32 {
@@ -1407,7 +1686,7 @@ type FdSnapshot struct {
 
 func (x *FdSnapshot) Reset() {
 	*x = FdSnapshot{}
-	mi := &file_event_proto_msgTypes[16]
+	mi := &file_event_proto_msgTypes[19]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1419,7 +1698,7 @@ func (x *FdSnapshot) String() string {
 func (*FdSnapshot) ProtoMessage() {}
 
 func (x *FdSnapshot) ProtoReflect() protoreflect.Message {
-	mi := &file_event_proto_msgTypes[16]
+	mi := &file_event_proto_msgTypes[19]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1432,7 +1711,7 @@ func (x *FdSnapshot) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use FdSnapshot.ProtoReflect.Descriptor instead.
 func (*FdSnapshot) Descriptor() ([]byte, []int) {
-	return file_event_proto_rawDescGZIP(), []int{16}
+	return file_event_proto_rawDescGZIP(), []int{19}
 }
 
 func (x *FdSnapshot) GetFds() []*FdEntry {
@@ -1453,7 +1732,7 @@ type FdEvent struct {
 
 func (x *FdEvent) Reset() {
 	*x = FdEvent{}
-	mi := &file_event_proto_msgTypes[17]
+	mi := &file_event_proto_msgTypes[20]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1465,7 +1744,7 @@ func (x *FdEvent) String() string {
 func (*FdEvent) ProtoMessage() {}
 
 func (x *FdEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_event_proto_msgTypes[17]
+	mi := &file_event_proto_msgTypes[20]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1478,7 +1757,7 @@ func (x *FdEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use FdEvent.ProtoReflect.Descriptor instead.
 func (*FdEvent) Descriptor() ([]byte, []int) {
-	return file_event_proto_rawDescGZIP(), []int{17}
+	return file_event_proto_rawDescGZIP(), []int{20}
 }
 
 func (x *FdEvent) GetMessage() string {
@@ -1504,7 +1783,7 @@ type LockEntry struct {
 
 func (x *LockEntry) Reset() {
 	*x = LockEntry{}
-	mi := &file_event_proto_msgTypes[18]
+	mi := &file_event_proto_msgTypes[21]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1516,7 +1795,7 @@ func (x *LockEntry) String() string {
 func (*LockEntry) ProtoMessage() {}
 
 func (x *LockEntry) ProtoReflect() protoreflect.Message {
-	mi := &file_event_proto_msgTypes[18]
+	mi := &file_event_proto_msgTypes[21]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1529,7 +1808,7 @@ func (x *LockEntry) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LockEntry.ProtoReflect.Descriptor instead.
 func (*LockEntry) Descriptor() ([]byte, []int) {
-	return file_event_proto_rawDescGZIP(), []int{18}
+	return file_event_proto_rawDescGZIP(), []int{21}
 }
 
 func (x *LockEntry) GetUaddr() uint64 {
@@ -1590,7 +1869,7 @@ type LockSnapshot struct {
 
 func (x *LockSnapshot) Reset() {
 	*x = LockSnapshot{}
-	mi := &file_event_proto_msgTypes[19]
+	mi := &file_event_proto_msgTypes[22]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1602,7 +1881,7 @@ func (x *LockSnapshot) String() string {
 func (*LockSnapshot) ProtoMessage() {}
 
 func (x *LockSnapshot) ProtoReflect() protoreflect.Message {
-	mi := &file_event_proto_msgTypes[19]
+	mi := &file_event_proto_msgTypes[22]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1615,7 +1894,7 @@ func (x *LockSnapshot) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LockSnapshot.ProtoReflect.Descriptor instead.
 func (*LockSnapshot) Descriptor() ([]byte, []int) {
-	return file_event_proto_rawDescGZIP(), []int{19}
+	return file_event_proto_rawDescGZIP(), []int{22}
 }
 
 func (x *LockSnapshot) GetLocks() []*LockEntry {
@@ -1636,7 +1915,7 @@ type TimelineEvent struct {
 
 func (x *TimelineEvent) Reset() {
 	*x = TimelineEvent{}
-	mi := &file_event_proto_msgTypes[20]
+	mi := &file_event_proto_msgTypes[23]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1648,7 +1927,7 @@ func (x *TimelineEvent) String() string {
 func (*TimelineEvent) ProtoMessage() {}
 
 func (x *TimelineEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_event_proto_msgTypes[20]
+	mi := &file_event_proto_msgTypes[23]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1661,7 +1940,7 @@ func (x *TimelineEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TimelineEvent.ProtoReflect.Descriptor instead.
 func (*TimelineEvent) Descriptor() ([]byte, []int) {
-	return file_event_proto_rawDescGZIP(), []int{20}
+	return file_event_proto_rawDescGZIP(), []int{23}
 }
 
 func (x *TimelineEvent) GetMessage() string {
@@ -1678,7 +1957,7 @@ const file_event_proto_rawDesc = "" +
 	"\vevent.proto\x12\aptop.v1\"@\n" +
 	"\bStackRef\x12\x19\n" +
 	"\bstack_id\x18\x01 \x01(\x04R\astackId\x12\x19\n" +
-	"\bbuild_id\x18\x02 \x01(\tR\abuildId\"\x82\x06\n" +
+	"\bbuild_id\x18\x02 \x01(\tR\abuildId\"\xe4\x06\n" +
 	"\x05Event\x12 \n" +
 	"\fts_unix_nano\x18\x01 \x01(\x03R\n" +
 	"tsUnixNano\x12\x10\n" +
@@ -1698,7 +1977,10 @@ const file_event_proto_rawDesc = "" +
 	"\x03fds\x18\x12 \x01(\v2\x13.ptop.v1.FdSnapshotH\x00R\x03fds\x12-\n" +
 	"\bfd_event\x18\x13 \x01(\v2\x10.ptop.v1.FdEventH\x00R\afdEvent\x12-\n" +
 	"\x05locks\x18\x14 \x01(\v2\x15.ptop.v1.LockSnapshotH\x00R\x05locks\x124\n" +
-	"\btimeline\x18\x15 \x01(\v2\x16.ptop.v1.TimelineEventH\x00R\btimelineB\t\n" +
+	"\btimeline\x18\x15 \x01(\v2\x16.ptop.v1.TimelineEventH\x00R\btimeline\x12+\n" +
+	"\x04heap\x18\x16 \x01(\v2\x15.ptop.v1.HeapSnapshotH\x00R\x04heap\x123\n" +
+	"\n" +
+	"heap_event\x18\x17 \x01(\v2\x12.ptop.v1.HeapEventH\x00R\theapEventB\t\n" +
 	"\apayload\"(\n" +
 	"\tCpuSample\x12\x1b\n" +
 	"\tusage_pct\x18\x01 \x01(\x01R\busagePct\"V\n" +
@@ -1728,7 +2010,30 @@ const file_event_proto_rawDesc = "" +
 	"\vpage_faults\x18\x03 \x01(\x04R\n" +
 	"pageFaults\x12 \n" +
 	"\fallocs_per_s\x18\x04 \x01(\x04R\n" +
-	"allocsPerS\"\x9e\x01\n" +
+	"allocsPerS\"\x97\x01\n" +
+	"\tHeapEvent\x12\x0e\n" +
+	"\x02op\x18\x01 \x01(\tR\x02op\x12\x12\n" +
+	"\x04size\x18\x02 \x01(\x04R\x04size\x12\x12\n" +
+	"\x04addr\x18\x03 \x01(\x04R\x04addr\x12\x1f\n" +
+	"\vlifetime_ms\x18\x04 \x01(\x01R\n" +
+	"lifetimeMs\x12\x1b\n" +
+	"\tcall_site\x18\x05 \x01(\x04R\bcallSite\x12\x14\n" +
+	"\x05large\x18\x06 \x01(\bR\x05large\"\xcc\x01\n" +
+	"\fHeapCallSite\x12\x1b\n" +
+	"\tcall_site\x18\x01 \x01(\x04R\bcallSite\x12\x19\n" +
+	"\baddr_hex\x18\x02 \x01(\tR\aaddrHex\x12\x1d\n" +
+	"\n" +
+	"live_bytes\x18\x03 \x01(\x04R\tliveBytes\x12\x1f\n" +
+	"\valloc_count\x18\x04 \x01(\x04R\n" +
+	"allocCount\x12&\n" +
+	"\x0favg_lifetime_ms\x18\x05 \x01(\x01R\ravgLifetimeMs\x12\x1c\n" +
+	"\tsuspected\x18\x06 \x01(\bR\tsuspected\"\xc4\x01\n" +
+	"\fHeapSnapshot\x12&\n" +
+	"\x0flive_heap_bytes\x18\x01 \x01(\x04R\rliveHeapBytes\x12\x1d\n" +
+	"\n" +
+	"alloc_rate\x18\x02 \x01(\x01R\tallocRate\x120\n" +
+	"\x14suspected_leak_bytes\x18\x03 \x01(\x04R\x12suspectedLeakBytes\x12;\n" +
+	"\x0etop_call_sites\x18\x04 \x03(\v2\x15.ptop.v1.HeapCallSiteR\ftopCallSites\"\x9e\x01\n" +
 	"\n" +
 	"ThreadInfo\x12\x10\n" +
 	"\x03tid\x18\x01 \x01(\x05R\x03tid\x12\x12\n" +
@@ -1824,7 +2129,7 @@ func file_event_proto_rawDescGZIP() []byte {
 }
 
 var file_event_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
-var file_event_proto_msgTypes = make([]protoimpl.MessageInfo, 21)
+var file_event_proto_msgTypes = make([]protoimpl.MessageInfo, 24)
 var file_event_proto_goTypes = []any{
 	(Category)(0),              // 0: ptop.v1.Category
 	(*StackRef)(nil),           // 1: ptop.v1.StackRef
@@ -1835,19 +2140,22 @@ var file_event_proto_goTypes = []any{
 	(*NetConn)(nil),            // 6: ptop.v1.NetConn
 	(*NetworkSnapshot)(nil),    // 7: ptop.v1.NetworkSnapshot
 	(*MemStats)(nil),           // 8: ptop.v1.MemStats
-	(*ThreadInfo)(nil),         // 9: ptop.v1.ThreadInfo
-	(*ThreadSnapshot)(nil),     // 10: ptop.v1.ThreadSnapshot
-	(*IoWaitSample)(nil),       // 11: ptop.v1.IoWaitSample
-	(*IoThroughputSample)(nil), // 12: ptop.v1.IoThroughputSample
-	(*IoFileStats)(nil),        // 13: ptop.v1.IoFileStats
-	(*LatencyBucket)(nil),      // 14: ptop.v1.LatencyBucket
-	(*IoSnapshot)(nil),         // 15: ptop.v1.IoSnapshot
-	(*FdEntry)(nil),            // 16: ptop.v1.FdEntry
-	(*FdSnapshot)(nil),         // 17: ptop.v1.FdSnapshot
-	(*FdEvent)(nil),            // 18: ptop.v1.FdEvent
-	(*LockEntry)(nil),          // 19: ptop.v1.LockEntry
-	(*LockSnapshot)(nil),       // 20: ptop.v1.LockSnapshot
-	(*TimelineEvent)(nil),      // 21: ptop.v1.TimelineEvent
+	(*HeapEvent)(nil),          // 9: ptop.v1.HeapEvent
+	(*HeapCallSite)(nil),       // 10: ptop.v1.HeapCallSite
+	(*HeapSnapshot)(nil),       // 11: ptop.v1.HeapSnapshot
+	(*ThreadInfo)(nil),         // 12: ptop.v1.ThreadInfo
+	(*ThreadSnapshot)(nil),     // 13: ptop.v1.ThreadSnapshot
+	(*IoWaitSample)(nil),       // 14: ptop.v1.IoWaitSample
+	(*IoThroughputSample)(nil), // 15: ptop.v1.IoThroughputSample
+	(*IoFileStats)(nil),        // 16: ptop.v1.IoFileStats
+	(*LatencyBucket)(nil),      // 17: ptop.v1.LatencyBucket
+	(*IoSnapshot)(nil),         // 18: ptop.v1.IoSnapshot
+	(*FdEntry)(nil),            // 19: ptop.v1.FdEntry
+	(*FdSnapshot)(nil),         // 20: ptop.v1.FdSnapshot
+	(*FdEvent)(nil),            // 21: ptop.v1.FdEvent
+	(*LockEntry)(nil),          // 22: ptop.v1.LockEntry
+	(*LockSnapshot)(nil),       // 23: ptop.v1.LockSnapshot
+	(*TimelineEvent)(nil),      // 24: ptop.v1.TimelineEvent
 }
 var file_event_proto_depIdxs = []int32{
 	0,  // 0: ptop.v1.Event.category:type_name -> ptop.v1.Category
@@ -1856,26 +2164,29 @@ var file_event_proto_depIdxs = []int32{
 	5,  // 3: ptop.v1.Event.syscalls:type_name -> ptop.v1.SyscallSnapshot
 	7,  // 4: ptop.v1.Event.network:type_name -> ptop.v1.NetworkSnapshot
 	8,  // 5: ptop.v1.Event.memory:type_name -> ptop.v1.MemStats
-	10, // 6: ptop.v1.Event.threads:type_name -> ptop.v1.ThreadSnapshot
-	11, // 7: ptop.v1.Event.io_wait:type_name -> ptop.v1.IoWaitSample
-	12, // 8: ptop.v1.Event.io_throughput:type_name -> ptop.v1.IoThroughputSample
-	15, // 9: ptop.v1.Event.io:type_name -> ptop.v1.IoSnapshot
-	17, // 10: ptop.v1.Event.fds:type_name -> ptop.v1.FdSnapshot
-	18, // 11: ptop.v1.Event.fd_event:type_name -> ptop.v1.FdEvent
-	20, // 12: ptop.v1.Event.locks:type_name -> ptop.v1.LockSnapshot
-	21, // 13: ptop.v1.Event.timeline:type_name -> ptop.v1.TimelineEvent
-	4,  // 14: ptop.v1.SyscallSnapshot.stats:type_name -> ptop.v1.SyscallStat
-	6,  // 15: ptop.v1.NetworkSnapshot.conns:type_name -> ptop.v1.NetConn
-	9,  // 16: ptop.v1.ThreadSnapshot.threads:type_name -> ptop.v1.ThreadInfo
-	13, // 17: ptop.v1.IoSnapshot.top_files:type_name -> ptop.v1.IoFileStats
-	14, // 18: ptop.v1.IoSnapshot.latency_buckets:type_name -> ptop.v1.LatencyBucket
-	16, // 19: ptop.v1.FdSnapshot.fds:type_name -> ptop.v1.FdEntry
-	19, // 20: ptop.v1.LockSnapshot.locks:type_name -> ptop.v1.LockEntry
-	21, // [21:21] is the sub-list for method output_type
-	21, // [21:21] is the sub-list for method input_type
-	21, // [21:21] is the sub-list for extension type_name
-	21, // [21:21] is the sub-list for extension extendee
-	0,  // [0:21] is the sub-list for field type_name
+	13, // 6: ptop.v1.Event.threads:type_name -> ptop.v1.ThreadSnapshot
+	14, // 7: ptop.v1.Event.io_wait:type_name -> ptop.v1.IoWaitSample
+	15, // 8: ptop.v1.Event.io_throughput:type_name -> ptop.v1.IoThroughputSample
+	18, // 9: ptop.v1.Event.io:type_name -> ptop.v1.IoSnapshot
+	20, // 10: ptop.v1.Event.fds:type_name -> ptop.v1.FdSnapshot
+	21, // 11: ptop.v1.Event.fd_event:type_name -> ptop.v1.FdEvent
+	23, // 12: ptop.v1.Event.locks:type_name -> ptop.v1.LockSnapshot
+	24, // 13: ptop.v1.Event.timeline:type_name -> ptop.v1.TimelineEvent
+	11, // 14: ptop.v1.Event.heap:type_name -> ptop.v1.HeapSnapshot
+	9,  // 15: ptop.v1.Event.heap_event:type_name -> ptop.v1.HeapEvent
+	4,  // 16: ptop.v1.SyscallSnapshot.stats:type_name -> ptop.v1.SyscallStat
+	6,  // 17: ptop.v1.NetworkSnapshot.conns:type_name -> ptop.v1.NetConn
+	10, // 18: ptop.v1.HeapSnapshot.top_call_sites:type_name -> ptop.v1.HeapCallSite
+	12, // 19: ptop.v1.ThreadSnapshot.threads:type_name -> ptop.v1.ThreadInfo
+	16, // 20: ptop.v1.IoSnapshot.top_files:type_name -> ptop.v1.IoFileStats
+	17, // 21: ptop.v1.IoSnapshot.latency_buckets:type_name -> ptop.v1.LatencyBucket
+	19, // 22: ptop.v1.FdSnapshot.fds:type_name -> ptop.v1.FdEntry
+	22, // 23: ptop.v1.LockSnapshot.locks:type_name -> ptop.v1.LockEntry
+	24, // [24:24] is the sub-list for method output_type
+	24, // [24:24] is the sub-list for method input_type
+	24, // [24:24] is the sub-list for extension type_name
+	24, // [24:24] is the sub-list for extension extendee
+	0,  // [0:24] is the sub-list for field type_name
 }
 
 func init() { file_event_proto_init() }
@@ -1896,6 +2207,8 @@ func file_event_proto_init() {
 		(*Event_FdEvent)(nil),
 		(*Event_Locks)(nil),
 		(*Event_Timeline)(nil),
+		(*Event_Heap)(nil),
+		(*Event_HeapEvent)(nil),
 	}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
@@ -1903,7 +2216,7 @@ func file_event_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_event_proto_rawDesc), len(file_event_proto_rawDesc)),
 			NumEnums:      1,
-			NumMessages:   21,
+			NumMessages:   24,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/proto/event.proto
+++ b/proto/event.proto
@@ -56,9 +56,12 @@ message Event {
     FdEvent fd_event = 19;
     LockSnapshot locks = 20;
     TimelineEvent timeline = 21;
-    // 22+ reserved for #52 capabilities (malloc/free pairing, pre-encryption
-    // payload, signals, detailed net errors, fs semantics, security/LSM,
-    // exec-context enrichment).
+    // #52 capabilities:
+    HeapSnapshot heap = 22; // #53 — periodic heap aggregate
+    HeapEvent heap_event = 23; // #53 — per alloc/free
+    // 24+ reserved for the remaining #52 capabilities (pre-encryption payload,
+    // signals, detailed net errors, fs semantics, security/LSM, exec-context
+    // enrichment).
   }
 }
 
@@ -98,6 +101,41 @@ message MemStats {
   uint64 heap_bytes = 2;
   uint64 page_faults = 3;
   uint64 allocs_per_s = 4;
+}
+
+// ─── Heap allocations (#53 — libc malloc/free pairing) ──────────────────────
+// HeapEvent is a single allocation or free observed via libc uprobes. op is
+// "malloc"|"calloc"|"realloc"|"free"; lifetime_ms is set on free; call_site is
+// the application call-site address (resolved to a symbol out-of-band by #54).
+message HeapEvent {
+  string op = 1;
+  uint64 size = 2;
+  uint64 addr = 3;
+  double lifetime_ms = 4;
+  uint64 call_site = 5;
+  bool large = 6; // allocation ≥ 128KB
+}
+
+// HeapCallSite aggregates the live allocations attributed to one application
+// call site (by the alloc site, so a free decrements where it was allocated).
+message HeapCallSite {
+  uint64 call_site = 1;
+  string addr_hex = 2; // "0x…" display form ("unknown" when unresolved)
+  uint64 live_bytes = 3;
+  uint64 alloc_count = 4;
+  double avg_lifetime_ms = 5;
+  bool suspected = 6; // has live allocations older than the leak threshold
+}
+
+// HeapSnapshot is the periodic heap aggregate. live_heap_bytes and
+// suspected_leak_bytes derive from the kernel's LRU-bounded live set, so they
+// undercount on alloc-heavy targets — never exact. alloc_rate is allocations
+// per second over the last window.
+message HeapSnapshot {
+  uint64 live_heap_bytes = 1;
+  double alloc_rate = 2;
+  uint64 suspected_leak_bytes = 3;
+  repeated HeapCallSite top_call_sites = 4;
 }
 
 // ─── Threads ────────────────────────────────────────────────────────────────


### PR DESCRIPTION
PR1 of #53 (epic #52) — the **capture engine + stream** half. The TUI (F1 memory panel) lands in a follow-up PR.

## What

A new eBPF heap collector that uprobes the target's libc `malloc`/`calloc`/`realloc`/`free`, pairs alloc→free by the returned pointer, and derives:

- **per-call-site live bytes / alloc count / average lifetime**
- **allocation lifetime** (`free.ts − alloc.ts`), emitted per event
- **suspected-leak signal** — live allocations older than a threshold (default 10s)
- **large-allocation tag** for sizes ≥ 128KB (glibc's M_MMAP_THRESHOLD), derived from the malloc request size — no extra probe

It augments the memory subsystem (does not replace `MemEBPF`); it is eBPF-only with no `/proc` fallback, so static / non-libc targets (Go binaries) simply have no heap data and degrade cleanly.

## How

- `internal/bpf/programs/heap.bpf.c` — uprobe/uretprobe allocator probes gated by the shared `pid_is_target` filter; per-pointer `LRU_HASH` live set (bounded, 131072); **kernel-side per-call-site aggregation** (`heap_callsite_live`, keyed by `stack_id`) so userspace iterates only the small map; a free attributes its bytes to the **alloc site** for consistent `live_bytes`; `STACK_TRACE` call sites via `bpf_get_stackid(BPF_F_USER_STACK)`; ringbuf events. realloc/calloc edge cases (NULL/0/OOM/overflow) handled.
- `internal/bpf/heap.go` (+ stub) — resolves the target's libc from `/proc/<pid>/maps`, PID-scoped `Uprobe`/`Uretprobe` via `OpenExecutable`, ringbuf reader, map iteration, leak scan (`CLOCK_MONOTONIC` to match `bpf_ktime_get_ns`), stack resolution.
- `pkg/collector` — `HeapEBPFCollector` (+ stub), `HeapStats`/`HeapEvent`/`HeapCallSite` types, pure `chooseTopCallSites`/`isSuspectedLeak`/`pickAppFrame` helpers with unit tests; wired into `Set` (`Sources.Heap`, `MockHeap`, `Stop`/`Collectors`).
- `proto/event.proto` — `HeapSnapshot` + `HeapEvent` at oneof fields 22/23 (under the #52 reservation) + `mapper.go` cases + `mapper_test.go`.

## Design notes / honesty

- **Call sites are shown in hex** (like the futex `uaddr`); #54 will symbolize them — this PR already wires the `STACK_TRACE` machinery #54 builds on.
- The kernel live set is **LRU-bounded**, so live-heap and leak figures **undercount** on alloc-heavy targets. This is documented in `heap.bpf.c` and the type comments and never presented as exact.
- "Suspected leak" = *currently live AND older than T* — a stateless property of the live set (consistent with the epic's no-baseline/no-diffing principle), a suspicion not a proof.
- Per-event `HeapEvent`s are forwarded best-effort (dropped under backpressure like every other collector); the aggregated `HeapStats` is the lossless view.
- Direct `mmap(2)` allocation tracking (bypassing malloc) is intentionally deferred to a follow-up.

## Verification

- ✅ Default + ebpf-tag stub lanes on macOS: `go vet`, `go build`, `go test -race` green.
- ✅ `buf lint` / `format` / `breaking` vs main clean (fields 22/23 are additive).
- The real `linux && ebpf` lane (uprobe attach + verifier) is exercised by CI (`make gen` + `-tags=ebpf`). API surface (`OpenExecutable`/`Uprobe`/`UprobeOptions.PID`, `uprobe`/`uretprobe` section → `BPF_PROG_TYPE_KPROBE`) verified against cilium/ebpf v0.13.0.

Part of #52. Closes #53.

🤖 Generated with [Claude Code](https://claude.com/claude-code)