### PR TITLE
heap: F1 live-heap panel — sparkline + top call sites + leak (#53)

### DIFF
--- a/internal/tui/format.go
+++ b/internal/tui/format.go
@@ -17,6 +17,26 @@ func fmtBytes(b uint64) string {
 	}
 }
 
+// fmtRate formats an allocations-per-second rate compactly:
+// 320 → "320/s", 1234 → "1.2k/s".
+func fmtRate(r float64) string {
+	if r < 0 {
+		r = 0
+	}
+	if r >= 1000 {
+		return fmt.Sprintf("%.1fk/s", r/1000)
+	}
+	return fmt.Sprintf("%.0f/s", r)
+}
+
+// plural returns the plural suffix "s" for counts other than 1.
+func plural(n int) string {
+	if n == 1 {
+		return ""
+	}
+	return "s"
+}
+
 // fmtBytesPerSec is the same as fmtBytes but with a "/s" suffix.
 func fmtBytesPerSec(bps float64) string {
 	if bps < 0 {

--- a/internal/tui/heap_view_test.go
+++ b/internal/tui/heap_view_test.go
@@ -1,0 +1,60 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/trentas/ptop/pkg/collector"
+)
+
+// TestHeapMsgUpdatesState verifies a HeapMsg lands in the model, appends the
+// live-heap value to the sparkline history, and that the F1 overview then
+// renders the heap detail (top call site + live-heap + alloc-rate rows) instead
+// of the compact classic panel.
+func TestHeapMsgUpdatesState(t *testing.T) {
+	m := NewModel(Config{PID: 1, FPS: 5, NoEBPF: true})
+	hs := collector.HeapStats{
+		LiveHeapBytes:      4 << 20,
+		AllocRate:          1500,
+		SuspectedLeakBytes: 1 << 20,
+		TopCallSites: []collector.HeapCallSite{
+			{CallSite: 0x4011a3, AddrHex: "0x4011a3", LiveBytes: 2 << 20, AllocCount: 128, Suspected: true},
+		},
+	}
+	nm, _ := m.Update(HeapMsg(hs))
+	mm := nm.(Model)
+
+	if mm.HeapStats.LiveHeapBytes != hs.LiveHeapBytes {
+		t.Errorf("LiveHeapBytes = %d, want %d", mm.HeapStats.LiveHeapBytes, hs.LiveHeapBytes)
+	}
+	if n := len(mm.HeapLiveHist); n == 0 || mm.HeapLiveHist[n-1] != float64(hs.LiveHeapBytes) {
+		t.Errorf("HeapLiveHist not appended with live bytes: %v", mm.HeapLiveHist)
+	}
+
+	mm.Width, mm.Height = 180, 50
+	mm.ActiveTab = TabOverview
+	out := mm.View()
+	for _, want := range []string{"0x4011a3", "Live heap", "Alloc rate", "top alloc sites"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("F1 overview missing %q with heap data", want)
+		}
+	}
+}
+
+// TestMemPanelClassicWithoutHeap confirms the F1 Memory panel keeps the compact
+// mockup layout (no heap detail) when there is no heap data — preserving the
+// degraded-mode / macOS / Go-target appearance.
+func TestMemPanelClassicWithoutHeap(t *testing.T) {
+	m := NewModel(Config{PID: 1, FPS: 5, NoEBPF: true})
+	m.Width, m.Height = 180, 50
+	m.ActiveTab = TabOverview
+	out := m.View()
+	for _, heapOnly := range []string{"top alloc sites", "Live heap", "Alloc rate"} {
+		if strings.Contains(out, heapOnly) {
+			t.Errorf("F1 overview shows heap-only marker %q without any heap data", heapOnly)
+		}
+	}
+	if !strings.Contains(out, "RSS") {
+		t.Errorf("F1 overview missing the Memory panel entirely")
+	}
+}

--- a/internal/tui/help.go
+++ b/internal/tui/help.go
@@ -107,6 +107,15 @@ func renderHelpOverlayWithStatus(m Model, w, h int) string {
 			m.usingMockIOFiles, m.ioFilesSource),
 		statusRow("network", m.usingMockNet, m.netSource),
 		statusRow("memory", m.usingMockMem, m.memSource),
+		// Heap (malloc/free) is eBPF-only and never simulated: it's "real via
+		// eBPF" when the libc uprobes attached, else genuinely unavailable
+		// (macOS, --no-ebpf, or a static / non-libc target) — never "mock".
+		func() string {
+			if m.heapSource != "" {
+				return statusRow("heap", false, m.heapSource)
+			}
+			return statusRowNA("heap", "needs eBPF + a libc-linked target")
+		}(),
 		statusRowMaybeNA("locks", locksUnavailable, "no public __ulock_wait hook on macOS (see #22)",
 			m.locksSource == "", m.locksSource),
 		statusRow("threads", m.usingMockThreads, m.threadsSource),

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -76,6 +76,7 @@ type FDMsg []collector.FDEntry
 type CpuMsg collector.CpuSample
 type ThreadsMsg []collector.ThreadInfo
 type MemMsg collector.MemStats
+type HeapMsg collector.HeapStats
 type IOWaitMsg collector.IOWaitSample
 type IOThroughputMsg collector.IOThroughputSample
 type TimelineMsg collector.TimelineEvent
@@ -108,6 +109,8 @@ type Model struct {
 	SyscallCounts  map[string]uint64
 	NetConns       []collector.NetConn
 	MemStats       collector.MemStats
+	HeapStats      collector.HeapStats // eBPF malloc/free pairing (#53); empty without eBPF
+	HeapLiveHist   []float64           // live-heap bytes history for the F1 sparkline
 	Threads        []collector.ThreadInfo
 	IOStats        collector.IOStats
 	IOReadHist     []float64
@@ -173,6 +176,7 @@ type Model struct {
 	netSource      string
 	threadsSource  string
 	memSource      string
+	heapSource     string
 	locksSource    string
 
 	// Stable caches to avoid visual reordering between ticks.
@@ -219,6 +223,7 @@ func NewModel(cfg Config) Model {
 	m.cpuSource = m.collectors.Sources.CPU
 	m.threadsSource = m.collectors.Sources.Threads
 	m.memSource = m.collectors.Sources.Mem
+	m.heapSource = m.collectors.Sources.Heap
 	m.syscallsSource = m.collectors.Sources.Syscalls
 	m.ioFilesSource = m.collectors.Sources.IOFiles
 	m.netSource = m.collectors.Sources.Net
@@ -287,6 +292,9 @@ func (m Model) Init() tea.Cmd {
 	}
 	if m.collectors.MemEBPF != nil {
 		cmds = append(cmds, waitForMemEBPF(m.collectors.MemEBPF))
+	}
+	if m.collectors.HeapEBPF != nil {
+		cmds = append(cmds, waitForHeapEBPF(m.collectors.HeapEBPF))
 	}
 	if m.collectors.FutexEBPF != nil {
 		cmds = append(cmds, waitForFutexEBPF(m.collectors.FutexEBPF))
@@ -372,6 +380,11 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, waitForMemEBPF(m.collectors.MemEBPF)
 		}
 		return m, waitForMem(m.collectors.MemProc)
+
+	case HeapMsg:
+		m.HeapStats = collector.HeapStats(v)
+		m.HeapLiveHist = appendCapped(m.HeapLiveHist, float64(m.HeapStats.LiveHeapBytes), 60)
+		return m, waitForHeapEBPF(m.collectors.HeapEBPF)
 
 	case IOWaitMsg:
 		m.IOStats.IOWaitPct = collector.IOWaitSample(v).Pct
@@ -1121,6 +1134,30 @@ func waitForMemEBPF(c *collector.MemEBPFCollector) tea.Cmd {
 		v := <-ch
 		if s, ok := v.(collector.MemStats); ok {
 			return MemMsg(s)
+		}
+		return TickMsg(time.Now())
+	}
+}
+
+// waitForHeapEBPF drains the heap collector's channel. It carries two payloads:
+// the periodic HeapStats aggregate (what the F1 panel renders) and per-alloc/free
+// HeapEvents (for the gRPC stream). The TUI only surfaces the aggregate, so it
+// blocks reading — discarding HeapEvents — until the next HeapStats, which avoids
+// a per-allocation render storm.
+func waitForHeapEBPF(c *collector.HeapEBPFCollector) tea.Cmd {
+	if c == nil {
+		return nil
+	}
+	return func() tea.Msg {
+		ch := c.Subscribe()
+		if ch == nil {
+			return TickMsg(time.Now())
+		}
+		for v := range ch {
+			if s, ok := v.(collector.HeapStats); ok {
+				return HeapMsg(s)
+			}
+			// HeapEvent: not shown in the aggregate panel — keep reading.
 		}
 		return TickMsg(time.Now())
 	}

--- a/internal/tui/panels.go
+++ b/internal/tui/panels.go
@@ -528,28 +528,101 @@ func renderNetMini(conns []collector.NetConn, w, h int, showTraffic bool) string
 
 // ─── Memory ──────────────────────────────────────────────────────────────────
 
-func renderMemMini(s collector.MemStats, w int) string {
-	rows := []struct {
-		label string
-		value string
-		color lipgloss.Color
-	}{
-		{"RSS", fmt.Sprintf("%.0f MB", float64(s.RSSBytes)/(1<<20)), ColorCyan},
-		{"Heap", fmt.Sprintf("%.0f MB", float64(s.HeapBytes)/(1<<20)), ColorPurple},
-		{"Page faults", fmt.Sprintf("%d", s.PageFaults), ColorAmber},
-		{"Allocs/s", fmt.Sprintf("%d", s.AllocsPerS), ColorGreen},
+// kvGap joins a pre-styled label and value, right-aligning the value to fill w.
+func kvGap(left, right string, w int) string {
+	gap := w - lipgloss.Width(left) - lipgloss.Width(right)
+	if gap < 1 {
+		gap = 1
 	}
-	lines := make([]string, 0, len(rows))
-	for _, r := range rows {
-		left := MutedStyle.Render(r.label)
-		right := lipgloss.NewStyle().Foreground(r.color).Background(ColorPanel).Render(r.value)
-		gap := w - lipgloss.Width(left) - lipgloss.Width(right)
-		if gap < 1 {
-			gap = 1
+	return left + panelGap(gap) + right
+}
+
+// kvLine renders a "label … value" row filling width w (value right-aligned).
+func kvLine(label, value string, color lipgloss.Color, w int) string {
+	return kvGap(MutedStyle.Render(label),
+		lipgloss.NewStyle().Foreground(color).Background(ColorPanel).Render(value), w)
+}
+
+// renderMemMini renders the F1 Memory panel. Without eBPF heap data it shows the
+// classic RSS / Heap / Page-faults / Allocs rows (the mockup's MemPanel). When
+// the heap collector (#53) is active it adds a live-heap sparkline, the real
+// allocation rate, a suspected-leak summary, and the top allocating call sites.
+func renderMemMini(s collector.MemStats, heap collector.HeapStats, liveHist []float64, w, h int) string {
+	if len(heap.TopCallSites) == 0 {
+		return strings.Join([]string{
+			kvLine("RSS", fmt.Sprintf("%.0f MB", float64(s.RSSBytes)/(1<<20)), ColorCyan, w),
+			kvLine("Heap", fmt.Sprintf("%.0f MB", float64(s.HeapBytes)/(1<<20)), ColorPurple, w),
+			kvLine("Page faults", fmt.Sprintf("%d", s.PageFaults), ColorAmber, w),
+			kvLine("Allocs/s", fmt.Sprintf("%d", s.AllocsPerS), ColorGreen, w),
+		}, "\n")
+	}
+	return renderMemHeap(s, heap, liveHist, w, h)
+}
+
+func renderMemHeap(s collector.MemStats, heap collector.HeapStats, liveHist []float64, w, h int) string {
+	lines := []string{
+		kvLine("RSS", fmt.Sprintf("%.0f MB", float64(s.RSSBytes)/(1<<20)), ColorCyan, w),
+		kvLine("Heap", fmt.Sprintf("%.0f MB", float64(s.HeapBytes)/(1<<20)), ColorPurple, w),
+	}
+
+	// Live heap: sparkline of the kernel live-set sum + its current value.
+	label := MutedStyle.Render("Live heap")
+	val := TealStyle.Render(fmtBytes(heap.LiveHeapBytes))
+	sparkW := w - lipgloss.Width(label) - lipgloss.Width(val) - 2
+	if sparkW < 4 {
+		sparkW = 4
+	}
+	lines = append(lines, label+panelSp1+Sparkline(liveHist, sparkW, ColorTeal)+panelSp1+val)
+
+	// Real allocation rate from malloc/free events (not the /proc fault proxy).
+	lines = append(lines, kvLine("Alloc rate", fmtRate(heap.AllocRate), ColorGreen, w))
+
+	// Suspected-leak summary — live allocations older than the leak threshold.
+	if heap.SuspectedLeakBytes > 0 {
+		nLeak := 0
+		for _, cs := range heap.TopCallSites {
+			if cs.Suspected {
+				nLeak++
+			}
 		}
-		lines = append(lines, left+panelGap(gap)+right)
+		lines = append(lines, kvGap(MutedStyle.Render("Suspected leak"),
+			RedStyle.Render(fmt.Sprintf("⚠ %s · %d site%s", fmtBytes(heap.SuspectedLeakBytes), nLeak, plural(nLeak))), w))
+	} else {
+		lines = append(lines, kvGap(MutedStyle.Render("Leaks"), GreenStyle.Render("✓ none"), w))
+	}
+
+	// Top allocating call sites — fill whatever vertical room is left (one line
+	// reserved for the header).
+	if avail := h - len(lines) - 1; avail >= 1 {
+		lines = append(lines, DimStyle.Render(truncate("─ top alloc sites ───────────────────────────────", w)))
+		sites := heap.TopCallSites
+		if len(sites) > avail {
+			sites = sites[:avail]
+		}
+		for _, cs := range sites {
+			lines = append(lines, renderHeapSiteRow(cs, w))
+		}
 	}
 	return strings.Join(lines, "\n")
+}
+
+// renderHeapSiteRow lays out one call site: leak marker, call-site address (hex
+// until #54 symbolizes it), live bytes, and cumulative allocation count.
+func renderHeapSiteRow(cs collector.HeapCallSite, w int) string {
+	leak := MutedStyle.Render("  ")
+	if cs.Suspected {
+		leak = RedStyle.Render("⚠ ")
+	}
+	const bytesW, countW = 8, 7
+	bytesSpan := BrightStyle.Width(bytesW).Align(lipgloss.Right).Render(fmtBytes(cs.LiveBytes))
+	countSpan := MutedStyle.Width(countW).Align(lipgloss.Right).Render(fmt.Sprintf("×%d", cs.AllocCount))
+
+	addrW := w - lipgloss.Width(leak) - bytesW - countW - 2
+	if addrW < 6 {
+		addrW = 6
+	}
+	addrSpan := CyanStyle.Width(addrW).Render(truncate(cs.AddrHex, addrW))
+	return leak + addrSpan + panelSp1 + bytesSpan + panelSp1 + countSpan
 }
 
 // ─── Timeline ────────────────────────────────────────────────────────────────

--- a/internal/tui/snapshot.go
+++ b/internal/tui/snapshot.go
@@ -31,6 +31,7 @@ type SnapshotData struct {
 	SyscallCounts  map[string]uint64         `json:"syscall_counts"`
 	NetConns       []collector.NetConn       `json:"network_connections"`
 	MemStats       collector.MemStats        `json:"memory"`
+	HeapStats      collector.HeapStats       `json:"heap"`
 	Threads        []collector.ThreadInfo    `json:"threads"`
 	IOStats        collector.IOStats         `json:"io"`
 	IOReadHist     []float64                 `json:"io_read_history"`
@@ -54,6 +55,7 @@ func buildSnapshot(m Model) Snapshot {
 			SyscallCounts:  copyUintMap(m.SyscallCounts),
 			NetConns:       append([]collector.NetConn(nil), m.NetConns...),
 			MemStats:       m.MemStats,
+			HeapStats:      m.HeapStats,
 			Threads:        append([]collector.ThreadInfo(nil), m.Threads...),
 			IOStats:        m.IOStats,
 			IOReadHist:     append([]float64(nil), m.IOReadHist...),

--- a/internal/tui/view_overview.go
+++ b/internal/tui/view_overview.go
@@ -32,7 +32,15 @@ func renderOverviewView(m Model, w, h int) string {
 
 	leftW, rightW := splitOverviewWidth(w)
 	leftHs := splitFlex([]float64{1.0, 1.5, 1.4}, h)
-	rightHs := splitFlex([]float64{1.1, 0.9, 0.9, 0.65, 1.8}, h)
+
+	// The Memory panel grows to fit the heap detail (live-heap sparkline + top
+	// call sites) only when the eBPF heap collector (#53) has data; otherwise it
+	// keeps the compact mockup layout and the Event Stream keeps its height.
+	memRatio, evRatio := 0.65, 1.8
+	if len(m.HeapStats.TopCallSites) > 0 {
+		memRatio, evRatio = 1.55, 0.9
+	}
+	rightHs := splitFlex([]float64{1.1, 0.9, 0.9, memRatio, evRatio}, h)
 
 	// Coluna esquerda
 	cpu := Panel("CPU",
@@ -63,7 +71,7 @@ func renderOverviewView(m Model, w, h int) string {
 		rightW, rightHs[2])
 
 	memPanel := Panel("Memory",
-		renderMemMini(m.MemStats, rightW-2),
+		renderMemMini(m.MemStats, m.HeapStats, m.HeapLiveHist, rightW-2, rightHs[3]-3),
 		rightW, rightHs[3])
 
 	timelinePanel := Panel("Event Stream",


### PR DESCRIPTION
PR2 of #53 (epic #52) — the **TUI** half. **Stacked on #73** (base is its branch), so this diff shows only the TUI changes.

> ⚠️ **Merge order:** merge #73 first, then this. If #73 is merged with *delete branch*, retarget this PR to `main` **before** deleting (in this repo, deleting the base branch of an open dependent PR has auto-closed it). Simplest: retarget this to `main` once #73 lands.

## What

The F1 **Memory** panel grows to surface the eBPF heap signal (#53) when it's present, and stays the compact mockup layout otherwise — so degraded mode, macOS, `--no-ebpf`, and static/non-libc (Go) targets look exactly as before.

When heap data is live it adds:
- **Live-heap sparkline** + current live-set bytes.
- **Real allocation rate** (from malloc/free events, not the `/proc` page-fault proxy).
- **Suspected-leak summary** — live allocations older than the threshold (red ⚠ when > 0, else `✓ none`).
- **Top allocating call sites** — hex address (until #54 symbolizes them), live bytes, alloc count, and a per-site leak marker. The list fills whatever vertical room the panel has.

```
▸ MEMORY
RSS                              148 MB
Heap                              92 MB
Live heap ⡟⡟⡟⡟⡟⡿⡏⡏⡏⡟⡟⡟⡟⡟⡿⡏⡏ 64.0MB
Alloc rate                       1.8k/s
Suspected leak         ⚠ 1.2MB · 1 site
─ top alloc sites ─────────────
⚠ 0x4011a3              42.0MB    ×128
  0x40bf02              18.0MB     ×64
```

## How

- `model.go`: `HeapMsg` + `waitForHeapEBPF` (drains the collector channel, surfacing the periodic `HeapStats` aggregate and discarding per-alloc/free `HeapEvent`s so a malloc storm can't become a render storm); `HeapStats` + `HeapLiveHist` state; source label. No change to other subsystems' wiring.
- `panels.go` / `view_overview.go`: heap-aware Memory panel; the Memory/Event-Stream height ratios shift **only when heap data is present** (keeps the no-heap layout — and any regression appearance — identical).
- `help.go`: a dedicated heap collector row — `● real via eBPF` when attached, else `✕ unavailable — needs eBPF + a libc-linked target`. Heap is **never** shown as "mock" (we don't fabricate call sites).
- `snapshot.go`: `HeapStats` added to the JSON/JSONL export.
- `format.go`: `fmtRate` / `plural` helpers.

## Honesty / scope

- Call sites are hex until **#54** symbolizes them (this reuses #53's `STACK_TRACE` machinery).
- Heap data only appears with eBPF + a libc-linked target; we never simulate it, so the demo/mock and macOS paths show the classic panel.
- Per-event `HeapEvent`s are consumed but not drawn (they're for the gRPC stream); the aggregate is the panel's source.

## Verification

- ✅ `go build`, `go vet`, `go test -race ./...` green on macOS.
- New `heap_view_test.go`: a `HeapMsg` updates state + history and the F1 overview renders the heap detail; without heap data the panel stays classic (no heap markers).
- Visual dump (above) checked at 150×44 — no overflow, sparkline/columns aligned, Event Stream still readable.

Part of #52. Completes the TUI for #53 (with #73).

🤖 Generated with [Claude Code](https://claude.com/claude-code)