### PR TITLE
symbol: ELF/gosym symbolization core (pkg/symbol) (#54)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,7 +18,7 @@ If something here drifts from reality, the code wins. Update this file.
 |--------|-----------|--------|
 | TUI    | [Bubbletea](https://github.com/charmbracelet/bubbletea) + [Lipgloss](https://github.com/charmbracelet/lipgloss) | Mature, composable, mouse support |
 | eBPF   | [cilium/ebpf](https://github.com/cilium/ebpf) | Pure-Go, no libbpf.so needed at runtime |
-| Build  | Go 1.22+, clang, libbpf-dev (build only) | Single static binary on Linux (`CGO_ENABLED=0`) |
+| Build  | Go 1.25+, clang, libbpf-dev (build only) | Single static binary on Linux (`CGO_ENABLED=0`) |
 | eBPF C | clang `-target bpf` → `.bpf.o` → `go:embed` | See `Makefile` |
 | macOS  | libproc + Mach via cgo (darwin-only build tag) | The only public path for per-process info on macOS |
 
@@ -125,7 +125,7 @@ ptop/
 │   │   ├── service.pb.go          Subscribe messages (generated)
 │   │   ├── service_grpc.pb.go     EventStream service (generated)
 │   │   └── doc.go                 package doc
-│   └── collector/                 /proc + eBPF collectors + shared types
+│   ├── collector/                 /proc + eBPF collectors + shared types
 │       ├── types.go               public type contracts (see below)
 │       ├── set.go                 source-priority selection + lifecycle (Set)
 │       ├── source_{linux,darwin}.go  platform source labels (Source*)
@@ -146,6 +146,10 @@ ptop/
 │       ├── sockets.go             inode → host:port via /proc/net/*
 │       ├── syscall_names.go       syscall id → name table
 │       └── *_test.go, *_stub.go
+│   └── symbol/                    ELF→symbol resolution (addr → func/file:line, #54)
+│       ├── elf.go                 OS-agnostic ELF/gosym core (Module, build-id)
+│       ├── proc_linux.go          live-pid Symbolizer via /proc/<pid>/maps
+│       └── proc_other.go          non-Linux stub
 └── assets/
     ├── mockup.jsx                 authoritative visual spec
     └── screenshot-overview.txt    regression fixture

--- a/pkg/symbol/doc.go
+++ b/pkg/symbol/doc.go
@@ -1,0 +1,17 @@
+// Package symbol resolves runtime stack addresses captured by ptop's eBPF
+// tracers into human-readable frames (function + file:line). It is the
+// userspace half of issue #54.
+//
+// The ELF Module core (elf.go) is OS-agnostic: it parses any ELF image with
+// debug/elf and debug/gosym, so it works — and is unit-tested — on every
+// platform. The Symbolizer (proc_linux.go) ties a per-module cache to a live
+// process via /proc/<pid>/maps and is Linux-only (proc_other.go stubs it).
+//
+// Per-module resolution order: the Go line table (.gopclntab) yields func +
+// file:line for Go binaries and survives symbol stripping; the ELF symbol
+// table (.symtab/.dynsym) yields function names for C/C++; a stripped module
+// degrades gracefully to "module+0xoffset". Modules are parsed once and cached.
+//
+// Deferred (see #54): C/C++ file:line (DWARF), C++ demangling, and kernel-stack
+// resolution via /proc/kallsyms.
+package symbol

--- a/pkg/symbol/elf.go
+++ b/pkg/symbol/elf.go
@@ -1,0 +1,257 @@
+package symbol
+
+import (
+	"debug/elf"
+	"debug/gosym"
+	"encoding/binary"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"path/filepath"
+	"sort"
+	"sync"
+)
+
+// Frame is a symbolized stack frame.
+//
+//   - Func is "" when the address couldn't be resolved to a function (a stripped
+//     non-Go module); Module + Offset still locate it as "lib+0xNN".
+//   - File/Line are populated only for Go modules (via .gopclntab) in this cut.
+//     C/C++ file:line needs DWARF, which is deferred (#54 follow-up).
+//   - Offset is module-relative (file vaddr − the module's load base), so it is
+//     comparable across runs/ASLR.
+type Frame struct {
+	Func    string
+	File    string
+	Line    int
+	Module  string
+	Offset  uint64
+	BuildID string
+}
+
+// funcSym is one STT_FUNC symbol, used for nearest-address lookup.
+type funcSym struct {
+	value uint64
+	size  uint64
+	name  string
+}
+
+// progLoad is the subset of a PT_LOAD program header needed to convert a file
+// offset to a virtual address.
+type progLoad struct {
+	off, vaddr, filesz uint64
+}
+
+// Module wraps a parsed ELF image and resolves file virtual addresses to
+// Frames. It retains no open file handle (all needed data is read at open
+// time), so it is cheap to cache and safe for concurrent Resolve calls.
+type Module struct {
+	name     string
+	funcs    []funcSym // sorted by value, deduped
+	loads    []progLoad
+	loadBase uint64 // smallest PT_LOAD vaddr (link-time base)
+	buildID  string
+
+	// gosym is built lazily on first use — parsing a large .gopclntab is
+	// expensive and most modules are never the one a frame lands in.
+	gosymOnce sync.Once
+	gotab     *gosym.Table
+	pclnData  []byte
+	textAddr  uint64
+}
+
+// OpenModule parses the ELF image in r. name is used for Frame.Module (its
+// basename) and error messages. r is fully consumed before returning; the
+// caller may close it immediately.
+func OpenModule(r io.ReaderAt, name string) (*Module, error) {
+	f, err := elf.NewFile(r)
+	if err != nil {
+		return nil, fmt.Errorf("parse ELF %s: %w", name, err)
+	}
+	defer f.Close()
+
+	m := &Module{name: filepath.Base(name), loadBase: ^uint64(0)}
+	for _, p := range f.Progs {
+		if p.Type != elf.PT_LOAD {
+			continue
+		}
+		m.loads = append(m.loads, progLoad{off: p.Off, vaddr: p.Vaddr, filesz: p.Filesz})
+		if p.Vaddr < m.loadBase {
+			m.loadBase = p.Vaddr
+		}
+	}
+	if m.loadBase == ^uint64(0) {
+		m.loadBase = 0
+	}
+
+	m.buildID = readBuildID(f)
+	m.funcs = collectFuncs(f)
+
+	// Stash the Go line table inputs for lazy gosym construction.
+	if sec := f.Section(".gopclntab"); sec != nil {
+		if data, err := sec.Data(); err == nil && len(data) > 0 {
+			m.pclnData = data
+			if t := f.Section(".text"); t != nil {
+				m.textAddr = t.Addr
+			}
+		}
+	}
+
+	return m, nil
+}
+
+// Name returns the module basename.
+func (m *Module) Name() string { return m.name }
+
+// BuildID returns the GNU build-id (hex) or "" if absent.
+func (m *Module) BuildID() string { return m.buildID }
+
+// Resolve maps a file virtual address to a Frame. It tries, in order: the Go
+// line table (func + file:line), the ELF symbol table (func name only), then a
+// module+offset fallback for stripped binaries.
+func (m *Module) Resolve(fileVaddr uint64) Frame {
+	fr := Frame{Module: m.name, BuildID: m.buildID, Offset: fileVaddr - m.loadBase}
+
+	if tab := m.gosym(); tab != nil {
+		if file, line, fn := tab.PCToLine(fileVaddr); fn != nil {
+			fr.Func, fr.File, fr.Line = fn.Name, file, line
+			return fr
+		}
+	}
+	if name, ok := lookupFunc(m.funcs, fileVaddr); ok {
+		fr.Func = name
+		return fr
+	}
+	return fr
+}
+
+func (m *Module) gosym() *gosym.Table {
+	m.gosymOnce.Do(func() {
+		if len(m.pclnData) == 0 {
+			return
+		}
+		lt := gosym.NewLineTable(m.pclnData, m.textAddr)
+		if tab, err := gosym.NewTable(nil, lt); err == nil {
+			m.gotab = tab
+		}
+	})
+	return m.gotab
+}
+
+// collectFuncs gathers STT_FUNC symbols from .symtab and .dynsym, sorted by
+// address and deduped (the two tables overlap).
+func collectFuncs(f *elf.File) []funcSym {
+	var out []funcSym
+	add := func(syms []elf.Symbol) {
+		for _, s := range syms {
+			if elf.ST_TYPE(s.Info) != elf.STT_FUNC || s.Value == 0 || s.Name == "" {
+				continue
+			}
+			out = append(out, funcSym{value: s.Value, size: s.Size, name: s.Name})
+		}
+	}
+	if syms, err := f.Symbols(); err == nil {
+		add(syms)
+	}
+	if dyn, err := f.DynamicSymbols(); err == nil {
+		add(dyn)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].value != out[j].value {
+			return out[i].value < out[j].value
+		}
+		return out[i].size > out[j].size // prefer the sized entry on a tie
+	})
+	// Dedupe identical addresses (keep the first, which has the larger size).
+	deduped := out[:0]
+	var last uint64 = ^uint64(0)
+	for _, s := range out {
+		if s.value == last {
+			continue
+		}
+		deduped = append(deduped, s)
+		last = s.value
+	}
+	return deduped
+}
+
+// lookupFunc finds the function containing addr by nearest-preceding address.
+// A sized symbol bounds its range [value, value+size); a size-0 symbol (common
+// for asm stubs) is attributed everything up to the next symbol.
+func lookupFunc(funcs []funcSym, addr uint64) (string, bool) {
+	if len(funcs) == 0 {
+		return "", false
+	}
+	i := sort.Search(len(funcs), func(i int) bool { return funcs[i].value > addr }) - 1
+	if i < 0 {
+		return "", false
+	}
+	s := funcs[i]
+	if s.size > 0 && addr >= s.value+s.size {
+		return "", false // in the gap after a sized symbol
+	}
+	return s.name, true
+}
+
+// fileVaddr converts a runtime address (a VA in the target process) to the file
+// virtual address the symbol table / gosym key on, using the maps segment that
+// contained it plus the module's PT_LOAD headers. Works for PIE and non-PIE,
+// the main executable and shared libraries.
+func fileVaddr(runtimeAddr, segStart, segFileOff uint64, loads []progLoad) (uint64, bool) {
+	fileOff := runtimeAddr - segStart + segFileOff
+	for _, p := range loads {
+		if fileOff >= p.off && fileOff < p.off+p.filesz {
+			return fileOff - p.off + p.vaddr, true
+		}
+	}
+	return 0, false
+}
+
+// readBuildID reads the GNU build-id from the .note.gnu.build-id section, or
+// from a PT_NOTE segment when sections are stripped. Returns hex or "".
+func readBuildID(f *elf.File) string {
+	if s := f.Section(".note.gnu.build-id"); s != nil {
+		if d, err := s.Data(); err == nil {
+			if id := parseBuildIDNote(d, f.ByteOrder); id != "" {
+				return id
+			}
+		}
+	}
+	for _, p := range f.Progs {
+		if p.Type != elf.PT_NOTE {
+			continue
+		}
+		d := make([]byte, p.Filesz)
+		if _, err := io.ReadFull(p.Open(), d); err == nil {
+			if id := parseBuildIDNote(d, f.ByteOrder); id != "" {
+				return id
+			}
+		}
+	}
+	return ""
+}
+
+// parseBuildIDNote walks ELF notes (namesz, descsz, type, name, desc — each
+// field 4-byte aligned) and returns the hex of the NT_GNU_BUILD_ID desc.
+func parseBuildIDNote(data []byte, bo binary.ByteOrder) string {
+	const ntGNUBuildID = 3
+	for off := 0; off+12 <= len(data); {
+		namesz := int(bo.Uint32(data[off : off+4]))
+		descsz := int(bo.Uint32(data[off+4 : off+8]))
+		ntype := bo.Uint32(data[off+8 : off+12])
+		nameStart := off + 12
+		descStart := nameStart + align4(namesz)
+		descEnd := descStart + descsz
+		if namesz < 0 || descsz < 0 || descEnd > len(data) || nameStart+namesz > len(data) {
+			break
+		}
+		name := string(data[nameStart : nameStart+namesz])
+		if ntype == ntGNUBuildID && (name == "GNU\x00" || name == "GNU") {
+			return hex.EncodeToString(data[descStart:descEnd])
+		}
+		off = descStart + align4(descsz)
+	}
+	return ""
+}
+
+func align4(n int) int { return (n + 3) &^ 3 }

--- a/pkg/symbol/elf_test.go
+++ b/pkg/symbol/elf_test.go
@@ -1,0 +1,192 @@
+package symbol
+
+import (
+	"debug/elf"
+	"encoding/binary"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestParseBuildIDNote(t *testing.T) {
+	bo := binary.LittleEndian
+	var b []byte
+	u32 := func(v uint32) {
+		var x [4]byte
+		bo.PutUint32(x[:], v)
+		b = append(b, x[:]...)
+	}
+	desc := []byte{0xde, 0xad, 0xbe, 0xef}
+	u32(4)                 // namesz: "GNU\0"
+	u32(uint32(len(desc))) // descsz
+	u32(3)                 // NT_GNU_BUILD_ID
+	b = append(b, "GNU\x00"...)
+	b = append(b, desc...)
+
+	if got := parseBuildIDNote(b, bo); got != "deadbeef" {
+		t.Errorf("parseBuildIDNote = %q, want deadbeef", got)
+	}
+	if got := parseBuildIDNote([]byte{0, 0, 0, 0}, bo); got != "" {
+		t.Errorf("no-note = %q, want empty", got)
+	}
+}
+
+func TestFileVaddr(t *testing.T) {
+	cases := []struct {
+		name                       string
+		loads                      []progLoad
+		addr, segStart, segFileOff uint64
+		want                       uint64
+		ok                         bool
+	}{
+		// ET_EXEC: text mapped at its link vaddr 0x401000 from file off 0x1000.
+		{"non-pie", []progLoad{{off: 0x1000, vaddr: 0x401000, filesz: 0x2000}},
+			0x401234, 0x401000, 0x1000, 0x401234, true},
+		// PIE/ET_DYN: link vaddr small (0x1000), mapped high under ASLR.
+		{"pie", []progLoad{{off: 0x1000, vaddr: 0x1000, filesz: 0x2000}},
+			0x7f0000000234, 0x7f0000000000, 0x1000, 0x1234, true},
+		// addr's file offset falls outside every PT_LOAD.
+		{"out-of-load", []progLoad{{off: 0x1000, vaddr: 0x1000, filesz: 0x2000}},
+			0xdead0000, 0xdead0000, 0x9000, 0, false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got, ok := fileVaddr(c.addr, c.segStart, c.segFileOff, c.loads)
+			if ok != c.ok || (ok && got != c.want) {
+				t.Errorf("fileVaddr = %#x,%v want %#x,%v", got, ok, c.want, c.ok)
+			}
+		})
+	}
+}
+
+func TestLookupFunc(t *testing.T) {
+	funcs := []funcSym{
+		{value: 0x1000, size: 0x100, name: "a"},
+		{value: 0x1200, size: 0, name: "b"}, // size-0 asm stub
+		{value: 0x1400, size: 0x50, name: "c"},
+	}
+	cases := []struct {
+		addr uint64
+		want string
+		ok   bool
+	}{
+		{0x0fff, "", false}, // before first symbol
+		{0x1000, "a", true}, // start of a
+		{0x10ff, "a", true}, // within sized a
+		{0x1100, "", false}, // gap after sized a
+		{0x1200, "b", true}, // size-0 b
+		{0x13ff, "b", true}, // size-0 b extends to next symbol
+		{0x1400, "c", true},
+		{0x1500, "", false}, // gap after sized c
+	}
+	for _, c := range cases {
+		got, ok := lookupFunc(funcs, c.addr)
+		if ok != c.ok || got != c.want {
+			t.Errorf("lookupFunc(%#x) = %q,%v want %q,%v", c.addr, got, ok, c.want, c.ok)
+		}
+	}
+}
+
+func TestResolveStrippedFallback(t *testing.T) {
+	// No symbols, no gosym → module + module-relative offset.
+	m := &Module{name: "libfoo.so", loadBase: 0x1000, buildID: "abcd"}
+	fr := m.Resolve(0x2500)
+	if fr.Func != "" || fr.Module != "libfoo.so" || fr.Offset != 0x1500 || fr.BuildID != "abcd" {
+		t.Errorf("fallback frame = %+v", fr)
+	}
+}
+
+// buildGoFixture cross-compiles testdata/gofixture for linux/amd64 (pure Go,
+// CGO off → builds on any host including macOS) and returns the ELF path.
+func buildGoFixture(t *testing.T, ldflags string) string {
+	t.Helper()
+	out := filepath.Join(t.TempDir(), "fixture")
+	args := []string{"build", "-o", out}
+	if ldflags != "" {
+		args = append(args, "-ldflags", ldflags)
+	}
+	args = append(args, "./testdata/gofixture")
+	cmd := exec.Command("go", args...)
+	cmd.Env = append(os.Environ(), "GOOS=linux", "GOARCH=amd64", "CGO_ENABLED=0")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("build fixture: %v\n%s", err, out)
+	}
+	return out
+}
+
+func symValue(t *testing.T, path, name string) uint64 {
+	t.Helper()
+	f, err := elf.Open(path)
+	if err != nil {
+		t.Fatalf("elf.Open: %v", err)
+	}
+	defer f.Close()
+	syms, err := f.Symbols()
+	if err != nil {
+		t.Fatalf("Symbols: %v", err)
+	}
+	for _, s := range syms {
+		if s.Name == name {
+			return s.Value
+		}
+	}
+	t.Fatalf("symbol %q not found", name)
+	return 0
+}
+
+func TestModuleResolveGo(t *testing.T) {
+	path := buildGoFixture(t, "-B 0x0011223344556677")
+	addr := symValue(t, path, "main.leakyAlloc")
+
+	f, err := os.Open(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+	m, err := OpenModule(f, path)
+	if err != nil {
+		t.Fatalf("OpenModule: %v", err)
+	}
+
+	fr := m.Resolve(addr)
+	if fr.Func != "main.leakyAlloc" {
+		t.Errorf("Func = %q, want main.leakyAlloc", fr.Func)
+	}
+	if !strings.HasSuffix(fr.File, "gofixture/main.go") {
+		t.Errorf("File = %q, want …/gofixture/main.go", fr.File)
+	}
+	if fr.Line <= 0 {
+		t.Errorf("Line = %d, want > 0", fr.Line)
+	}
+	if fr.BuildID != "0011223344556677" {
+		t.Errorf("BuildID = %q, want 0011223344556677", fr.BuildID)
+	}
+}
+
+func TestModuleResolveStrippedGo(t *testing.T) {
+	// -s strips .symtab but .gopclntab survives → gosym still resolves.
+	path := buildGoFixture(t, "-s -w")
+	f, err := os.Open(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+	m, err := OpenModule(f, path)
+	if err != nil {
+		t.Fatalf("OpenModule: %v", err)
+	}
+	tab := m.gosym()
+	if tab == nil {
+		t.Fatal("gosym nil on stripped Go binary (.gopclntab should survive -s)")
+	}
+	fn := tab.LookupFunc("main.leakyAlloc")
+	if fn == nil {
+		t.Fatal("LookupFunc(main.leakyAlloc) = nil")
+	}
+	fr := m.Resolve(fn.Entry)
+	if fr.Func != "main.leakyAlloc" || !strings.HasSuffix(fr.File, "gofixture/main.go") {
+		t.Errorf("stripped resolve = %+v", fr)
+	}
+}

--- a/pkg/symbol/proc_linux.go
+++ b/pkg/symbol/proc_linux.go
@@ -1,0 +1,169 @@
+//go:build linux
+
+package symbol
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+)
+
+// segment is one executable, file-backed mapping from /proc/<pid>/maps.
+type segment struct {
+	start, end uint64
+	fileOff    uint64
+	path       string
+}
+
+// Symbolizer resolves runtime addresses of a live process to Frames. It parses
+// the process's executable mappings once at construction and lazily opens +
+// caches each backing ELF module on first use.
+type Symbolizer struct {
+	pid  int
+	segs []segment
+
+	mu   sync.Mutex
+	mods map[string]*Module // by resolved path; nil value = open failed
+}
+
+// NewSymbolizer snapshots pid's executable mappings. The set of mapped modules
+// is assumed stable for the lifetime of the symbolizer (true for the steady
+// state ptop observes); dlopen after construction won't be picked up.
+func NewSymbolizer(pid int) (*Symbolizer, error) {
+	segs, err := parseMaps(pid)
+	if err != nil {
+		return nil, err
+	}
+	return &Symbolizer{pid: pid, segs: segs, mods: make(map[string]*Module)}, nil
+}
+
+// Symbolize resolves a runtime address. It never errors: an address in an
+// unmapped / anonymous / unreadable region degrades to a bare Frame{Offset}.
+func (s *Symbolizer) Symbolize(addr uint64) Frame {
+	seg, ok := s.segFor(addr)
+	if !ok {
+		return Frame{Offset: addr}
+	}
+	m := s.module(seg.path)
+	if m == nil {
+		return Frame{Module: filepath.Base(seg.path), Offset: addr - seg.start}
+	}
+	v, ok := fileVaddr(addr, seg.start, seg.fileOff, m.loads)
+	if !ok {
+		return Frame{Module: m.name, Offset: addr - seg.start, BuildID: m.buildID}
+	}
+	return m.Resolve(v)
+}
+
+func (s *Symbolizer) Close() error { return nil }
+
+func (s *Symbolizer) segFor(addr uint64) (segment, bool) {
+	for _, sg := range s.segs {
+		if addr >= sg.start && addr < sg.end {
+			return sg, true
+		}
+	}
+	return segment{}, false
+}
+
+// module opens and caches the ELF backing path. A cached nil means a prior open
+// failed (negative cache) so we don't retry a bad path every frame.
+func (s *Symbolizer) module(path string) *Module {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if m, ok := s.mods[path]; ok {
+		return m
+	}
+	m := s.openModule(path)
+	s.mods[path] = m
+	return m
+}
+
+func (s *Symbolizer) openModule(path string) *Module {
+	f, err := s.openModuleFile(path)
+	if err != nil {
+		return nil
+	}
+	defer f.Close()
+	m, err := OpenModule(f, path)
+	if err != nil {
+		return nil
+	}
+	return m
+}
+
+// openModuleFile opens the file backing a mapping. It prefers the path as seen
+// from the target's mount namespace (/proc/<pid>/root<path>) so the on-disk
+// bytes match the running image inside containers; falls back to the bare path,
+// then to /proc/<pid>/map_files (which resolves even deleted/overlay inodes).
+func (s *Symbolizer) openModuleFile(path string) (*os.File, error) {
+	path = strings.TrimSuffix(path, " (deleted)")
+	candidates := []string{
+		fmt.Sprintf("/proc/%d/root%s", s.pid, path),
+		path,
+	}
+	for _, c := range candidates {
+		if f, err := os.Open(c); err == nil {
+			return f, nil
+		}
+	}
+	// Last resort: the map_files symlink keyed by the segment's address range.
+	if sg, ok := s.segByPath(path); ok {
+		mf := fmt.Sprintf("/proc/%d/map_files/%x-%x", s.pid, sg.start, sg.end)
+		if f, err := os.Open(mf); err == nil {
+			return f, nil
+		}
+	}
+	return nil, os.ErrNotExist
+}
+
+func (s *Symbolizer) segByPath(path string) (segment, bool) {
+	for _, sg := range s.segs {
+		if strings.TrimSuffix(sg.path, " (deleted)") == path {
+			return sg, true
+		}
+	}
+	return segment{}, false
+}
+
+// parseMaps returns the executable, file-backed segments of pid. Anonymous,
+// non-executable, and pseudo ([vdso], [stack], …) mappings are skipped.
+func parseMaps(pid int) ([]segment, error) {
+	f, err := os.Open(fmt.Sprintf("/proc/%d/maps", pid))
+	if err != nil {
+		return nil, fmt.Errorf("open maps of %d: %w", pid, err)
+	}
+	defer f.Close()
+
+	var segs []segment
+	sc := bufio.NewScanner(f)
+	for sc.Scan() {
+		fields := strings.Fields(sc.Text())
+		if len(fields) < 6 {
+			continue
+		}
+		if !strings.Contains(fields[1], "x") {
+			continue // executable segments only
+		}
+		path := strings.Join(fields[5:], " ")
+		if !strings.HasPrefix(path, "/") {
+			continue // skip [vdso]/[stack]/anon
+		}
+		dash := strings.IndexByte(fields[0], '-')
+		if dash < 0 {
+			continue
+		}
+		start, e1 := strconv.ParseUint(fields[0][:dash], 16, 64)
+		end, e2 := strconv.ParseUint(fields[0][dash+1:], 16, 64)
+		fileOff, e3 := strconv.ParseUint(fields[2], 16, 64)
+		if e1 != nil || e2 != nil || e3 != nil {
+			continue
+		}
+		segs = append(segs, segment{start: start, end: end, fileOff: fileOff, path: path})
+	}
+	return segs, sc.Err()
+}

--- a/pkg/symbol/proc_other.go
+++ b/pkg/symbol/proc_other.go
@@ -1,0 +1,16 @@
+//go:build !linux
+
+package symbol
+
+import "errors"
+
+// Symbolizer is unavailable off Linux: resolving a live process's addresses
+// needs /proc/<pid>/maps. The ELF Module core (elf.go) still works everywhere.
+type Symbolizer struct{}
+
+func NewSymbolizer(int) (*Symbolizer, error) {
+	return nil, errors.New("symbolizer requires /proc (Linux only)")
+}
+
+func (*Symbolizer) Symbolize(uint64) Frame { return Frame{} }
+func (*Symbolizer) Close() error           { return nil }

--- a/pkg/symbol/testdata/gofixture/main.go
+++ b/pkg/symbol/testdata/gofixture/main.go
@@ -1,0 +1,19 @@
+// Fixture binary cross-compiled for linux by pkg/symbol's tests to exercise
+// gosym-based symbolization. It is not part of the module build (the go tool
+// ignores testdata), so its imports stay minimal.
+package main
+
+import "fmt"
+
+//go:noinline
+func leakyAlloc(n int) []byte {
+	return make([]byte, n)
+}
+
+func main() {
+	var kept [][]byte
+	for i := 0; i < 3; i++ {
+		kept = append(kept, leakyAlloc(1024))
+	}
+	fmt.Println(len(kept))
+}


### PR DESCRIPTION
PR1 of #54 (epic #52) — the **symbolizer core**. A standalone, OS-agnostic package that turns runtime stack addresses into `func (file:line)`. It's the cross-cutting enabler that will resolve the **hex call sites #53 shows in the F1 heap panel** into real symbols.

Independent of the (now-merged) heap collector — this PR adds no wiring; it's pure new code under `pkg/symbol`, reviewable and mergeable on its own.

## What

`pkg/symbol` resolves an address in a target process to a `Frame{Func, File, Line, Module, Offset, BuildID}`:

- **`elf.go` (no build tag, OS-agnostic):** `Module` wraps a `debug/elf` image and `Resolve(fileVaddr)`:
  - **Go** binaries → `.gopclntab` via `debug/gosym` gives **func + file:line** (and survives `-s` stripping, since pclntab stays).
  - **C/C++** → `.symtab`/`.dynsym` give the **function name** (nearest-preceding lookup, size-0 asm-stub aware).
  - **Stripped** → graceful `module+0xoffset`.
  - build-id from `.note.gnu.build-id` (section or `PT_NOTE`); gosym built **lazily** (pclntab parse is expensive); correct **PIE/non-PIE** file-vaddr math.
- **`proc_linux.go` (`//go:build linux`):** `Symbolizer` for a live pid — parses `/proc/<pid>/maps` executable segments, opens + caches each backing module (prefers `/proc/<pid>/root<path>`, handles `(deleted)` + `map_files`), and `Symbolize(addr)` → `Frame`, never erroring (anon/vDSO → bare offset). `proc_other.go` stubs it off Linux.

## How it's tested on macOS (the core is cross-platform)

`debug/elf`/`debug/gosym` parse ELF on any OS, so the core is unit-tested directly on macOS:
- Pure tests: `parseBuildIDNote` (synthetic notes), `fileVaddr` (PIE + non-PIE), `lookupFunc` (size-0 + gaps), stripped→offset fallback.
- A **cross-compiled Go fixture** (`go build GOOS=linux` of `testdata/gofixture`) → asserts `Resolve` returns the right func/file:line + build-id, **including the stripped-binary case** (gosym still resolves). No `/proc`, no clang needed.

## Scope / deferred (next PRs & follow-ups)

- **PR2** — wire the symbolizer into the heap collector: `HeapCallSite` gains func/file/line, the F1 panel shows `myalloc (alloc.c:42)` instead of `0x4011a3`.
- **PR3** — `StackRef` on the event envelope + a `ResolveStack` RPC side-channel.
- **Deferred:** C/C++ file:line (DWARF — usually stripped), C++ demangling (no stdlib demangler; would add a dep), kernel-stack resolution (`/proc/kallsyms`; heap captures user stacks only), inlined frames.

## Verification

- ✅ `go build`, `go vet`, `go test -race ./...` green on macOS (incl. the cross-compiled fixture).
- The `//go:build linux` `Symbolizer` (the thin `/proc` layer) compiles in CI's ebpf lane; its pure math (`fileVaddr`) is covered on macOS.
- Also corrects `CLAUDE.md` Go `1.22`→`1.25` (matches `go.mod`) and lists `pkg/symbol` in the tree.

Part of #52. First of three PRs for #54.

🤖 Generated with [Claude Code](https://claude.com/claude-code)