### PR TITLE
symbol: resolve heap call sites to func (file:line) (#54)

### DIFF
--- a/internal/serve/mapper.go
+++ b/internal/serve/mapper.go
@@ -152,6 +152,7 @@ func heapCallSites(in []collector.HeapCallSite) []*pb.HeapCallSite {
 		out[i] = &pb.HeapCallSite{
 			CallSite: s.CallSite, AddrHex: s.AddrHex, LiveBytes: s.LiveBytes,
 			AllocCount: s.AllocCount, AvgLifetimeMs: s.AvgLifetimeMs, Suspected: s.Suspected,
+			Func: s.Func, File: s.File, Line: int32(s.Line), Module: s.Module, Offset: s.Offset,
 		}
 	}
 	return out

--- a/internal/serve/mapper_test.go
+++ b/internal/serve/mapper_test.go
@@ -29,12 +29,19 @@ func TestToEventCategoriesAndPayloads(t *testing.T) {
 			pb.Category_CATEGORY_MEMORY, func(e *pb.Event) bool { return e.GetMemory().GetRssBytes() == 1000 }},
 		{"heap_snapshot", collector.HeapStats{
 			LiveHeapBytes: 4096, AllocRate: 12.5, SuspectedLeakBytes: 1024,
-			TopCallSites: []collector.HeapCallSite{{CallSite: 0xabc, AddrHex: "0xabc", LiveBytes: 4096, Suspected: true}},
-			Timestamp:    time.Unix(6, 0),
+			TopCallSites: []collector.HeapCallSite{{CallSite: 0xabc, AddrHex: "0xabc",
+				Func: "main.leak", File: "/build/main.go", Line: 42, Module: "app", Offset: 0x1a3,
+				LiveBytes: 4096, Suspected: true}},
+			Timestamp: time.Unix(6, 0),
 		}, pb.Category_CATEGORY_MEMORY, func(e *pb.Event) bool {
 			h := e.GetHeap()
-			return h.GetLiveHeapBytes() == 4096 && h.GetSuspectedLeakBytes() == 1024 &&
-				len(h.GetTopCallSites()) == 1 && h.GetTopCallSites()[0].GetAddrHex() == "0xabc"
+			if h.GetLiveHeapBytes() != 4096 || h.GetSuspectedLeakBytes() != 1024 || len(h.GetTopCallSites()) != 1 {
+				return false
+			}
+			cs := h.GetTopCallSites()[0]
+			return cs.GetAddrHex() == "0xabc" && cs.GetFunc() == "main.leak" &&
+				cs.GetFile() == "/build/main.go" && cs.GetLine() == 42 &&
+				cs.GetModule() == "app" && cs.GetOffset() == 0x1a3
 		}},
 		{"heap_event", collector.HeapEvent{Op: "free", Size: 256, Addr: 0xdead, LifetimeMs: 7.5, CallSite: 0xabc, Large: false},
 			pb.Category_CATEGORY_MEMORY, func(e *pb.Event) bool {

--- a/internal/tui/heap_view_test.go
+++ b/internal/tui/heap_view_test.go
@@ -18,7 +18,12 @@ func TestHeapMsgUpdatesState(t *testing.T) {
 		AllocRate:          1500,
 		SuspectedLeakBytes: 1 << 20,
 		TopCallSites: []collector.HeapCallSite{
-			{CallSite: 0x4011a3, AddrHex: "0x4011a3", LiveBytes: 2 << 20, AllocCount: 128, Suspected: true},
+			// Symbolized (#54): rendered as "func (file:line)", not hex.
+			{CallSite: 0x4011a3, AddrHex: "0x4011a3", Func: "leakyAlloc",
+				File: "/build/app/alloc.go", Line: 42, Module: "app",
+				LiveBytes: 2 << 20, AllocCount: 128, Suspected: true},
+			// Unresolved: falls back to the raw-address hex.
+			{CallSite: 0x7f00, AddrHex: "0x7f00", LiveBytes: 1 << 20, AllocCount: 9},
 		},
 	}
 	nm, _ := m.Update(HeapMsg(hs))
@@ -34,10 +39,40 @@ func TestHeapMsgUpdatesState(t *testing.T) {
 	mm.Width, mm.Height = 180, 50
 	mm.ActiveTab = TabOverview
 	out := mm.View()
-	for _, want := range []string{"0x4011a3", "Live heap", "Alloc rate", "top alloc sites"} {
+	// "leakyAlloc" proves the symbolized site renders (the full "(alloc.go:42)"
+	// suffix may be truncated by the panel width); "0x7f00" proves the
+	// unresolved fallback still shows hex.
+	for _, want := range []string{"leakyAlloc", "0x7f00", "Live heap", "Alloc rate", "top alloc sites"} {
 		if !strings.Contains(out, want) {
 			t.Errorf("F1 overview missing %q with heap data", want)
 		}
+	}
+}
+
+// TestHeapSiteLabel covers the call-site label fallback chain (#54): full
+// func+file:line, func-only, module+offset, and raw-address/unknown.
+func TestHeapSiteLabel(t *testing.T) {
+	cases := []struct {
+		name string
+		cs   collector.HeapCallSite
+		want string
+	}{
+		{"go func+line", collector.HeapCallSite{
+			Func: "main.leakyAlloc", File: "/build/app/main.go", Line: 42,
+			Module: "app", AddrHex: "0x4011a3"}, "main.leakyAlloc (main.go:42)"},
+		{"c func only", collector.HeapCallSite{
+			Func: "malloc", Module: "libc.so.6", AddrHex: "0x7f12"}, "malloc"},
+		{"stripped module+offset", collector.HeapCallSite{
+			Module: "libfoo.so", Offset: 0x1500, AddrHex: "0x55aa1500"}, "libfoo.so+0x1500"},
+		{"raw hex fallback", collector.HeapCallSite{AddrHex: "0xdead"}, "0xdead"},
+		{"unknown", collector.HeapCallSite{AddrHex: "unknown"}, "unknown"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := heapSiteLabel(c.cs); got != c.want {
+				t.Errorf("heapSiteLabel = %q, want %q", got, c.want)
+			}
+		})
 	}
 }
 

--- a/internal/tui/panels.go
+++ b/internal/tui/panels.go
@@ -2,6 +2,7 @@ package tui
 
 import (
 	"fmt"
+	"path/filepath"
 	"sort"
 	"strings"
 
@@ -606,8 +607,8 @@ func renderMemHeap(s collector.MemStats, heap collector.HeapStats, liveHist []fl
 	return strings.Join(lines, "\n")
 }
 
-// renderHeapSiteRow lays out one call site: leak marker, call-site address (hex
-// until #54 symbolizes it), live bytes, and cumulative allocation count.
+// renderHeapSiteRow lays out one call site: leak marker, symbolized site label
+// (#54), live bytes, and cumulative allocation count.
 func renderHeapSiteRow(cs collector.HeapCallSite, w int) string {
 	leak := MutedStyle.Render("  ")
 	if cs.Suspected {
@@ -617,12 +618,31 @@ func renderHeapSiteRow(cs collector.HeapCallSite, w int) string {
 	bytesSpan := BrightStyle.Width(bytesW).Align(lipgloss.Right).Render(fmtBytes(cs.LiveBytes))
 	countSpan := MutedStyle.Width(countW).Align(lipgloss.Right).Render(fmt.Sprintf("×%d", cs.AllocCount))
 
-	addrW := w - lipgloss.Width(leak) - bytesW - countW - 2
-	if addrW < 6 {
-		addrW = 6
+	siteW := w - lipgloss.Width(leak) - bytesW - countW - 2
+	if siteW < 6 {
+		siteW = 6
 	}
-	addrSpan := CyanStyle.Width(addrW).Render(truncate(cs.AddrHex, addrW))
-	return leak + addrSpan + panelSp1 + bytesSpan + panelSp1 + countSpan
+	siteSpan := CyanStyle.Width(siteW).Render(truncate(heapSiteLabel(cs), siteW))
+	return leak + siteSpan + panelSp1 + bytesSpan + panelSp1 + countSpan
+}
+
+// heapSiteLabel renders a call site as the most specific form available:
+//
+//	func (file:line)  — resolved with a line table (Go)
+//	func              — resolved by symbol name only (C; no DWARF line info)
+//	module+0xoffset   — stripped module, located by load offset
+//	0x… / unknown     — stack walk failed or address fell outside every module
+func heapSiteLabel(cs collector.HeapCallSite) string {
+	if cs.Func != "" {
+		if cs.File != "" && cs.Line > 0 {
+			return fmt.Sprintf("%s (%s:%d)", cs.Func, filepath.Base(cs.File), cs.Line)
+		}
+		return cs.Func
+	}
+	if cs.Module != "" {
+		return fmt.Sprintf("%s+0x%x", cs.Module, cs.Offset)
+	}
+	return cs.AddrHex
 }
 
 // ─── Timeline ────────────────────────────────────────────────────────────────

--- a/pkg/collector/heap_ebpf.go
+++ b/pkg/collector/heap_ebpf.go
@@ -5,11 +5,13 @@ package collector
 import (
 	"fmt"
 	"io"
+	"os"
 	"sync"
 	"sync/atomic"
 	"time"
 
 	"github.com/trentas/ptop/internal/bpf"
+	"github.com/trentas/ptop/pkg/symbol"
 )
 
 // HeapEBPFCollector tracks libc heap allocations via the uprobe-based eBPF
@@ -27,6 +29,7 @@ import (
 // presented as exact.
 type HeapEBPFCollector struct {
 	tracer *bpf.HeapTracer
+	sym    *symbol.Symbolizer // nil if /proc maps couldn't be parsed
 	ch     chan interface{}
 	stop   chan struct{}
 	pid    int
@@ -35,9 +38,17 @@ type HeapEBPFCollector struct {
 
 	allocCount uint64 // atomic; allocations since the last publish (rate)
 
-	mu       sync.Mutex
-	siteAddr map[int32]uint64 // stack_id → resolved app call-site (cache)
-	lastAt   time.Time        // publishLoop-only; rate baseline
+	mu        sync.Mutex
+	siteCache map[int32]heapSite // stack_id → resolved app call-site (cache)
+	lastAt    time.Time          // publishLoop-only; rate baseline
+}
+
+// heapSite is the resolved application call site for a stack_id: the raw frame
+// address plus its symbolization. Cached because stacks are stable for the
+// process lifetime and symbolizing re-reads ELF modules.
+type heapSite struct {
+	addr  uint64
+	frame symbol.Frame
 }
 
 const (
@@ -51,7 +62,7 @@ func NewHeapEBPFCollector() *HeapEBPFCollector {
 		ch:            make(chan interface{}, 64),
 		stop:          make(chan struct{}),
 		leakThreshold: heapDefaultLeakThreshold,
-		siteAddr:      make(map[int32]uint64),
+		siteCache:     make(map[int32]heapSite),
 	}
 }
 
@@ -62,6 +73,13 @@ func (c *HeapEBPFCollector) Start(pid int) error {
 	}
 	c.tracer = tracer
 	c.pid = pid
+	// Symbolize call sites best-effort: without /proc maps (or off Linux) the
+	// sites degrade to hex, exactly as before #54 — never fail Start over it.
+	if sym, err := symbol.NewSymbolizer(pid); err == nil {
+		c.sym = sym
+	} else {
+		fmt.Fprintf(os.Stderr, "heap: call-site symbolization unavailable for pid %d: %v\n", pid, err)
+	}
 	go c.readLoop()
 	go c.publishLoop()
 	return nil
@@ -72,6 +90,10 @@ func (c *HeapEBPFCollector) Stop() {
 	if c.tracer != nil {
 		_ = c.tracer.Close()
 		c.tracer = nil
+	}
+	if c.sym != nil {
+		_ = c.sym.Close()
+		c.sym = nil
 	}
 }
 
@@ -94,7 +116,7 @@ func (c *HeapEBPFCollector) readLoop() {
 			Size:       ev.Size,
 			Addr:       ev.Addr,
 			LifetimeMs: float64(ev.LifetimeNs) / 1e6,
-			CallSite:   c.resolveSite(ev.StackID),
+			CallSite:   c.resolveSite(ev.StackID).addr,
 			Large:      ev.Flags&bpf.HeapFlagLarge != 0,
 		}
 		select {
@@ -104,30 +126,34 @@ func (c *HeapEBPFCollector) readLoop() {
 	}
 }
 
-// resolveSite maps a stack_id to the application call-site address, caching it
-// (stacks are stable for the process lifetime).
-func (c *HeapEBPFCollector) resolveSite(stackID int32) uint64 {
+// resolveSite maps a stack_id to its application call site (address + symbol),
+// caching the result (stacks are stable for the process lifetime). Concurrent
+// callers (readLoop + publishLoop) share the cache under c.mu.
+func (c *HeapEBPFCollector) resolveSite(stackID int32) heapSite {
 	if stackID < 0 {
-		return 0
+		return heapSite{}
 	}
 	c.mu.Lock()
-	if a, ok := c.siteAddr[stackID]; ok {
+	if s, ok := c.siteCache[stackID]; ok {
 		c.mu.Unlock()
-		return a
+		return s
 	}
 	c.mu.Unlock()
 
 	frames, err := c.tracer.ResolveStack(stackID)
 	if err != nil {
-		return 0
+		return heapSite{}
 	}
 	lo, hi := c.tracer.LibcRange()
-	addr := pickAppFrame(frames, lo, hi)
+	site := heapSite{addr: pickAppFrame(frames, lo, hi)}
+	if c.sym != nil && site.addr != 0 {
+		site.frame = c.sym.Symbolize(site.addr)
+	}
 
 	c.mu.Lock()
-	c.siteAddr[stackID] = addr
+	c.siteCache[stackID] = site
 	c.mu.Unlock()
-	return addr
+	return site
 }
 
 func (c *HeapEBPFCollector) publishLoop() {
@@ -179,10 +205,15 @@ func (c *HeapEBPFCollector) snapshot() (HeapStats, error) {
 		if raw.LifetimeCount > 0 {
 			avgLifeMs = float64(raw.LifetimeSumNs) / float64(raw.LifetimeCount) / 1e6
 		}
-		addr := c.resolveSite(sid)
+		site := c.resolveSite(sid)
 		sites = append(sites, HeapCallSite{
-			CallSite:      addr,
-			AddrHex:       heapAddrHex(addr),
+			CallSite:      site.addr,
+			AddrHex:       heapAddrHex(site.addr),
+			Func:          site.frame.Func,
+			File:          site.frame.File,
+			Line:          site.frame.Line,
+			Module:        site.frame.Module,
+			Offset:        site.frame.Offset,
 			LiveBytes:     uint64(lb),
 			AllocCount:    raw.AllocCount,
 			AvgLifetimeMs: avgLifeMs,

--- a/pkg/collector/types.go
+++ b/pkg/collector/types.go
@@ -43,8 +43,9 @@ type MemStats struct {
 
 // HeapEvent is a single allocation or free observed via libc uprobes.
 // Op is "malloc"|"calloc"|"realloc"|"free". LifetimeMs is set on free
-// (free.ts − alloc.ts). CallSite is the application call-site address (shown in
-// hex; #54 will symbolize it). Large flags allocations ≥ 128KB.
+// (free.ts − alloc.ts). CallSite is the application call-site address (raw
+// instruction pointer; the aggregate HeapCallSite carries the symbolized form).
+// Large flags allocations ≥ 128KB.
 type HeapEvent struct {
 	Op         string
 	Size       uint64
@@ -57,9 +58,20 @@ type HeapEvent struct {
 // HeapCallSite aggregates the currently-live allocations attributed to one
 // application call site (by the alloc-site stack, so a free decrements the site
 // it was allocated from).
+//
+// CallSite is the raw instruction pointer; Func/File/Line/Module/Offset are its
+// symbolization (#54). Func is "" when the address can't be resolved to a
+// function (stripped non-Go module — Module+Offset still locate it); File/Line
+// are set only for Go modules in this cut (C/C++ file:line needs DWARF). AddrHex
+// is the raw-address fallback ("0x…", or "unknown" when the stack walk failed).
 type HeapCallSite struct {
 	CallSite      uint64  // raw application instruction pointer
-	AddrHex       string  // "0x…" display form ("unknown" when unresolved)
+	AddrHex       string  // "0x…" raw-address fallback ("unknown" when unresolved)
+	Func          string  // resolved function name ("" if unresolved)
+	File          string  // source file (Go only in this cut; "" otherwise)
+	Line          int     // source line (0 if unknown)
+	Module        string  // backing module basename ("" if unresolved)
+	Offset        uint64  // module-relative offset of the call site
 	LiveBytes     uint64  // bytes still live from this site
 	AllocCount    uint64  // total allocations ever from this site
 	AvgLifetimeMs float64 // mean lifetime of freed allocations from this site

--- a/pkg/streampb/event.pb.go
+++ b/pkg/streampb/event.pb.go
@@ -926,14 +926,25 @@ func (x *HeapEvent) GetLarge() bool {
 
 // HeapCallSite aggregates the live allocations attributed to one application
 // call site (by the alloc site, so a free decrements where it was allocated).
+//
+// call_site is the raw instruction pointer; func/file/line/module/offset are its
+// symbolization (#54). func is "" when the address can't be resolved to a
+// function (stripped non-Go module — module+offset still locate it); file/line
+// are set only for Go modules in this cut (C/C++ file:line needs DWARF). addr_hex
+// is the raw-address fallback ("0x…", or "unknown" when the stack walk failed).
 type HeapCallSite struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	CallSite      uint64                 `protobuf:"varint,1,opt,name=call_site,json=callSite,proto3" json:"call_site,omitempty"`
-	AddrHex       string                 `protobuf:"bytes,2,opt,name=addr_hex,json=addrHex,proto3" json:"addr_hex,omitempty"` // "0x…" display form ("unknown" when unresolved)
+	AddrHex       string                 `protobuf:"bytes,2,opt,name=addr_hex,json=addrHex,proto3" json:"addr_hex,omitempty"` // raw-address fallback ("0x…"; "unknown" when unresolved)
 	LiveBytes     uint64                 `protobuf:"varint,3,opt,name=live_bytes,json=liveBytes,proto3" json:"live_bytes,omitempty"`
 	AllocCount    uint64                 `protobuf:"varint,4,opt,name=alloc_count,json=allocCount,proto3" json:"alloc_count,omitempty"`
 	AvgLifetimeMs float64                `protobuf:"fixed64,5,opt,name=avg_lifetime_ms,json=avgLifetimeMs,proto3" json:"avg_lifetime_ms,omitempty"`
 	Suspected     bool                   `protobuf:"varint,6,opt,name=suspected,proto3" json:"suspected,omitempty"` // has live allocations older than the leak threshold
+	Func          string                 `protobuf:"bytes,7,opt,name=func,proto3" json:"func,omitempty"`            // resolved function name ("" if unresolved)
+	File          string                 `protobuf:"bytes,8,opt,name=file,proto3" json:"file,omitempty"`            // source file (Go only in this cut; "" otherwise)
+	Line          int32                  `protobuf:"varint,9,opt,name=line,proto3" json:"line,omitempty"`           // source line (0 if unknown)
+	Module        string                 `protobuf:"bytes,10,opt,name=module,proto3" json:"module,omitempty"`       // backing module basename ("" if unresolved)
+	Offset        uint64                 `protobuf:"varint,11,opt,name=offset,proto3" json:"offset,omitempty"`      // module-relative offset of the call site
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -1008,6 +1019,41 @@ func (x *HeapCallSite) GetSuspected() bool {
 		return x.Suspected
 	}
 	return false
+}
+
+func (x *HeapCallSite) GetFunc() string {
+	if x != nil {
+		return x.Func
+	}
+	return ""
+}
+
+func (x *HeapCallSite) GetFile() string {
+	if x != nil {
+		return x.File
+	}
+	return ""
+}
+
+func (x *HeapCallSite) GetLine() int32 {
+	if x != nil {
+		return x.Line
+	}
+	return 0
+}
+
+func (x *HeapCallSite) GetModule() string {
+	if x != nil {
+		return x.Module
+	}
+	return ""
+}
+
+func (x *HeapCallSite) GetOffset() uint64 {
+	if x != nil {
+		return x.Offset
+	}
+	return 0
 }
 
 // HeapSnapshot is the periodic heap aggregate. live_heap_bytes and
@@ -2018,7 +2064,7 @@ const file_event_proto_rawDesc = "" +
 	"\vlifetime_ms\x18\x04 \x01(\x01R\n" +
 	"lifetimeMs\x12\x1b\n" +
 	"\tcall_site\x18\x05 \x01(\x04R\bcallSite\x12\x14\n" +
-	"\x05large\x18\x06 \x01(\bR\x05large\"\xcc\x01\n" +
+	"\x05large\x18\x06 \x01(\bR\x05large\"\xb8\x02\n" +
 	"\fHeapCallSite\x12\x1b\n" +
 	"\tcall_site\x18\x01 \x01(\x04R\bcallSite\x12\x19\n" +
 	"\baddr_hex\x18\x02 \x01(\tR\aaddrHex\x12\x1d\n" +
@@ -2027,7 +2073,13 @@ const file_event_proto_rawDesc = "" +
 	"\valloc_count\x18\x04 \x01(\x04R\n" +
 	"allocCount\x12&\n" +
 	"\x0favg_lifetime_ms\x18\x05 \x01(\x01R\ravgLifetimeMs\x12\x1c\n" +
-	"\tsuspected\x18\x06 \x01(\bR\tsuspected\"\xc4\x01\n" +
+	"\tsuspected\x18\x06 \x01(\bR\tsuspected\x12\x12\n" +
+	"\x04func\x18\a \x01(\tR\x04func\x12\x12\n" +
+	"\x04file\x18\b \x01(\tR\x04file\x12\x12\n" +
+	"\x04line\x18\t \x01(\x05R\x04line\x12\x16\n" +
+	"\x06module\x18\n" +
+	" \x01(\tR\x06module\x12\x16\n" +
+	"\x06offset\x18\v \x01(\x04R\x06offset\"\xc4\x01\n" +
 	"\fHeapSnapshot\x12&\n" +
 	"\x0flive_heap_bytes\x18\x01 \x01(\x04R\rliveHeapBytes\x12\x1d\n" +
 	"\n" +

--- a/proto/event.proto
+++ b/proto/event.proto
@@ -118,13 +118,24 @@ message HeapEvent {
 
 // HeapCallSite aggregates the live allocations attributed to one application
 // call site (by the alloc site, so a free decrements where it was allocated).
+//
+// call_site is the raw instruction pointer; func/file/line/module/offset are its
+// symbolization (#54). func is "" when the address can't be resolved to a
+// function (stripped non-Go module — module+offset still locate it); file/line
+// are set only for Go modules in this cut (C/C++ file:line needs DWARF). addr_hex
+// is the raw-address fallback ("0x…", or "unknown" when the stack walk failed).
 message HeapCallSite {
   uint64 call_site = 1;
-  string addr_hex = 2; // "0x…" display form ("unknown" when unresolved)
+  string addr_hex = 2; // raw-address fallback ("0x…"; "unknown" when unresolved)
   uint64 live_bytes = 3;
   uint64 alloc_count = 4;
   double avg_lifetime_ms = 5;
   bool suspected = 6; // has live allocations older than the leak threshold
+  string func = 7; // resolved function name ("" if unresolved)
+  string file = 8; // source file (Go only in this cut; "" otherwise)
+  int32 line = 9; // source line (0 if unknown)
+  string module = 10; // backing module basename ("" if unresolved)
+  uint64 offset = 11; // module-relative offset of the call site
 }
 
 // HeapSnapshot is the periodic heap aggregate. live_heap_bytes and


### PR DESCRIPTION
## What

PR2 of #54. Wires the `pkg/symbol` Symbolizer (landed in #75) into the eBPF heap collector so the **F1 Memory panel shows allocation call sites as `func (file:line)`** instead of raw hex (`0x4011a3`).

Builds on #53 (heap malloc/free pairing). Off a fresh `main` — no PR stacking.

## Changes

- **collector**: `HeapEBPFCollector` builds a `*symbol.Symbolizer` for its pid in `Start` (best-effort — without `/proc` maps it degrades to hex, exactly as before #54, and never fails `Start`). `resolveSite` now returns a cached `{addr, symbol.Frame}` keyed by `stack_id`, shared by `readLoop` + `publishLoop` under the existing mutex.
- **types + proto**: `collector.HeapCallSite` (and `proto HeapCallSite`, additive fields 7–11) gain `Func/File/Line/Module/Offset`. `AddrHex` stays as the raw-address fallback.
- **TUI**: new `heapSiteLabel` formats the fallback chain — `func (file:line)` → `func` → `module+0xoff` → `0xhex`/`unknown`; `renderHeapSiteRow` renders it.
- **mapper**: carries the new fields onto the gRPC stream.

## Scope

`file:line` is **Go-only** in this cut (via `.gopclntab`/`gosym`); C/C++ DWARF line info is deferred (#54 follow-up). C functions resolve to a name; stripped modules to `module+0xoffset`.

PR3 (next): `StackRef` on `Event.stack` for heap events + a `ResolveStack` RPC.

## Tests

- `heapSiteLabel` fallback-chain unit test; F1 render asserts a symbolized site + a hex fallback.
- mapper round-trips the new fields.
- `go vet`/`build`/`test` green (default + `-tags=ebpf` stub lane). The real `linux && ebpf` lane is CI-validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)