### PR TITLE
serve: StackRef on heap events + ResolveStack RPC (#54)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -346,6 +346,16 @@ The gRPC subscriber and the JSONL writer are interchangeable `Sink`s
 sink: it writes one protojson `Event` per line to `ptop-events-<ts>.jsonl`
 (event-level — distinct from the TUI's state-snapshot `ptop-export-<ts>.jsonl`).
 
+Stack symbolization (#54) rides this surface: heap events carry a
+`StackRef{stack_id, build_id}` on the envelope (high-rate events stay small —
+they reference a stack, not its frames), and the `ResolveStack(stack_id)` RPC
+resolves it to leaf-first `StackFrame`s on demand. The heap collector owns the
+stack tracer + `symbol.Symbolizer`, so it backs both — `serve.Run` takes it as
+the optional `StackResolver`; a nil resolver simply omits stack refs and reports
+`found=false`. `build_id` is the target executable's GNU build-id, a stable
+per-process cache key (the same `stack_id` denotes a different stack once the
+binary changes).
+
 Version metadata is injected via `-ldflags` at release time
 (`main.version`, `main.commit`, `main.buildDate`). In dev they stay as
 `"dev"`/`"none"`/`"unknown"`.

--- a/cmd/ptop/main.go
+++ b/cmd/ptop/main.go
@@ -128,7 +128,15 @@ func runServe(addr string, pid int, noEBPF, export bool) {
 	set := collector.NewSet(collector.SetConfig{PID: pid, NoEBPF: noEBPF})
 	defer set.Stop()
 
-	if err := serve.Run(ctx, addr, pid, set.Collectors(), opts); err != nil {
+	// The heap collector owns the stack tracer + symbolizer, so it backs stack
+	// references + the ResolveStack RPC. Pass an untyped nil when it never
+	// started (avoid a non-nil interface wrapping a nil pointer).
+	var resolver serve.StackResolver
+	if set.HeapEBPF != nil {
+		resolver = set.HeapEBPF
+	}
+
+	if err := serve.Run(ctx, addr, pid, set.Collectors(), resolver, opts); err != nil {
 		set.Stop() // os.Exit skips the defer
 		fmt.Fprintf(os.Stderr, "fatal error: %v\n", err)
 		os.Exit(1)

--- a/internal/serve/hub.go
+++ b/internal/serve/hub.go
@@ -13,13 +13,14 @@ import (
 // of the unified event stream: a gRPC subscriber and a JSONL writer are both
 // just Sinks (see sink.go).
 type Hub struct {
-	pid   int
-	mu    sync.Mutex
-	sinks map[Sink]struct{}
+	pid     int
+	buildID string // target exec build-id, stamped onto every StackRef (#54)
+	mu      sync.Mutex
+	sinks   map[Sink]struct{}
 }
 
-func NewHub(pid int) *Hub {
-	return &Hub{pid: pid, sinks: make(map[Sink]struct{})}
+func NewHub(pid int, buildID string) *Hub {
+	return &Hub{pid: pid, buildID: buildID, sinks: make(map[Sink]struct{})}
 }
 
 // Start launches one fan-in goroutine per collector. Each maps published values
@@ -44,7 +45,7 @@ func (h *Hub) drain(ctx context.Context, ch <-chan interface{}) {
 			if !ok {
 				return
 			}
-			if ev := toEvent(h.pid, v); ev != nil {
+			if ev := toEvent(h.pid, h.buildID, v); ev != nil {
 				h.broadcast(ev)
 			}
 		}

--- a/internal/serve/hub_test.go
+++ b/internal/serve/hub_test.go
@@ -24,7 +24,7 @@ func TestHubFanOut(t *testing.T) {
 	defer cancel()
 
 	f := newFake(8)
-	h := NewHub(7)
+	h := NewHub(7, "")
 	sub := h.subscribe(nil)
 	h.Start(ctx, []collector.Collector{f})
 
@@ -52,7 +52,7 @@ func TestHubCategoryFilter(t *testing.T) {
 	defer cancel()
 
 	f := newFake(8)
-	h := NewHub(1)
+	h := NewHub(1, "")
 	sub := h.subscribe([]pb.Category{pb.Category_CATEGORY_NETWORK})
 	h.Start(ctx, []collector.Collector{f})
 
@@ -84,7 +84,7 @@ func TestHubBackpressureDrops(t *testing.T) {
 
 	// Source channel large enough to hold every emit without blocking the test.
 	f := newFake(subBuffer + 200)
-	h := NewHub(1)
+	h := NewHub(1, "")
 	sub := h.subscribe(nil) // never read → its buffer fills, then drops
 	h.Start(ctx, []collector.Collector{f})
 
@@ -107,7 +107,7 @@ func TestHubBackpressureDrops(t *testing.T) {
 }
 
 func TestHubUnsubscribe(t *testing.T) {
-	h := NewHub(1)
+	h := NewHub(1, "")
 	sub := h.subscribe(nil)
 	if h.sinkCount() != 1 {
 		t.Fatalf("count = %d, want 1", h.sinkCount())

--- a/internal/serve/mapper.go
+++ b/internal/serve/mapper.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/trentas/ptop/pkg/collector"
 	pb "github.com/trentas/ptop/pkg/streampb"
+	"github.com/trentas/ptop/pkg/symbol"
 )
 
 // toEvent converts a value published on a collector channel into a stream
@@ -13,9 +14,10 @@ import (
 // skipped by the hub.
 //
 // The envelope timestamp comes from the value's own Timestamp where it has one,
-// else the current time. Field copies are mechanical: the proto messages mirror
+// else the current time. buildID stamps the StackRef on stack-bearing events
+// (#54). Field copies are mechanical: the proto messages mirror
 // collector/types.go 1:1.
-func toEvent(pid int, v interface{}) *pb.Event {
+func toEvent(pid int, buildID string, v interface{}) *pb.Event {
 	ev := &pb.Event{Pid: int32(pid)}
 
 	switch x := v.(type) {
@@ -66,6 +68,7 @@ func toEvent(pid int, v interface{}) *pb.Event {
 	case collector.HeapEvent:
 		ev.TsUnixNano = nowNano()
 		ev.Category = pb.Category_CATEGORY_MEMORY
+		ev.Stack = stackRef(x.StackID, buildID)
 		ev.Payload = &pb.Event_HeapEvent{HeapEvent: &pb.HeapEvent{
 			Op: x.Op, Size: x.Size, Addr: x.Addr,
 			LifetimeMs: x.LifetimeMs, CallSite: x.CallSite, Large: x.Large,
@@ -153,6 +156,39 @@ func heapCallSites(in []collector.HeapCallSite) []*pb.HeapCallSite {
 			CallSite: s.CallSite, AddrHex: s.AddrHex, LiveBytes: s.LiveBytes,
 			AllocCount: s.AllocCount, AvgLifetimeMs: s.AvgLifetimeMs, Suspected: s.Suspected,
 			Func: s.Func, File: s.File, Line: int32(s.Line), Module: s.Module, Offset: s.Offset,
+			StackId: stackID(s.StackID),
+		}
+	}
+	return out
+}
+
+// stackRef builds the envelope StackRef for a stack-bearing event, or nil when
+// the stack walk failed (negative kernel sentinel) so consumers don't chase a
+// dead id.
+func stackRef(stackID int32, buildID string) *pb.StackRef {
+	if stackID < 0 {
+		return nil
+	}
+	return &pb.StackRef{StackId: uint64(stackID), BuildId: buildID}
+}
+
+// stackID widens a kernel stack id for the wire. A negative sentinel (walk
+// failed) becomes 0 — ResolveStack(0) reports not-found, the same as any id the
+// kernel has since evicted.
+func stackID(id int32) uint64 {
+	if id < 0 {
+		return 0
+	}
+	return uint64(id)
+}
+
+// stackFrames maps resolved symbol frames onto the wire form for ResolveStack.
+func stackFrames(in []symbol.Frame) []*pb.StackFrame {
+	out := make([]*pb.StackFrame, len(in))
+	for i, f := range in {
+		out[i] = &pb.StackFrame{
+			Func: f.Func, File: f.File, Line: int32(f.Line),
+			Module: f.Module, Offset: f.Offset, BuildId: f.BuildID,
 		}
 	}
 	return out

--- a/internal/serve/mapper_test.go
+++ b/internal/serve/mapper_test.go
@@ -10,6 +10,7 @@ import (
 
 func TestToEventCategoriesAndPayloads(t *testing.T) {
 	const pid = 1234
+	const buildID = "bid-abc"
 	cases := []struct {
 		name string
 		in   interface{}
@@ -31,7 +32,7 @@ func TestToEventCategoriesAndPayloads(t *testing.T) {
 			LiveHeapBytes: 4096, AllocRate: 12.5, SuspectedLeakBytes: 1024,
 			TopCallSites: []collector.HeapCallSite{{CallSite: 0xabc, AddrHex: "0xabc",
 				Func: "main.leak", File: "/build/main.go", Line: 42, Module: "app", Offset: 0x1a3,
-				LiveBytes: 4096, Suspected: true}},
+				StackID: 7, LiveBytes: 4096, Suspected: true}},
 			Timestamp: time.Unix(6, 0),
 		}, pb.Category_CATEGORY_MEMORY, func(e *pb.Event) bool {
 			h := e.GetHeap()
@@ -41,12 +42,14 @@ func TestToEventCategoriesAndPayloads(t *testing.T) {
 			cs := h.GetTopCallSites()[0]
 			return cs.GetAddrHex() == "0xabc" && cs.GetFunc() == "main.leak" &&
 				cs.GetFile() == "/build/main.go" && cs.GetLine() == 42 &&
-				cs.GetModule() == "app" && cs.GetOffset() == 0x1a3
+				cs.GetModule() == "app" && cs.GetOffset() == 0x1a3 && cs.GetStackId() == 7
 		}},
-		{"heap_event", collector.HeapEvent{Op: "free", Size: 256, Addr: 0xdead, LifetimeMs: 7.5, CallSite: 0xabc, Large: false},
+		// heap_event carries a StackRef{stack_id, build_id} on the envelope.
+		{"heap_event", collector.HeapEvent{Op: "free", Size: 256, Addr: 0xdead, LifetimeMs: 7.5, CallSite: 0xabc, StackID: 9, Large: false},
 			pb.Category_CATEGORY_MEMORY, func(e *pb.Event) bool {
 				he := e.GetHeapEvent()
-				return he.GetOp() == "free" && he.GetSize() == 256 && he.GetLifetimeMs() == 7.5
+				return he.GetOp() == "free" && he.GetSize() == 256 && he.GetLifetimeMs() == 7.5 &&
+					e.GetStack().GetStackId() == 9 && e.GetStack().GetBuildId() == buildID
 			}},
 		{"threads", []collector.ThreadInfo{{TID: 11, Name: "main", CtxSwitches: 4}},
 			pb.Category_CATEGORY_THREAD, func(e *pb.Event) bool {
@@ -84,7 +87,7 @@ func TestToEventCategoriesAndPayloads(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			ev := toEvent(pid, tc.in)
+			ev := toEvent(pid, buildID, tc.in)
 			if ev == nil {
 				t.Fatalf("toEvent returned nil for %T", tc.in)
 			}
@@ -105,24 +108,40 @@ func TestToEventCategoriesAndPayloads(t *testing.T) {
 }
 
 func TestToEventUnknownReturnsNil(t *testing.T) {
-	if ev := toEvent(1, "not a collector value"); ev != nil {
+	if ev := toEvent(1, "", "not a collector value"); ev != nil {
 		t.Errorf("expected nil for unknown type, got %v", ev)
 	}
-	if ev := toEvent(1, 42); ev != nil {
+	if ev := toEvent(1, "", 42); ev != nil {
 		t.Errorf("expected nil for unknown type, got %v", ev)
+	}
+}
+
+// A failed stack walk (negative kernel sentinel) must not surface a dead id:
+// the heap event gets no StackRef and a snapshot site reports stack_id 0.
+func TestToEventNegativeStackID(t *testing.T) {
+	ev := toEvent(1, "bid", collector.HeapEvent{Op: "malloc", StackID: -1})
+	if ev.GetStack() != nil {
+		t.Errorf("Stack = %v, want nil for a failed stack walk", ev.GetStack())
+	}
+
+	ev = toEvent(1, "bid", collector.HeapStats{
+		TopCallSites: []collector.HeapCallSite{{AddrHex: "unknown", StackID: -1}},
+	})
+	if id := ev.GetHeap().GetTopCallSites()[0].GetStackId(); id != 0 {
+		t.Errorf("StackId = %d, want 0 for a failed stack walk", id)
 	}
 }
 
 // A value carrying a timestamp uses it; one without falls back to now.
 func TestToEventTimestamp(t *testing.T) {
 	ts := time.Unix(100, 500)
-	ev := toEvent(1, collector.CpuSample{UsagePct: 1, Timestamp: ts})
+	ev := toEvent(1, "", collector.CpuSample{UsagePct: 1, Timestamp: ts})
 	if ev.GetTsUnixNano() != ts.UnixNano() {
 		t.Errorf("ts = %d, want %d", ev.GetTsUnixNano(), ts.UnixNano())
 	}
 
 	before := time.Now().UnixNano()
-	ev = toEvent(1, collector.MemStats{RSSBytes: 1})
+	ev = toEvent(1, "", collector.MemStats{RSSBytes: 1})
 	if ev.GetTsUnixNano() < before {
 		t.Errorf("ts = %d, expected >= %d (now)", ev.GetTsUnixNano(), before)
 	}

--- a/internal/serve/serve.go
+++ b/internal/serve/serve.go
@@ -31,14 +31,22 @@ type Options struct {
 // and returns. The caller owns the collectors' lifecycle (typically
 // set.Collectors() here and set.Stop() after Run returns). addr is
 // "unix:///path" or "tcp://host:port".
-func Run(ctx context.Context, addr string, pid int, cols []collector.Collector, opts Options) error {
+//
+// resolver (optional, nil-safe) symbolizes captured stacks: it stamps the
+// per-process build-id onto every StackRef and backs the ResolveStack RPC. Pass
+// set.HeapEBPF when non-nil; nil leaves heap events without stack references.
+func Run(ctx context.Context, addr string, pid int, cols []collector.Collector, resolver StackResolver, opts Options) error {
 	lis, cleanup, err := listen(addr)
 	if err != nil {
 		return err
 	}
 	defer cleanup()
 
-	hub := NewHub(pid)
+	var buildID string
+	if resolver != nil {
+		buildID = resolver.ProcessBuildID()
+	}
+	hub := NewHub(pid, buildID)
 	hub.Start(ctx, cols)
 
 	// Optional JSONL sink: a non-gRPC consumer of the same event stream.
@@ -54,7 +62,7 @@ func Run(ctx context.Context, addr string, pid int, cols []collector.Collector, 
 	}
 
 	srv := grpc.NewServer()
-	pb.RegisterEventStreamServiceServer(srv, &eventStreamService{hub: hub})
+	pb.RegisterEventStreamServiceServer(srv, &eventStreamService{hub: hub, resolver: resolver})
 
 	// On cancel, Stop() (not GracefulStop): Subscribe streams are long-lived and
 	// only end when the client disconnects, so GracefulStop would block forever.

--- a/internal/serve/serve_test.go
+++ b/internal/serve/serve_test.go
@@ -42,7 +42,7 @@ func TestServeUnixEndToEnd(t *testing.T) {
 	}()
 
 	runErr := make(chan error, 1)
-	go func() { runErr <- Run(ctx, addr, 99, []collector.Collector{f}, Options{}) }()
+	go func() { runErr <- Run(ctx, addr, 99, []collector.Collector{f}, nil, Options{}) }()
 
 	// Wait for the listener socket to appear before dialing.
 	waitFor(t, func() bool { _, err := os.Stat(sock); return err == nil })
@@ -108,7 +108,7 @@ func TestServeBackpressureMetaOverGRPC(t *testing.T) {
 
 	f := newFake(8192) // holds the burst without blocking the producer
 	runErr := make(chan error, 1)
-	go func() { runErr <- Run(ctx, addr, 1, []collector.Collector{f}, Options{}) }()
+	go func() { runErr <- Run(ctx, addr, 1, []collector.Collector{f}, nil, Options{}) }()
 	waitFor(t, func() bool { _, err := os.Stat(sock); return err == nil })
 
 	conn, err := grpc.NewClient(addr, grpc.WithTransportCredentials(insecure.NewCredentials()))
@@ -176,7 +176,7 @@ func TestServeJSONLExport(t *testing.T) {
 
 	runErr := make(chan error, 1)
 	go func() {
-		runErr <- Run(ctx, "unix://"+sock, 5, []collector.Collector{f}, Options{JSONLPath: jsonl})
+		runErr <- Run(ctx, "unix://"+sock, 5, []collector.Collector{f}, nil, Options{JSONLPath: jsonl})
 	}()
 	waitFor(t, func() bool { _, err := os.Stat(sock); return err == nil })
 

--- a/internal/serve/service.go
+++ b/internal/serve/service.go
@@ -1,15 +1,45 @@
 package serve
 
 import (
+	"context"
 	"sync/atomic"
 
 	pb "github.com/trentas/ptop/pkg/streampb"
+	"github.com/trentas/ptop/pkg/symbol"
 )
+
+// StackResolver turns a captured stack id (seen on the stream as
+// Event.stack.stack_id or HeapCallSite.stack_id) into its symbolized frames and
+// reports the target's build-id (a stable per-process cache key). The eBPF heap
+// collector implements it; a nil resolver disables stack references and makes
+// ResolveStack report not-found.
+type StackResolver interface {
+	// ProcessBuildID is the target executable's GNU build-id, or "" if none.
+	ProcessBuildID() string
+	// ResolveStack returns the leaf-first frames for a stack id; ok is false
+	// when the id is unknown or symbolization is unavailable.
+	ResolveStack(stackID uint64) (frames []symbol.Frame, ok bool)
+}
 
 // eventStreamService implements the generated EventStreamServiceServer over a Hub.
 type eventStreamService struct {
 	pb.UnimplementedEventStreamServiceServer
-	hub *Hub
+	hub      *Hub
+	resolver StackResolver // nil when the build has no symbolization
+}
+
+// ResolveStack symbolizes a stack id seen on the stream into its leaf-first
+// frames (out-of-band so high-rate events stay small). Resolution is
+// best-effort: an unknown id, or no resolver, yields found=false (not an error).
+func (svc *eventStreamService) ResolveStack(_ context.Context, req *pb.ResolveStackRequest) (*pb.ResolveStackResponse, error) {
+	if svc.resolver == nil {
+		return &pb.ResolveStackResponse{Found: false}, nil
+	}
+	frames, ok := svc.resolver.ResolveStack(req.GetStackId())
+	if !ok {
+		return &pb.ResolveStackResponse{Found: false}, nil
+	}
+	return &pb.ResolveStackResponse{Found: true, Frames: stackFrames(frames)}, nil
 }
 
 // Subscribe registers the client with the hub and streams its queued responses

--- a/internal/serve/service_test.go
+++ b/internal/serve/service_test.go
@@ -1,0 +1,72 @@
+package serve
+
+import (
+	"context"
+	"testing"
+
+	pb "github.com/trentas/ptop/pkg/streampb"
+	"github.com/trentas/ptop/pkg/symbol"
+)
+
+// fakeResolver is a StackResolver driven by the test.
+type fakeResolver struct {
+	buildID string
+	frames  map[uint64][]symbol.Frame
+}
+
+func (r *fakeResolver) ProcessBuildID() string { return r.buildID }
+func (r *fakeResolver) ResolveStack(id uint64) ([]symbol.Frame, bool) {
+	fr, ok := r.frames[id]
+	return fr, ok
+}
+
+func TestResolveStackRPC(t *testing.T) {
+	res := &fakeResolver{
+		buildID: "bid",
+		frames: map[uint64][]symbol.Frame{
+			42: {
+				{Func: "main.leak", File: "/build/main.go", Line: 7, Module: "app", Offset: 0x1a3, BuildID: "bid"},
+				{Func: "main.main", File: "/build/main.go", Line: 20, Module: "app", Offset: 0x2b4},
+			},
+		},
+	}
+	svc := &eventStreamService{resolver: res}
+
+	// Known id → found, frames mapped leaf-first 1:1.
+	resp, err := svc.ResolveStack(context.Background(), &pb.ResolveStackRequest{StackId: 42})
+	if err != nil {
+		t.Fatalf("ResolveStack: %v", err)
+	}
+	if !resp.GetFound() {
+		t.Fatal("found = false, want true for a known id")
+	}
+	if n := len(resp.GetFrames()); n != 2 {
+		t.Fatalf("frames = %d, want 2", n)
+	}
+	f0 := resp.GetFrames()[0]
+	if f0.GetFunc() != "main.leak" || f0.GetFile() != "/build/main.go" || f0.GetLine() != 7 ||
+		f0.GetModule() != "app" || f0.GetOffset() != 0x1a3 || f0.GetBuildId() != "bid" {
+		t.Errorf("frame[0] = %+v", f0)
+	}
+
+	// Unknown id → found=false, no error.
+	resp, err = svc.ResolveStack(context.Background(), &pb.ResolveStackRequest{StackId: 99})
+	if err != nil {
+		t.Fatalf("ResolveStack(unknown): %v", err)
+	}
+	if resp.GetFound() || len(resp.GetFrames()) != 0 {
+		t.Errorf("unknown id: found=%v frames=%d, want false/0", resp.GetFound(), len(resp.GetFrames()))
+	}
+}
+
+func TestResolveStackRPCNilResolver(t *testing.T) {
+	// A build without symbolization (nil resolver) never errors — just not-found.
+	svc := &eventStreamService{}
+	resp, err := svc.ResolveStack(context.Background(), &pb.ResolveStackRequest{StackId: 1})
+	if err != nil {
+		t.Fatalf("ResolveStack: %v", err)
+	}
+	if resp.GetFound() {
+		t.Error("found = true with no resolver, want false")
+	}
+}

--- a/pkg/collector/heap_agg_test.go
+++ b/pkg/collector/heap_agg_test.go
@@ -80,6 +80,20 @@ func TestHeapAddrHex(t *testing.T) {
 	}
 }
 
+// TestHeapResolverZeroValue locks in the StackResolver contract a not-yet-
+// Start()ed (or stub) collector must honor: no tracer/symbolizer → graceful
+// not-found and an empty build-id, never a panic. Holds on both lanes (the real
+// collector guards on a nil tracer; the stub returns the same).
+func TestHeapResolverZeroValue(t *testing.T) {
+	c := &HeapEBPFCollector{}
+	if fr, ok := c.ResolveStack(1); ok || fr != nil {
+		t.Errorf("ResolveStack = %v,%v; want nil,false", fr, ok)
+	}
+	if id := c.ProcessBuildID(); id != "" {
+		t.Errorf("ProcessBuildID = %q, want \"\"", id)
+	}
+}
+
 func TestHeapOpName(t *testing.T) {
 	cases := map[uint32]string{0: "malloc", 1: "calloc", 2: "realloc", 3: "free", 99: "?"}
 	for op, want := range cases {

--- a/pkg/collector/heap_ebpf.go
+++ b/pkg/collector/heap_ebpf.go
@@ -38,9 +38,10 @@ type HeapEBPFCollector struct {
 
 	allocCount uint64 // atomic; allocations since the last publish (rate)
 
-	mu        sync.Mutex
-	siteCache map[int32]heapSite // stack_id → resolved app call-site (cache)
-	lastAt    time.Time          // publishLoop-only; rate baseline
+	mu         sync.Mutex
+	siteCache  map[int32]heapSite       // stack_id → resolved app call-site (cache)
+	stackCache map[int32][]symbol.Frame // stack_id → full leaf-first frames (cache)
+	lastAt     time.Time                // publishLoop-only; rate baseline
 }
 
 // heapSite is the resolved application call site for a stack_id: the raw frame
@@ -63,6 +64,7 @@ func NewHeapEBPFCollector() *HeapEBPFCollector {
 		stop:          make(chan struct{}),
 		leakThreshold: heapDefaultLeakThreshold,
 		siteCache:     make(map[int32]heapSite),
+		stackCache:    make(map[int32][]symbol.Frame),
 	}
 }
 
@@ -117,6 +119,7 @@ func (c *HeapEBPFCollector) readLoop() {
 			Addr:       ev.Addr,
 			LifetimeMs: float64(ev.LifetimeNs) / 1e6,
 			CallSite:   c.resolveSite(ev.StackID).addr,
+			StackID:    ev.StackID,
 			Large:      ev.Flags&bpf.HeapFlagLarge != 0,
 		}
 		select {
@@ -154,6 +157,53 @@ func (c *HeapEBPFCollector) resolveSite(stackID int32) heapSite {
 	c.siteCache[stackID] = site
 	c.mu.Unlock()
 	return site
+}
+
+// ResolveStack returns the full leaf-first symbolized frames of a captured
+// stack id, or ok=false when the id is unknown (negative sentinel, evicted from
+// the kernel map, or empty). Results are cached (stacks are immutable for the
+// process lifetime). Safe for concurrent use — the headless server calls it
+// from gRPC handlers while readLoop/publishLoop run. Implements the resolver the
+// EventStreamService.ResolveStack RPC is built on (#54).
+func (c *HeapEBPFCollector) ResolveStack(stackID uint64) ([]symbol.Frame, bool) {
+	if c.tracer == nil || int32(stackID) < 0 {
+		return nil, false
+	}
+	sid := int32(stackID)
+	c.mu.Lock()
+	if fr, ok := c.stackCache[sid]; ok {
+		c.mu.Unlock()
+		return fr, true
+	}
+	c.mu.Unlock()
+
+	addrs, err := c.tracer.ResolveStack(sid)
+	if err != nil || len(addrs) == 0 {
+		return nil, false
+	}
+	frames := make([]symbol.Frame, len(addrs))
+	for i, a := range addrs {
+		if c.sym != nil {
+			frames[i] = c.sym.Symbolize(a)
+		} else {
+			frames[i] = symbol.Frame{Offset: a}
+		}
+	}
+
+	c.mu.Lock()
+	c.stackCache[sid] = frames
+	c.mu.Unlock()
+	return frames, true
+}
+
+// ProcessBuildID returns the target executable's GNU build-id — a stable key
+// for the stack ids this collector hands out (see symbol.Symbolizer). "" when
+// the process has no build-id or no symbolizer was built.
+func (c *HeapEBPFCollector) ProcessBuildID() string {
+	if c.sym == nil {
+		return ""
+	}
+	return c.sym.ProcessBuildID()
 }
 
 func (c *HeapEBPFCollector) publishLoop() {
@@ -214,6 +264,7 @@ func (c *HeapEBPFCollector) snapshot() (HeapStats, error) {
 			Line:          site.frame.Line,
 			Module:        site.frame.Module,
 			Offset:        site.frame.Offset,
+			StackID:       sid,
 			LiveBytes:     uint64(lb),
 			AllocCount:    raw.AllocCount,
 			AvgLifetimeMs: avgLifeMs,

--- a/pkg/collector/heap_ebpf_stub.go
+++ b/pkg/collector/heap_ebpf_stub.go
@@ -2,7 +2,11 @@
 
 package collector
 
-import "errors"
+import (
+	"errors"
+
+	"github.com/trentas/ptop/pkg/symbol"
+)
 
 type HeapEBPFCollector struct{}
 
@@ -12,3 +16,9 @@ func (*HeapEBPFCollector) Start(int) error {
 }
 func (*HeapEBPFCollector) Stop()                         {}
 func (*HeapEBPFCollector) Subscribe() <-chan interface{} { return nil }
+
+// ResolveStack / ProcessBuildID satisfy the serve.StackResolver shape so the
+// headless server can hold a *HeapEBPFCollector uniformly; without eBPF there
+// is nothing to resolve.
+func (*HeapEBPFCollector) ResolveStack(uint64) ([]symbol.Frame, bool) { return nil, false }
+func (*HeapEBPFCollector) ProcessBuildID() string                     { return "" }

--- a/pkg/collector/types.go
+++ b/pkg/collector/types.go
@@ -45,13 +45,15 @@ type MemStats struct {
 // Op is "malloc"|"calloc"|"realloc"|"free". LifetimeMs is set on free
 // (free.ts − alloc.ts). CallSite is the application call-site address (raw
 // instruction pointer; the aggregate HeapCallSite carries the symbolized form).
-// Large flags allocations ≥ 128KB.
+// StackID is the kernel stack-map id of the captured stack (<0 when the walk
+// failed), resolvable to full frames out-of-band. Large flags allocations ≥ 128KB.
 type HeapEvent struct {
 	Op         string
 	Size       uint64
 	Addr       uint64
 	LifetimeMs float64
 	CallSite   uint64
+	StackID    int32
 	Large      bool
 }
 
@@ -72,6 +74,7 @@ type HeapCallSite struct {
 	Line          int     // source line (0 if unknown)
 	Module        string  // backing module basename ("" if unresolved)
 	Offset        uint64  // module-relative offset of the call site
+	StackID       int32   // kernel stack-map id (<0 unknown); resolves to full frames
 	LiveBytes     uint64  // bytes still live from this site
 	AllocCount    uint64  // total allocations ever from this site
 	AvgLifetimeMs float64 // mean lifetime of freed allocations from this site

--- a/pkg/streampb/event.pb.go
+++ b/pkg/streampb/event.pb.go
@@ -94,8 +94,10 @@ func (Category) EnumDescriptor() ([]byte, []int) {
 }
 
 // StackRef references a stack captured at event time and resolved out-of-band
-// (#54 — stack symbolization). It stays empty until that lands; consumers
-// fetch frames via a side-channel keyed by stack_id (+ build_id for caching).
+// (#54 — stack symbolization). stack_id is the kernel stack-map id; build_id is
+// the target executable's GNU build-id, a stable per-process cache key (the
+// same stack_id means a different stack once the binary changes). Consumers
+// fetch the frames via EventStreamService.ResolveStack.
 type StackRef struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	StackId       uint64                 `protobuf:"varint,1,opt,name=stack_id,json=stackId,proto3" json:"stack_id,omitempty"`
@@ -148,6 +150,95 @@ func (x *StackRef) GetBuildId() string {
 	return ""
 }
 
+// StackFrame is one symbolized frame of a captured stack (#54), leaf-first.
+// func is "" when the address couldn't be resolved to a function (stripped
+// non-Go module — module+offset still locate it); file/line are populated only
+// for Go modules in this cut (C/C++ file:line needs DWARF). offset is
+// module-relative, so it is comparable across runs/ASLR.
+type StackFrame struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Func          string                 `protobuf:"bytes,1,opt,name=func,proto3" json:"func,omitempty"`
+	File          string                 `protobuf:"bytes,2,opt,name=file,proto3" json:"file,omitempty"`
+	Line          int32                  `protobuf:"varint,3,opt,name=line,proto3" json:"line,omitempty"`
+	Module        string                 `protobuf:"bytes,4,opt,name=module,proto3" json:"module,omitempty"`
+	Offset        uint64                 `protobuf:"varint,5,opt,name=offset,proto3" json:"offset,omitempty"`
+	BuildId       string                 `protobuf:"bytes,6,opt,name=build_id,json=buildId,proto3" json:"build_id,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *StackFrame) Reset() {
+	*x = StackFrame{}
+	mi := &file_event_proto_msgTypes[1]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *StackFrame) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*StackFrame) ProtoMessage() {}
+
+func (x *StackFrame) ProtoReflect() protoreflect.Message {
+	mi := &file_event_proto_msgTypes[1]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use StackFrame.ProtoReflect.Descriptor instead.
+func (*StackFrame) Descriptor() ([]byte, []int) {
+	return file_event_proto_rawDescGZIP(), []int{1}
+}
+
+func (x *StackFrame) GetFunc() string {
+	if x != nil {
+		return x.Func
+	}
+	return ""
+}
+
+func (x *StackFrame) GetFile() string {
+	if x != nil {
+		return x.File
+	}
+	return ""
+}
+
+func (x *StackFrame) GetLine() int32 {
+	if x != nil {
+		return x.Line
+	}
+	return 0
+}
+
+func (x *StackFrame) GetModule() string {
+	if x != nil {
+		return x.Module
+	}
+	return ""
+}
+
+func (x *StackFrame) GetOffset() uint64 {
+	if x != nil {
+		return x.Offset
+	}
+	return 0
+}
+
+func (x *StackFrame) GetBuildId() string {
+	if x != nil {
+		return x.BuildId
+	}
+	return ""
+}
+
 // Event is the single unified message on the stream. The envelope carries the
 // common fields (time, pid/tid, category, optional stack); the category-
 // specific data lives in the payload oneof. Snapshot-style payloads (lists)
@@ -187,7 +278,7 @@ type Event struct {
 
 func (x *Event) Reset() {
 	*x = Event{}
-	mi := &file_event_proto_msgTypes[1]
+	mi := &file_event_proto_msgTypes[2]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -199,7 +290,7 @@ func (x *Event) String() string {
 func (*Event) ProtoMessage() {}
 
 func (x *Event) ProtoReflect() protoreflect.Message {
-	mi := &file_event_proto_msgTypes[1]
+	mi := &file_event_proto_msgTypes[2]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -212,7 +303,7 @@ func (x *Event) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Event.ProtoReflect.Descriptor instead.
 func (*Event) Descriptor() ([]byte, []int) {
-	return file_event_proto_rawDescGZIP(), []int{1}
+	return file_event_proto_rawDescGZIP(), []int{2}
 }
 
 func (x *Event) GetTsUnixNano() int64 {
@@ -482,7 +573,7 @@ type CpuSample struct {
 
 func (x *CpuSample) Reset() {
 	*x = CpuSample{}
-	mi := &file_event_proto_msgTypes[2]
+	mi := &file_event_proto_msgTypes[3]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -494,7 +585,7 @@ func (x *CpuSample) String() string {
 func (*CpuSample) ProtoMessage() {}
 
 func (x *CpuSample) ProtoReflect() protoreflect.Message {
-	mi := &file_event_proto_msgTypes[2]
+	mi := &file_event_proto_msgTypes[3]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -507,7 +598,7 @@ func (x *CpuSample) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CpuSample.ProtoReflect.Descriptor instead.
 func (*CpuSample) Descriptor() ([]byte, []int) {
-	return file_event_proto_rawDescGZIP(), []int{2}
+	return file_event_proto_rawDescGZIP(), []int{3}
 }
 
 func (x *CpuSample) GetUsagePct() float64 {
@@ -529,7 +620,7 @@ type SyscallStat struct {
 
 func (x *SyscallStat) Reset() {
 	*x = SyscallStat{}
-	mi := &file_event_proto_msgTypes[3]
+	mi := &file_event_proto_msgTypes[4]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -541,7 +632,7 @@ func (x *SyscallStat) String() string {
 func (*SyscallStat) ProtoMessage() {}
 
 func (x *SyscallStat) ProtoReflect() protoreflect.Message {
-	mi := &file_event_proto_msgTypes[3]
+	mi := &file_event_proto_msgTypes[4]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -554,7 +645,7 @@ func (x *SyscallStat) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SyscallStat.ProtoReflect.Descriptor instead.
 func (*SyscallStat) Descriptor() ([]byte, []int) {
-	return file_event_proto_rawDescGZIP(), []int{3}
+	return file_event_proto_rawDescGZIP(), []int{4}
 }
 
 func (x *SyscallStat) GetName() string {
@@ -587,7 +678,7 @@ type SyscallSnapshot struct {
 
 func (x *SyscallSnapshot) Reset() {
 	*x = SyscallSnapshot{}
-	mi := &file_event_proto_msgTypes[4]
+	mi := &file_event_proto_msgTypes[5]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -599,7 +690,7 @@ func (x *SyscallSnapshot) String() string {
 func (*SyscallSnapshot) ProtoMessage() {}
 
 func (x *SyscallSnapshot) ProtoReflect() protoreflect.Message {
-	mi := &file_event_proto_msgTypes[4]
+	mi := &file_event_proto_msgTypes[5]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -612,7 +703,7 @@ func (x *SyscallSnapshot) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SyscallSnapshot.ProtoReflect.Descriptor instead.
 func (*SyscallSnapshot) Descriptor() ([]byte, []int) {
-	return file_event_proto_rawDescGZIP(), []int{4}
+	return file_event_proto_rawDescGZIP(), []int{5}
 }
 
 func (x *SyscallSnapshot) GetStats() []*SyscallStat {
@@ -639,7 +730,7 @@ type NetConn struct {
 
 func (x *NetConn) Reset() {
 	*x = NetConn{}
-	mi := &file_event_proto_msgTypes[5]
+	mi := &file_event_proto_msgTypes[6]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -651,7 +742,7 @@ func (x *NetConn) String() string {
 func (*NetConn) ProtoMessage() {}
 
 func (x *NetConn) ProtoReflect() protoreflect.Message {
-	mi := &file_event_proto_msgTypes[5]
+	mi := &file_event_proto_msgTypes[6]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -664,7 +755,7 @@ func (x *NetConn) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use NetConn.ProtoReflect.Descriptor instead.
 func (*NetConn) Descriptor() ([]byte, []int) {
-	return file_event_proto_rawDescGZIP(), []int{5}
+	return file_event_proto_rawDescGZIP(), []int{6}
 }
 
 func (x *NetConn) GetFd() int32 {
@@ -732,7 +823,7 @@ type NetworkSnapshot struct {
 
 func (x *NetworkSnapshot) Reset() {
 	*x = NetworkSnapshot{}
-	mi := &file_event_proto_msgTypes[6]
+	mi := &file_event_proto_msgTypes[7]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -744,7 +835,7 @@ func (x *NetworkSnapshot) String() string {
 func (*NetworkSnapshot) ProtoMessage() {}
 
 func (x *NetworkSnapshot) ProtoReflect() protoreflect.Message {
-	mi := &file_event_proto_msgTypes[6]
+	mi := &file_event_proto_msgTypes[7]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -757,7 +848,7 @@ func (x *NetworkSnapshot) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use NetworkSnapshot.ProtoReflect.Descriptor instead.
 func (*NetworkSnapshot) Descriptor() ([]byte, []int) {
-	return file_event_proto_rawDescGZIP(), []int{6}
+	return file_event_proto_rawDescGZIP(), []int{7}
 }
 
 func (x *NetworkSnapshot) GetConns() []*NetConn {
@@ -780,7 +871,7 @@ type MemStats struct {
 
 func (x *MemStats) Reset() {
 	*x = MemStats{}
-	mi := &file_event_proto_msgTypes[7]
+	mi := &file_event_proto_msgTypes[8]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -792,7 +883,7 @@ func (x *MemStats) String() string {
 func (*MemStats) ProtoMessage() {}
 
 func (x *MemStats) ProtoReflect() protoreflect.Message {
-	mi := &file_event_proto_msgTypes[7]
+	mi := &file_event_proto_msgTypes[8]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -805,7 +896,7 @@ func (x *MemStats) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use MemStats.ProtoReflect.Descriptor instead.
 func (*MemStats) Descriptor() ([]byte, []int) {
-	return file_event_proto_rawDescGZIP(), []int{7}
+	return file_event_proto_rawDescGZIP(), []int{8}
 }
 
 func (x *MemStats) GetRssBytes() uint64 {
@@ -854,7 +945,7 @@ type HeapEvent struct {
 
 func (x *HeapEvent) Reset() {
 	*x = HeapEvent{}
-	mi := &file_event_proto_msgTypes[8]
+	mi := &file_event_proto_msgTypes[9]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -866,7 +957,7 @@ func (x *HeapEvent) String() string {
 func (*HeapEvent) ProtoMessage() {}
 
 func (x *HeapEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_event_proto_msgTypes[8]
+	mi := &file_event_proto_msgTypes[9]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -879,7 +970,7 @@ func (x *HeapEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use HeapEvent.ProtoReflect.Descriptor instead.
 func (*HeapEvent) Descriptor() ([]byte, []int) {
-	return file_event_proto_rawDescGZIP(), []int{8}
+	return file_event_proto_rawDescGZIP(), []int{9}
 }
 
 func (x *HeapEvent) GetOp() string {
@@ -945,13 +1036,17 @@ type HeapCallSite struct {
 	Line          int32                  `protobuf:"varint,9,opt,name=line,proto3" json:"line,omitempty"`           // source line (0 if unknown)
 	Module        string                 `protobuf:"bytes,10,opt,name=module,proto3" json:"module,omitempty"`       // backing module basename ("" if unresolved)
 	Offset        uint64                 `protobuf:"varint,11,opt,name=offset,proto3" json:"offset,omitempty"`      // module-relative offset of the call site
+	// Kernel stack-map id of the alloc site, for EventStreamService.ResolveStack
+	// (the full leaf-first stack). A sentinel (resolves to not-found) when the
+	// stack walk failed.
+	StackId       uint64 `protobuf:"varint,12,opt,name=stack_id,json=stackId,proto3" json:"stack_id,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
 
 func (x *HeapCallSite) Reset() {
 	*x = HeapCallSite{}
-	mi := &file_event_proto_msgTypes[9]
+	mi := &file_event_proto_msgTypes[10]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -963,7 +1058,7 @@ func (x *HeapCallSite) String() string {
 func (*HeapCallSite) ProtoMessage() {}
 
 func (x *HeapCallSite) ProtoReflect() protoreflect.Message {
-	mi := &file_event_proto_msgTypes[9]
+	mi := &file_event_proto_msgTypes[10]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -976,7 +1071,7 @@ func (x *HeapCallSite) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use HeapCallSite.ProtoReflect.Descriptor instead.
 func (*HeapCallSite) Descriptor() ([]byte, []int) {
-	return file_event_proto_rawDescGZIP(), []int{9}
+	return file_event_proto_rawDescGZIP(), []int{10}
 }
 
 func (x *HeapCallSite) GetCallSite() uint64 {
@@ -1056,6 +1151,13 @@ func (x *HeapCallSite) GetOffset() uint64 {
 	return 0
 }
 
+func (x *HeapCallSite) GetStackId() uint64 {
+	if x != nil {
+		return x.StackId
+	}
+	return 0
+}
+
 // HeapSnapshot is the periodic heap aggregate. live_heap_bytes and
 // suspected_leak_bytes derive from the kernel's LRU-bounded live set, so they
 // undercount on alloc-heavy targets — never exact. alloc_rate is allocations
@@ -1072,7 +1174,7 @@ type HeapSnapshot struct {
 
 func (x *HeapSnapshot) Reset() {
 	*x = HeapSnapshot{}
-	mi := &file_event_proto_msgTypes[10]
+	mi := &file_event_proto_msgTypes[11]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1084,7 +1186,7 @@ func (x *HeapSnapshot) String() string {
 func (*HeapSnapshot) ProtoMessage() {}
 
 func (x *HeapSnapshot) ProtoReflect() protoreflect.Message {
-	mi := &file_event_proto_msgTypes[10]
+	mi := &file_event_proto_msgTypes[11]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1097,7 +1199,7 @@ func (x *HeapSnapshot) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use HeapSnapshot.ProtoReflect.Descriptor instead.
 func (*HeapSnapshot) Descriptor() ([]byte, []int) {
-	return file_event_proto_rawDescGZIP(), []int{10}
+	return file_event_proto_rawDescGZIP(), []int{11}
 }
 
 func (x *HeapSnapshot) GetLiveHeapBytes() uint64 {
@@ -1143,7 +1245,7 @@ type ThreadInfo struct {
 
 func (x *ThreadInfo) Reset() {
 	*x = ThreadInfo{}
-	mi := &file_event_proto_msgTypes[11]
+	mi := &file_event_proto_msgTypes[12]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1155,7 +1257,7 @@ func (x *ThreadInfo) String() string {
 func (*ThreadInfo) ProtoMessage() {}
 
 func (x *ThreadInfo) ProtoReflect() protoreflect.Message {
-	mi := &file_event_proto_msgTypes[11]
+	mi := &file_event_proto_msgTypes[12]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1168,7 +1270,7 @@ func (x *ThreadInfo) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ThreadInfo.ProtoReflect.Descriptor instead.
 func (*ThreadInfo) Descriptor() ([]byte, []int) {
-	return file_event_proto_rawDescGZIP(), []int{11}
+	return file_event_proto_rawDescGZIP(), []int{12}
 }
 
 func (x *ThreadInfo) GetTid() int32 {
@@ -1222,7 +1324,7 @@ type ThreadSnapshot struct {
 
 func (x *ThreadSnapshot) Reset() {
 	*x = ThreadSnapshot{}
-	mi := &file_event_proto_msgTypes[12]
+	mi := &file_event_proto_msgTypes[13]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1234,7 +1336,7 @@ func (x *ThreadSnapshot) String() string {
 func (*ThreadSnapshot) ProtoMessage() {}
 
 func (x *ThreadSnapshot) ProtoReflect() protoreflect.Message {
-	mi := &file_event_proto_msgTypes[12]
+	mi := &file_event_proto_msgTypes[13]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1247,7 +1349,7 @@ func (x *ThreadSnapshot) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ThreadSnapshot.ProtoReflect.Descriptor instead.
 func (*ThreadSnapshot) Descriptor() ([]byte, []int) {
-	return file_event_proto_rawDescGZIP(), []int{12}
+	return file_event_proto_rawDescGZIP(), []int{13}
 }
 
 func (x *ThreadSnapshot) GetThreads() []*ThreadInfo {
@@ -1267,7 +1369,7 @@ type IoWaitSample struct {
 
 func (x *IoWaitSample) Reset() {
 	*x = IoWaitSample{}
-	mi := &file_event_proto_msgTypes[13]
+	mi := &file_event_proto_msgTypes[14]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1279,7 +1381,7 @@ func (x *IoWaitSample) String() string {
 func (*IoWaitSample) ProtoMessage() {}
 
 func (x *IoWaitSample) ProtoReflect() protoreflect.Message {
-	mi := &file_event_proto_msgTypes[13]
+	mi := &file_event_proto_msgTypes[14]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1292,7 +1394,7 @@ func (x *IoWaitSample) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use IoWaitSample.ProtoReflect.Descriptor instead.
 func (*IoWaitSample) Descriptor() ([]byte, []int) {
-	return file_event_proto_rawDescGZIP(), []int{13}
+	return file_event_proto_rawDescGZIP(), []int{14}
 }
 
 func (x *IoWaitSample) GetPct() float64 {
@@ -1314,7 +1416,7 @@ type IoThroughputSample struct {
 
 func (x *IoThroughputSample) Reset() {
 	*x = IoThroughputSample{}
-	mi := &file_event_proto_msgTypes[14]
+	mi := &file_event_proto_msgTypes[15]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1326,7 +1428,7 @@ func (x *IoThroughputSample) String() string {
 func (*IoThroughputSample) ProtoMessage() {}
 
 func (x *IoThroughputSample) ProtoReflect() protoreflect.Message {
-	mi := &file_event_proto_msgTypes[14]
+	mi := &file_event_proto_msgTypes[15]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1339,7 +1441,7 @@ func (x *IoThroughputSample) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use IoThroughputSample.ProtoReflect.Descriptor instead.
 func (*IoThroughputSample) Descriptor() ([]byte, []int) {
-	return file_event_proto_rawDescGZIP(), []int{14}
+	return file_event_proto_rawDescGZIP(), []int{15}
 }
 
 func (x *IoThroughputSample) GetReadBytesPerS() float64 {
@@ -1385,7 +1487,7 @@ type IoFileStats struct {
 
 func (x *IoFileStats) Reset() {
 	*x = IoFileStats{}
-	mi := &file_event_proto_msgTypes[15]
+	mi := &file_event_proto_msgTypes[16]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1397,7 +1499,7 @@ func (x *IoFileStats) String() string {
 func (*IoFileStats) ProtoMessage() {}
 
 func (x *IoFileStats) ProtoReflect() protoreflect.Message {
-	mi := &file_event_proto_msgTypes[15]
+	mi := &file_event_proto_msgTypes[16]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1410,7 +1512,7 @@ func (x *IoFileStats) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use IoFileStats.ProtoReflect.Descriptor instead.
 func (*IoFileStats) Descriptor() ([]byte, []int) {
-	return file_event_proto_rawDescGZIP(), []int{15}
+	return file_event_proto_rawDescGZIP(), []int{16}
 }
 
 func (x *IoFileStats) GetPath() string {
@@ -1473,7 +1575,7 @@ type LatencyBucket struct {
 
 func (x *LatencyBucket) Reset() {
 	*x = LatencyBucket{}
-	mi := &file_event_proto_msgTypes[16]
+	mi := &file_event_proto_msgTypes[17]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1485,7 +1587,7 @@ func (x *LatencyBucket) String() string {
 func (*LatencyBucket) ProtoMessage() {}
 
 func (x *LatencyBucket) ProtoReflect() protoreflect.Message {
-	mi := &file_event_proto_msgTypes[16]
+	mi := &file_event_proto_msgTypes[17]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1498,7 +1600,7 @@ func (x *LatencyBucket) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LatencyBucket.ProtoReflect.Descriptor instead.
 func (*LatencyBucket) Descriptor() ([]byte, []int) {
-	return file_event_proto_rawDescGZIP(), []int{16}
+	return file_event_proto_rawDescGZIP(), []int{17}
 }
 
 func (x *LatencyBucket) GetLabel() string {
@@ -1539,7 +1641,7 @@ type IoSnapshot struct {
 
 func (x *IoSnapshot) Reset() {
 	*x = IoSnapshot{}
-	mi := &file_event_proto_msgTypes[17]
+	mi := &file_event_proto_msgTypes[18]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1551,7 +1653,7 @@ func (x *IoSnapshot) String() string {
 func (*IoSnapshot) ProtoMessage() {}
 
 func (x *IoSnapshot) ProtoReflect() protoreflect.Message {
-	mi := &file_event_proto_msgTypes[17]
+	mi := &file_event_proto_msgTypes[18]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1564,7 +1666,7 @@ func (x *IoSnapshot) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use IoSnapshot.ProtoReflect.Descriptor instead.
 func (*IoSnapshot) Descriptor() ([]byte, []int) {
-	return file_event_proto_rawDescGZIP(), []int{17}
+	return file_event_proto_rawDescGZIP(), []int{18}
 }
 
 func (x *IoSnapshot) GetReadBytesPerS() float64 {
@@ -1646,7 +1748,7 @@ type FdEntry struct {
 
 func (x *FdEntry) Reset() {
 	*x = FdEntry{}
-	mi := &file_event_proto_msgTypes[18]
+	mi := &file_event_proto_msgTypes[19]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1658,7 +1760,7 @@ func (x *FdEntry) String() string {
 func (*FdEntry) ProtoMessage() {}
 
 func (x *FdEntry) ProtoReflect() protoreflect.Message {
-	mi := &file_event_proto_msgTypes[18]
+	mi := &file_event_proto_msgTypes[19]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1671,7 +1773,7 @@ func (x *FdEntry) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use FdEntry.ProtoReflect.Descriptor instead.
 func (*FdEntry) Descriptor() ([]byte, []int) {
-	return file_event_proto_rawDescGZIP(), []int{18}
+	return file_event_proto_rawDescGZIP(), []int{19}
 }
 
 func (x *FdEntry) GetFd() int32 {
@@ -1732,7 +1834,7 @@ type FdSnapshot struct {
 
 func (x *FdSnapshot) Reset() {
 	*x = FdSnapshot{}
-	mi := &file_event_proto_msgTypes[19]
+	mi := &file_event_proto_msgTypes[20]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1744,7 +1846,7 @@ func (x *FdSnapshot) String() string {
 func (*FdSnapshot) ProtoMessage() {}
 
 func (x *FdSnapshot) ProtoReflect() protoreflect.Message {
-	mi := &file_event_proto_msgTypes[19]
+	mi := &file_event_proto_msgTypes[20]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1757,7 +1859,7 @@ func (x *FdSnapshot) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use FdSnapshot.ProtoReflect.Descriptor instead.
 func (*FdSnapshot) Descriptor() ([]byte, []int) {
-	return file_event_proto_rawDescGZIP(), []int{19}
+	return file_event_proto_rawDescGZIP(), []int{20}
 }
 
 func (x *FdSnapshot) GetFds() []*FdEntry {
@@ -1778,7 +1880,7 @@ type FdEvent struct {
 
 func (x *FdEvent) Reset() {
 	*x = FdEvent{}
-	mi := &file_event_proto_msgTypes[20]
+	mi := &file_event_proto_msgTypes[21]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1790,7 +1892,7 @@ func (x *FdEvent) String() string {
 func (*FdEvent) ProtoMessage() {}
 
 func (x *FdEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_event_proto_msgTypes[20]
+	mi := &file_event_proto_msgTypes[21]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1803,7 +1905,7 @@ func (x *FdEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use FdEvent.ProtoReflect.Descriptor instead.
 func (*FdEvent) Descriptor() ([]byte, []int) {
-	return file_event_proto_rawDescGZIP(), []int{20}
+	return file_event_proto_rawDescGZIP(), []int{21}
 }
 
 func (x *FdEvent) GetMessage() string {
@@ -1829,7 +1931,7 @@ type LockEntry struct {
 
 func (x *LockEntry) Reset() {
 	*x = LockEntry{}
-	mi := &file_event_proto_msgTypes[21]
+	mi := &file_event_proto_msgTypes[22]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1841,7 +1943,7 @@ func (x *LockEntry) String() string {
 func (*LockEntry) ProtoMessage() {}
 
 func (x *LockEntry) ProtoReflect() protoreflect.Message {
-	mi := &file_event_proto_msgTypes[21]
+	mi := &file_event_proto_msgTypes[22]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1854,7 +1956,7 @@ func (x *LockEntry) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LockEntry.ProtoReflect.Descriptor instead.
 func (*LockEntry) Descriptor() ([]byte, []int) {
-	return file_event_proto_rawDescGZIP(), []int{21}
+	return file_event_proto_rawDescGZIP(), []int{22}
 }
 
 func (x *LockEntry) GetUaddr() uint64 {
@@ -1915,7 +2017,7 @@ type LockSnapshot struct {
 
 func (x *LockSnapshot) Reset() {
 	*x = LockSnapshot{}
-	mi := &file_event_proto_msgTypes[22]
+	mi := &file_event_proto_msgTypes[23]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1927,7 +2029,7 @@ func (x *LockSnapshot) String() string {
 func (*LockSnapshot) ProtoMessage() {}
 
 func (x *LockSnapshot) ProtoReflect() protoreflect.Message {
-	mi := &file_event_proto_msgTypes[22]
+	mi := &file_event_proto_msgTypes[23]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1940,7 +2042,7 @@ func (x *LockSnapshot) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LockSnapshot.ProtoReflect.Descriptor instead.
 func (*LockSnapshot) Descriptor() ([]byte, []int) {
-	return file_event_proto_rawDescGZIP(), []int{22}
+	return file_event_proto_rawDescGZIP(), []int{23}
 }
 
 func (x *LockSnapshot) GetLocks() []*LockEntry {
@@ -1961,7 +2063,7 @@ type TimelineEvent struct {
 
 func (x *TimelineEvent) Reset() {
 	*x = TimelineEvent{}
-	mi := &file_event_proto_msgTypes[23]
+	mi := &file_event_proto_msgTypes[24]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1973,7 +2075,7 @@ func (x *TimelineEvent) String() string {
 func (*TimelineEvent) ProtoMessage() {}
 
 func (x *TimelineEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_event_proto_msgTypes[23]
+	mi := &file_event_proto_msgTypes[24]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1986,7 +2088,7 @@ func (x *TimelineEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TimelineEvent.ProtoReflect.Descriptor instead.
 func (*TimelineEvent) Descriptor() ([]byte, []int) {
-	return file_event_proto_rawDescGZIP(), []int{23}
+	return file_event_proto_rawDescGZIP(), []int{24}
 }
 
 func (x *TimelineEvent) GetMessage() string {
@@ -2003,7 +2105,15 @@ const file_event_proto_rawDesc = "" +
 	"\vevent.proto\x12\aptop.v1\"@\n" +
 	"\bStackRef\x12\x19\n" +
 	"\bstack_id\x18\x01 \x01(\x04R\astackId\x12\x19\n" +
-	"\bbuild_id\x18\x02 \x01(\tR\abuildId\"\xe4\x06\n" +
+	"\bbuild_id\x18\x02 \x01(\tR\abuildId\"\x93\x01\n" +
+	"\n" +
+	"StackFrame\x12\x12\n" +
+	"\x04func\x18\x01 \x01(\tR\x04func\x12\x12\n" +
+	"\x04file\x18\x02 \x01(\tR\x04file\x12\x12\n" +
+	"\x04line\x18\x03 \x01(\x05R\x04line\x12\x16\n" +
+	"\x06module\x18\x04 \x01(\tR\x06module\x12\x16\n" +
+	"\x06offset\x18\x05 \x01(\x04R\x06offset\x12\x19\n" +
+	"\bbuild_id\x18\x06 \x01(\tR\abuildId\"\xe4\x06\n" +
 	"\x05Event\x12 \n" +
 	"\fts_unix_nano\x18\x01 \x01(\x03R\n" +
 	"tsUnixNano\x12\x10\n" +
@@ -2064,7 +2174,7 @@ const file_event_proto_rawDesc = "" +
 	"\vlifetime_ms\x18\x04 \x01(\x01R\n" +
 	"lifetimeMs\x12\x1b\n" +
 	"\tcall_site\x18\x05 \x01(\x04R\bcallSite\x12\x14\n" +
-	"\x05large\x18\x06 \x01(\bR\x05large\"\xb8\x02\n" +
+	"\x05large\x18\x06 \x01(\bR\x05large\"\xd3\x02\n" +
 	"\fHeapCallSite\x12\x1b\n" +
 	"\tcall_site\x18\x01 \x01(\x04R\bcallSite\x12\x19\n" +
 	"\baddr_hex\x18\x02 \x01(\tR\aaddrHex\x12\x1d\n" +
@@ -2079,7 +2189,8 @@ const file_event_proto_rawDesc = "" +
 	"\x04line\x18\t \x01(\x05R\x04line\x12\x16\n" +
 	"\x06module\x18\n" +
 	" \x01(\tR\x06module\x12\x16\n" +
-	"\x06offset\x18\v \x01(\x04R\x06offset\"\xc4\x01\n" +
+	"\x06offset\x18\v \x01(\x04R\x06offset\x12\x19\n" +
+	"\bstack_id\x18\f \x01(\x04R\astackId\"\xc4\x01\n" +
 	"\fHeapSnapshot\x12&\n" +
 	"\x0flive_heap_bytes\x18\x01 \x01(\x04R\rliveHeapBytes\x12\x1d\n" +
 	"\n" +
@@ -2181,59 +2292,60 @@ func file_event_proto_rawDescGZIP() []byte {
 }
 
 var file_event_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
-var file_event_proto_msgTypes = make([]protoimpl.MessageInfo, 24)
+var file_event_proto_msgTypes = make([]protoimpl.MessageInfo, 25)
 var file_event_proto_goTypes = []any{
 	(Category)(0),              // 0: ptop.v1.Category
 	(*StackRef)(nil),           // 1: ptop.v1.StackRef
-	(*Event)(nil),              // 2: ptop.v1.Event
-	(*CpuSample)(nil),          // 3: ptop.v1.CpuSample
-	(*SyscallStat)(nil),        // 4: ptop.v1.SyscallStat
-	(*SyscallSnapshot)(nil),    // 5: ptop.v1.SyscallSnapshot
-	(*NetConn)(nil),            // 6: ptop.v1.NetConn
-	(*NetworkSnapshot)(nil),    // 7: ptop.v1.NetworkSnapshot
-	(*MemStats)(nil),           // 8: ptop.v1.MemStats
-	(*HeapEvent)(nil),          // 9: ptop.v1.HeapEvent
-	(*HeapCallSite)(nil),       // 10: ptop.v1.HeapCallSite
-	(*HeapSnapshot)(nil),       // 11: ptop.v1.HeapSnapshot
-	(*ThreadInfo)(nil),         // 12: ptop.v1.ThreadInfo
-	(*ThreadSnapshot)(nil),     // 13: ptop.v1.ThreadSnapshot
-	(*IoWaitSample)(nil),       // 14: ptop.v1.IoWaitSample
-	(*IoThroughputSample)(nil), // 15: ptop.v1.IoThroughputSample
-	(*IoFileStats)(nil),        // 16: ptop.v1.IoFileStats
-	(*LatencyBucket)(nil),      // 17: ptop.v1.LatencyBucket
-	(*IoSnapshot)(nil),         // 18: ptop.v1.IoSnapshot
-	(*FdEntry)(nil),            // 19: ptop.v1.FdEntry
-	(*FdSnapshot)(nil),         // 20: ptop.v1.FdSnapshot
-	(*FdEvent)(nil),            // 21: ptop.v1.FdEvent
-	(*LockEntry)(nil),          // 22: ptop.v1.LockEntry
-	(*LockSnapshot)(nil),       // 23: ptop.v1.LockSnapshot
-	(*TimelineEvent)(nil),      // 24: ptop.v1.TimelineEvent
+	(*StackFrame)(nil),         // 2: ptop.v1.StackFrame
+	(*Event)(nil),              // 3: ptop.v1.Event
+	(*CpuSample)(nil),          // 4: ptop.v1.CpuSample
+	(*SyscallStat)(nil),        // 5: ptop.v1.SyscallStat
+	(*SyscallSnapshot)(nil),    // 6: ptop.v1.SyscallSnapshot
+	(*NetConn)(nil),            // 7: ptop.v1.NetConn
+	(*NetworkSnapshot)(nil),    // 8: ptop.v1.NetworkSnapshot
+	(*MemStats)(nil),           // 9: ptop.v1.MemStats
+	(*HeapEvent)(nil),          // 10: ptop.v1.HeapEvent
+	(*HeapCallSite)(nil),       // 11: ptop.v1.HeapCallSite
+	(*HeapSnapshot)(nil),       // 12: ptop.v1.HeapSnapshot
+	(*ThreadInfo)(nil),         // 13: ptop.v1.ThreadInfo
+	(*ThreadSnapshot)(nil),     // 14: ptop.v1.ThreadSnapshot
+	(*IoWaitSample)(nil),       // 15: ptop.v1.IoWaitSample
+	(*IoThroughputSample)(nil), // 16: ptop.v1.IoThroughputSample
+	(*IoFileStats)(nil),        // 17: ptop.v1.IoFileStats
+	(*LatencyBucket)(nil),      // 18: ptop.v1.LatencyBucket
+	(*IoSnapshot)(nil),         // 19: ptop.v1.IoSnapshot
+	(*FdEntry)(nil),            // 20: ptop.v1.FdEntry
+	(*FdSnapshot)(nil),         // 21: ptop.v1.FdSnapshot
+	(*FdEvent)(nil),            // 22: ptop.v1.FdEvent
+	(*LockEntry)(nil),          // 23: ptop.v1.LockEntry
+	(*LockSnapshot)(nil),       // 24: ptop.v1.LockSnapshot
+	(*TimelineEvent)(nil),      // 25: ptop.v1.TimelineEvent
 }
 var file_event_proto_depIdxs = []int32{
 	0,  // 0: ptop.v1.Event.category:type_name -> ptop.v1.Category
 	1,  // 1: ptop.v1.Event.stack:type_name -> ptop.v1.StackRef
-	3,  // 2: ptop.v1.Event.cpu:type_name -> ptop.v1.CpuSample
-	5,  // 3: ptop.v1.Event.syscalls:type_name -> ptop.v1.SyscallSnapshot
-	7,  // 4: ptop.v1.Event.network:type_name -> ptop.v1.NetworkSnapshot
-	8,  // 5: ptop.v1.Event.memory:type_name -> ptop.v1.MemStats
-	13, // 6: ptop.v1.Event.threads:type_name -> ptop.v1.ThreadSnapshot
-	14, // 7: ptop.v1.Event.io_wait:type_name -> ptop.v1.IoWaitSample
-	15, // 8: ptop.v1.Event.io_throughput:type_name -> ptop.v1.IoThroughputSample
-	18, // 9: ptop.v1.Event.io:type_name -> ptop.v1.IoSnapshot
-	20, // 10: ptop.v1.Event.fds:type_name -> ptop.v1.FdSnapshot
-	21, // 11: ptop.v1.Event.fd_event:type_name -> ptop.v1.FdEvent
-	23, // 12: ptop.v1.Event.locks:type_name -> ptop.v1.LockSnapshot
-	24, // 13: ptop.v1.Event.timeline:type_name -> ptop.v1.TimelineEvent
-	11, // 14: ptop.v1.Event.heap:type_name -> ptop.v1.HeapSnapshot
-	9,  // 15: ptop.v1.Event.heap_event:type_name -> ptop.v1.HeapEvent
-	4,  // 16: ptop.v1.SyscallSnapshot.stats:type_name -> ptop.v1.SyscallStat
-	6,  // 17: ptop.v1.NetworkSnapshot.conns:type_name -> ptop.v1.NetConn
-	10, // 18: ptop.v1.HeapSnapshot.top_call_sites:type_name -> ptop.v1.HeapCallSite
-	12, // 19: ptop.v1.ThreadSnapshot.threads:type_name -> ptop.v1.ThreadInfo
-	16, // 20: ptop.v1.IoSnapshot.top_files:type_name -> ptop.v1.IoFileStats
-	17, // 21: ptop.v1.IoSnapshot.latency_buckets:type_name -> ptop.v1.LatencyBucket
-	19, // 22: ptop.v1.FdSnapshot.fds:type_name -> ptop.v1.FdEntry
-	22, // 23: ptop.v1.LockSnapshot.locks:type_name -> ptop.v1.LockEntry
+	4,  // 2: ptop.v1.Event.cpu:type_name -> ptop.v1.CpuSample
+	6,  // 3: ptop.v1.Event.syscalls:type_name -> ptop.v1.SyscallSnapshot
+	8,  // 4: ptop.v1.Event.network:type_name -> ptop.v1.NetworkSnapshot
+	9,  // 5: ptop.v1.Event.memory:type_name -> ptop.v1.MemStats
+	14, // 6: ptop.v1.Event.threads:type_name -> ptop.v1.ThreadSnapshot
+	15, // 7: ptop.v1.Event.io_wait:type_name -> ptop.v1.IoWaitSample
+	16, // 8: ptop.v1.Event.io_throughput:type_name -> ptop.v1.IoThroughputSample
+	19, // 9: ptop.v1.Event.io:type_name -> ptop.v1.IoSnapshot
+	21, // 10: ptop.v1.Event.fds:type_name -> ptop.v1.FdSnapshot
+	22, // 11: ptop.v1.Event.fd_event:type_name -> ptop.v1.FdEvent
+	24, // 12: ptop.v1.Event.locks:type_name -> ptop.v1.LockSnapshot
+	25, // 13: ptop.v1.Event.timeline:type_name -> ptop.v1.TimelineEvent
+	12, // 14: ptop.v1.Event.heap:type_name -> ptop.v1.HeapSnapshot
+	10, // 15: ptop.v1.Event.heap_event:type_name -> ptop.v1.HeapEvent
+	5,  // 16: ptop.v1.SyscallSnapshot.stats:type_name -> ptop.v1.SyscallStat
+	7,  // 17: ptop.v1.NetworkSnapshot.conns:type_name -> ptop.v1.NetConn
+	11, // 18: ptop.v1.HeapSnapshot.top_call_sites:type_name -> ptop.v1.HeapCallSite
+	13, // 19: ptop.v1.ThreadSnapshot.threads:type_name -> ptop.v1.ThreadInfo
+	17, // 20: ptop.v1.IoSnapshot.top_files:type_name -> ptop.v1.IoFileStats
+	18, // 21: ptop.v1.IoSnapshot.latency_buckets:type_name -> ptop.v1.LatencyBucket
+	20, // 22: ptop.v1.FdSnapshot.fds:type_name -> ptop.v1.FdEntry
+	23, // 23: ptop.v1.LockSnapshot.locks:type_name -> ptop.v1.LockEntry
 	24, // [24:24] is the sub-list for method output_type
 	24, // [24:24] is the sub-list for method input_type
 	24, // [24:24] is the sub-list for extension type_name
@@ -2246,7 +2358,7 @@ func file_event_proto_init() {
 	if File_event_proto != nil {
 		return
 	}
-	file_event_proto_msgTypes[1].OneofWrappers = []any{
+	file_event_proto_msgTypes[2].OneofWrappers = []any{
 		(*Event_Cpu)(nil),
 		(*Event_Syscalls)(nil),
 		(*Event_Network)(nil),
@@ -2268,7 +2380,7 @@ func file_event_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_event_proto_rawDesc), len(file_event_proto_rawDesc)),
 			NumEnums:      1,
-			NumMessages:   24,
+			NumMessages:   25,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/pkg/streampb/service.pb.go
+++ b/pkg/streampb/service.pb.go
@@ -200,6 +200,108 @@ func (*SubscribeResponse_Event) isSubscribeResponse_Kind() {}
 
 func (*SubscribeResponse_Meta) isSubscribeResponse_Kind() {}
 
+// ResolveStackRequest asks the server to symbolize a stack id referenced by an
+// event (Event.stack.stack_id or HeapCallSite.stack_id). The id is only valid
+// for the build identified by the accompanying StackRef.build_id.
+type ResolveStackRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	StackId       uint64                 `protobuf:"varint,1,opt,name=stack_id,json=stackId,proto3" json:"stack_id,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ResolveStackRequest) Reset() {
+	*x = ResolveStackRequest{}
+	mi := &file_service_proto_msgTypes[3]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ResolveStackRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ResolveStackRequest) ProtoMessage() {}
+
+func (x *ResolveStackRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_service_proto_msgTypes[3]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ResolveStackRequest.ProtoReflect.Descriptor instead.
+func (*ResolveStackRequest) Descriptor() ([]byte, []int) {
+	return file_service_proto_rawDescGZIP(), []int{3}
+}
+
+func (x *ResolveStackRequest) GetStackId() uint64 {
+	if x != nil {
+		return x.StackId
+	}
+	return 0
+}
+
+// ResolveStackResponse returns the leaf-first symbolized frames for the stack
+// id. found is false when the id is unknown — evicted from the kernel stack
+// map, never captured, or symbolization is unavailable on the server.
+type ResolveStackResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Frames        []*StackFrame          `protobuf:"bytes,1,rep,name=frames,proto3" json:"frames,omitempty"`
+	Found         bool                   `protobuf:"varint,2,opt,name=found,proto3" json:"found,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ResolveStackResponse) Reset() {
+	*x = ResolveStackResponse{}
+	mi := &file_service_proto_msgTypes[4]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ResolveStackResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ResolveStackResponse) ProtoMessage() {}
+
+func (x *ResolveStackResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_service_proto_msgTypes[4]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ResolveStackResponse.ProtoReflect.Descriptor instead.
+func (*ResolveStackResponse) Descriptor() ([]byte, []int) {
+	return file_service_proto_rawDescGZIP(), []int{4}
+}
+
+func (x *ResolveStackResponse) GetFrames() []*StackFrame {
+	if x != nil {
+		return x.Frames
+	}
+	return nil
+}
+
+func (x *ResolveStackResponse) GetFound() bool {
+	if x != nil {
+		return x.Found
+	}
+	return false
+}
+
 var File_service_proto protoreflect.FileDescriptor
 
 const file_service_proto_rawDesc = "" +
@@ -215,9 +317,15 @@ const file_service_proto_rawDesc = "" +
 	"\x11SubscribeResponse\x12&\n" +
 	"\x05event\x18\x01 \x01(\v2\x0e.ptop.v1.EventH\x00R\x05event\x12)\n" +
 	"\x04meta\x18\x02 \x01(\v2\x13.ptop.v1.StreamMetaH\x00R\x04metaB\x06\n" +
-	"\x04kind2Z\n" +
+	"\x04kind\"0\n" +
+	"\x13ResolveStackRequest\x12\x19\n" +
+	"\bstack_id\x18\x01 \x01(\x04R\astackId\"Y\n" +
+	"\x14ResolveStackResponse\x12+\n" +
+	"\x06frames\x18\x01 \x03(\v2\x13.ptop.v1.StackFrameR\x06frames\x12\x14\n" +
+	"\x05found\x18\x02 \x01(\bR\x05found2\xa7\x01\n" +
 	"\x12EventStreamService\x12D\n" +
-	"\tSubscribe\x12\x19.ptop.v1.SubscribeRequest\x1a\x1a.ptop.v1.SubscribeResponse0\x01B\x87\x01\n" +
+	"\tSubscribe\x12\x19.ptop.v1.SubscribeRequest\x1a\x1a.ptop.v1.SubscribeResponse0\x01\x12K\n" +
+	"\fResolveStack\x12\x1c.ptop.v1.ResolveStackRequest\x1a\x1d.ptop.v1.ResolveStackResponseB\x87\x01\n" +
 	"\vcom.ptop.v1B\fServiceProtoP\x01Z-github.com/trentas/ptop/pkg/streampb;streampb\xa2\x02\x03PXX\xaa\x02\aPtop.V1\xca\x02\aPtop\\V1\xe2\x02\x13Ptop\\V1\\GPBMetadata\xea\x02\bPtop::V1b\x06proto3"
 
 var (
@@ -232,25 +340,31 @@ func file_service_proto_rawDescGZIP() []byte {
 	return file_service_proto_rawDescData
 }
 
-var file_service_proto_msgTypes = make([]protoimpl.MessageInfo, 3)
+var file_service_proto_msgTypes = make([]protoimpl.MessageInfo, 5)
 var file_service_proto_goTypes = []any{
-	(*SubscribeRequest)(nil),  // 0: ptop.v1.SubscribeRequest
-	(*StreamMeta)(nil),        // 1: ptop.v1.StreamMeta
-	(*SubscribeResponse)(nil), // 2: ptop.v1.SubscribeResponse
-	(Category)(0),             // 3: ptop.v1.Category
-	(*Event)(nil),             // 4: ptop.v1.Event
+	(*SubscribeRequest)(nil),     // 0: ptop.v1.SubscribeRequest
+	(*StreamMeta)(nil),           // 1: ptop.v1.StreamMeta
+	(*SubscribeResponse)(nil),    // 2: ptop.v1.SubscribeResponse
+	(*ResolveStackRequest)(nil),  // 3: ptop.v1.ResolveStackRequest
+	(*ResolveStackResponse)(nil), // 4: ptop.v1.ResolveStackResponse
+	(Category)(0),                // 5: ptop.v1.Category
+	(*Event)(nil),                // 6: ptop.v1.Event
+	(*StackFrame)(nil),           // 7: ptop.v1.StackFrame
 }
 var file_service_proto_depIdxs = []int32{
-	3, // 0: ptop.v1.SubscribeRequest.categories:type_name -> ptop.v1.Category
-	4, // 1: ptop.v1.SubscribeResponse.event:type_name -> ptop.v1.Event
+	5, // 0: ptop.v1.SubscribeRequest.categories:type_name -> ptop.v1.Category
+	6, // 1: ptop.v1.SubscribeResponse.event:type_name -> ptop.v1.Event
 	1, // 2: ptop.v1.SubscribeResponse.meta:type_name -> ptop.v1.StreamMeta
-	0, // 3: ptop.v1.EventStreamService.Subscribe:input_type -> ptop.v1.SubscribeRequest
-	2, // 4: ptop.v1.EventStreamService.Subscribe:output_type -> ptop.v1.SubscribeResponse
-	4, // [4:5] is the sub-list for method output_type
-	3, // [3:4] is the sub-list for method input_type
-	3, // [3:3] is the sub-list for extension type_name
-	3, // [3:3] is the sub-list for extension extendee
-	0, // [0:3] is the sub-list for field type_name
+	7, // 3: ptop.v1.ResolveStackResponse.frames:type_name -> ptop.v1.StackFrame
+	0, // 4: ptop.v1.EventStreamService.Subscribe:input_type -> ptop.v1.SubscribeRequest
+	3, // 5: ptop.v1.EventStreamService.ResolveStack:input_type -> ptop.v1.ResolveStackRequest
+	2, // 6: ptop.v1.EventStreamService.Subscribe:output_type -> ptop.v1.SubscribeResponse
+	4, // 7: ptop.v1.EventStreamService.ResolveStack:output_type -> ptop.v1.ResolveStackResponse
+	6, // [6:8] is the sub-list for method output_type
+	4, // [4:6] is the sub-list for method input_type
+	4, // [4:4] is the sub-list for extension type_name
+	4, // [4:4] is the sub-list for extension extendee
+	0, // [0:4] is the sub-list for field type_name
 }
 
 func init() { file_service_proto_init() }
@@ -269,7 +383,7 @@ func file_service_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_service_proto_rawDesc), len(file_service_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   3,
+			NumMessages:   5,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/pkg/streampb/service_grpc.pb.go
+++ b/pkg/streampb/service_grpc.pb.go
@@ -19,7 +19,8 @@ import (
 const _ = grpc.SupportPackageIsVersion9
 
 const (
-	EventStreamService_Subscribe_FullMethodName = "/ptop.v1.EventStreamService/Subscribe"
+	EventStreamService_Subscribe_FullMethodName    = "/ptop.v1.EventStreamService/Subscribe"
+	EventStreamService_ResolveStack_FullMethodName = "/ptop.v1.EventStreamService/ResolveStack"
 )
 
 // EventStreamServiceClient is the client API for EventStreamService service.
@@ -32,6 +33,10 @@ type EventStreamServiceClient interface {
 	// Subscribe streams collector events for the server's target PID until the
 	// client disconnects. Multiple subscribers fan out from one collector.
 	Subscribe(ctx context.Context, in *SubscribeRequest, opts ...grpc.CallOption) (grpc.ServerStreamingClient[SubscribeResponse], error)
+	// ResolveStack symbolizes a stack id seen on the stream into its leaf-first
+	// frames — an out-of-band lookup so high-rate events stay small (they carry
+	// only the id). Resolution is best-effort; see ResolveStackResponse.found.
+	ResolveStack(ctx context.Context, in *ResolveStackRequest, opts ...grpc.CallOption) (*ResolveStackResponse, error)
 }
 
 type eventStreamServiceClient struct {
@@ -61,6 +66,16 @@ func (c *eventStreamServiceClient) Subscribe(ctx context.Context, in *SubscribeR
 // This type alias is provided for backwards compatibility with existing code that references the prior non-generic stream type by name.
 type EventStreamService_SubscribeClient = grpc.ServerStreamingClient[SubscribeResponse]
 
+func (c *eventStreamServiceClient) ResolveStack(ctx context.Context, in *ResolveStackRequest, opts ...grpc.CallOption) (*ResolveStackResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(ResolveStackResponse)
+	err := c.cc.Invoke(ctx, EventStreamService_ResolveStack_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // EventStreamServiceServer is the server API for EventStreamService service.
 // All implementations must embed UnimplementedEventStreamServiceServer
 // for forward compatibility.
@@ -71,6 +86,10 @@ type EventStreamServiceServer interface {
 	// Subscribe streams collector events for the server's target PID until the
 	// client disconnects. Multiple subscribers fan out from one collector.
 	Subscribe(*SubscribeRequest, grpc.ServerStreamingServer[SubscribeResponse]) error
+	// ResolveStack symbolizes a stack id seen on the stream into its leaf-first
+	// frames — an out-of-band lookup so high-rate events stay small (they carry
+	// only the id). Resolution is best-effort; see ResolveStackResponse.found.
+	ResolveStack(context.Context, *ResolveStackRequest) (*ResolveStackResponse, error)
 	mustEmbedUnimplementedEventStreamServiceServer()
 }
 
@@ -83,6 +102,9 @@ type UnimplementedEventStreamServiceServer struct{}
 
 func (UnimplementedEventStreamServiceServer) Subscribe(*SubscribeRequest, grpc.ServerStreamingServer[SubscribeResponse]) error {
 	return status.Errorf(codes.Unimplemented, "method Subscribe not implemented")
+}
+func (UnimplementedEventStreamServiceServer) ResolveStack(context.Context, *ResolveStackRequest) (*ResolveStackResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method ResolveStack not implemented")
 }
 func (UnimplementedEventStreamServiceServer) mustEmbedUnimplementedEventStreamServiceServer() {}
 func (UnimplementedEventStreamServiceServer) testEmbeddedByValue()                            {}
@@ -116,13 +138,36 @@ func _EventStreamService_Subscribe_Handler(srv interface{}, stream grpc.ServerSt
 // This type alias is provided for backwards compatibility with existing code that references the prior non-generic stream type by name.
 type EventStreamService_SubscribeServer = grpc.ServerStreamingServer[SubscribeResponse]
 
+func _EventStreamService_ResolveStack_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(ResolveStackRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(EventStreamServiceServer).ResolveStack(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: EventStreamService_ResolveStack_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(EventStreamServiceServer).ResolveStack(ctx, req.(*ResolveStackRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 // EventStreamService_ServiceDesc is the grpc.ServiceDesc for EventStreamService service.
 // It's only intended for direct use with grpc.RegisterService,
 // and not to be introspected or modified (even as a copy)
 var EventStreamService_ServiceDesc = grpc.ServiceDesc{
 	ServiceName: "ptop.v1.EventStreamService",
 	HandlerType: (*EventStreamServiceServer)(nil),
-	Methods:     []grpc.MethodDesc{},
+	Methods: []grpc.MethodDesc{
+		{
+			MethodName: "ResolveStack",
+			Handler:    _EventStreamService_ResolveStack_Handler,
+		},
+	},
 	Streams: []grpc.StreamDesc{
 		{
 			StreamName:    "Subscribe",

--- a/pkg/symbol/proc_linux.go
+++ b/pkg/symbol/proc_linux.go
@@ -28,6 +28,9 @@ type Symbolizer struct {
 
 	mu   sync.Mutex
 	mods map[string]*Module // by resolved path; nil value = open failed
+
+	buildOnce   sync.Once
+	execBuildID string
 }
 
 // NewSymbolizer snapshots pid's executable mappings. The set of mapped modules
@@ -60,6 +63,26 @@ func (s *Symbolizer) Symbolize(addr uint64) Frame {
 }
 
 func (s *Symbolizer) Close() error { return nil }
+
+// ProcessBuildID returns the GNU build-id (hex) of the target's main
+// executable, or "" if it has none / can't be read. It is a stable per-process
+// key for the stack ids this symbolizer's process hands out: the same stack id
+// denotes a different stack once the binary changes. Computed once, lazily.
+func (s *Symbolizer) ProcessBuildID() string {
+	s.buildOnce.Do(func() {
+		// /proc/<pid>/exe is a magic symlink the kernel resolves to the running
+		// image — readable even when the on-disk path is gone (deleted/overlay).
+		f, err := os.Open(fmt.Sprintf("/proc/%d/exe", s.pid))
+		if err != nil {
+			return
+		}
+		defer f.Close()
+		if m, err := OpenModule(f, "exe"); err == nil {
+			s.execBuildID = m.buildID
+		}
+	})
+	return s.execBuildID
+}
 
 func (s *Symbolizer) segFor(addr uint64) (segment, bool) {
 	for _, sg := range s.segs {

--- a/pkg/symbol/proc_other.go
+++ b/pkg/symbol/proc_other.go
@@ -14,3 +14,4 @@ func NewSymbolizer(int) (*Symbolizer, error) {
 
 func (*Symbolizer) Symbolize(uint64) Frame { return Frame{} }
 func (*Symbolizer) Close() error           { return nil }
+func (*Symbolizer) ProcessBuildID() string { return "" }

--- a/proto/event.proto
+++ b/proto/event.proto
@@ -20,11 +20,27 @@ enum Category {
 }
 
 // StackRef references a stack captured at event time and resolved out-of-band
-// (#54 — stack symbolization). It stays empty until that lands; consumers
-// fetch frames via a side-channel keyed by stack_id (+ build_id for caching).
+// (#54 — stack symbolization). stack_id is the kernel stack-map id; build_id is
+// the target executable's GNU build-id, a stable per-process cache key (the
+// same stack_id means a different stack once the binary changes). Consumers
+// fetch the frames via EventStreamService.ResolveStack.
 message StackRef {
   uint64 stack_id = 1;
   string build_id = 2;
+}
+
+// StackFrame is one symbolized frame of a captured stack (#54), leaf-first.
+// func is "" when the address couldn't be resolved to a function (stripped
+// non-Go module — module+offset still locate it); file/line are populated only
+// for Go modules in this cut (C/C++ file:line needs DWARF). offset is
+// module-relative, so it is comparable across runs/ASLR.
+message StackFrame {
+  string func = 1;
+  string file = 2;
+  int32 line = 3;
+  string module = 4;
+  uint64 offset = 5;
+  string build_id = 6;
 }
 
 // Event is the single unified message on the stream. The envelope carries the
@@ -136,6 +152,10 @@ message HeapCallSite {
   int32 line = 9; // source line (0 if unknown)
   string module = 10; // backing module basename ("" if unresolved)
   uint64 offset = 11; // module-relative offset of the call site
+  // Kernel stack-map id of the alloc site, for EventStreamService.ResolveStack
+  // (the full leaf-first stack). A sentinel (resolves to not-found) when the
+  // stack walk failed.
+  uint64 stack_id = 12;
 }
 
 // HeapSnapshot is the periodic heap aggregate. live_heap_bytes and

--- a/proto/service.proto
+++ b/proto/service.proto
@@ -30,10 +30,30 @@ message SubscribeResponse {
   }
 }
 
+// ResolveStackRequest asks the server to symbolize a stack id referenced by an
+// event (Event.stack.stack_id or HeapCallSite.stack_id). The id is only valid
+// for the build identified by the accompanying StackRef.build_id.
+message ResolveStackRequest {
+  uint64 stack_id = 1;
+}
+
+// ResolveStackResponse returns the leaf-first symbolized frames for the stack
+// id. found is false when the id is unknown — evicted from the kernel stack
+// map, never captured, or symbolization is unavailable on the server.
+message ResolveStackResponse {
+  repeated StackFrame frames = 1;
+  bool found = 2;
+}
+
 // EventStreamService is ptop's headless collection surface. ptop runs with the
 // elevated capabilities (CAP_BPF/CAP_PERFMON); subscribers connect with none.
 service EventStreamService {
   // Subscribe streams collector events for the server's target PID until the
   // client disconnects. Multiple subscribers fan out from one collector.
   rpc Subscribe(SubscribeRequest) returns (stream SubscribeResponse);
+
+  // ResolveStack symbolizes a stack id seen on the stream into its leaf-first
+  // frames — an out-of-band lookup so high-rate events stay small (they carry
+  // only the id). Resolution is best-effort; see ResolveStackResponse.found.
+  rpc ResolveStack(ResolveStackRequest) returns (ResolveStackResponse);
 }


### PR DESCRIPTION
## What

PR3 of #54 — closes the symbolization loop on the headless gRPC surface. Heap events now **reference a captured stack** (`StackRef{stack_id, build_id}`), resolvable out-of-band into full leaf-first frames via a new **`ResolveStack` RPC**. Off a fresh `main` (no PR stacking).

Builds on #75 (`pkg/symbol` core) and #76 (call-site symbolization in the F1 panel).

## Stream side (proto, additive → buf-breaking safe)

- `Event.stack = StackRef{stack_id, build_id}` on heap events. High-rate events stay small — they carry an id, not the frames.
- `HeapSnapshot.HeapCallSite` gains `stack_id` so a **top leak site** is resolvable too (not just per-event allocs).
- `rpc ResolveStack(stack_id) → {repeated StackFrame, found}`: best-effort. `found=false` for an unknown/evicted id or a server built without symbolization — never an error.
- A failed kernel stack walk (negative sentinel) omits the ref / reports `stack_id 0` rather than handing out a dead id.

## Data path (the non-trivial part)

The Hub only sees mapped `Event`s — it has no handle to the tracer/symbolizer. So:

- **`serve.StackResolver{ProcessBuildID, ResolveStack}`** — implemented by the eBPF heap collector, which owns the stack tracer + `symbol.Symbolizer`. Plumbed through `serve.Run` → `NewHub` (build-id stamp) + `eventStreamService` (the RPC). **Nil-safe end to end**: no resolver → no stack refs and `ResolveStack` reports not-found.
- `HeapEBPFCollector.ResolveStack` symbolizes the full leaf-first stack, cached by `stack_id` (mutex-shared with `readLoop`/`publishLoop`); `ProcessBuildID` reads the target's GNU build-id via `/proc/<pid>/exe` — a stable per-process cache key (the same `stack_id` denotes a different stack once the binary changes).

## Tests

- `ResolveStack` RPC: known id (frames mapped 1:1), unknown id, nil resolver.
- Negative-sentinel mapping (no `StackRef`, `stack_id 0`).
- Resolver zero-value contract (no tracer → graceful not-found, no panic) — holds on both lanes.
- Updated `toEvent`/`NewHub`/`Run` signatures across existing tests.
- `go vet`/`build`/`test` green (default + `-tags=ebpf` stub lane) and `GOOS=linux` cross-build/vet. The real `linux && ebpf` heap lane is CI-validated.

## Scope

`file:line` is Go-only (PR2 cut). **#54 fully lands with this PR.** Deferred follow-ups remain: kernel stacks (`/proc/kallsyms`), C/C++ DWARF line info, C++ demangling, inlined frames.

🤖 Generated with [Claude Code](https://claude.com/claude-code)