### PR TITLE
network: capture RST/retransmit errors on the event stream (#56)

### DIFF
--- a/internal/bpf/network.go
+++ b/internal/bpf/network.go
@@ -5,12 +5,16 @@ package bpf
 import (
 	"bytes"
 	_ "embed"
+	"encoding/binary"
 	"errors"
 	"fmt"
+	"io"
 	"net"
+	"os"
 
 	"github.com/cilium/ebpf"
 	"github.com/cilium/ebpf/link"
+	"github.com/cilium/ebpf/ringbuf"
 	"github.com/cilium/ebpf/rlimit"
 )
 
@@ -39,7 +43,26 @@ type NetConnVal struct {
 	TxBytes       uint64
 	RxBytes       uint64
 	State         uint32
-	_             uint32 // pad
+	Retransmits   uint32 // #56 — running tcp_retransmit_skb count
+}
+
+// Net error kinds — must match NET_ERR_* in programs/network.bpf.c.
+const (
+	NetErrRefused    uint32 = 0
+	NetErrReset      uint32 = 1
+	NetErrRetransmit uint32 = 2
+)
+
+// NetErrorRecord is the 1:1 layout of struct net_error_event in
+// programs/network.bpf.c. Fixed size 64 bytes; binary.LittleEndian parses it
+// directly from the ring buffer. Key is the connection 5-tuple (network-order
+// addrs, host-order ports), decoded the same way as net_conn_map keys.
+type NetErrorRecord struct {
+	TsNs        uint64
+	Key         NetConnKey // 40 bytes
+	Kind        uint32
+	Retransmits uint32
+	DetailNs    uint64
 }
 
 // NetSnapshot is the user-friendly format returned by Stats() — the 5-tuple
@@ -64,6 +87,7 @@ type NetTracer struct {
 	coll  *ebpf.Collection
 	links []link.Link
 	cmap  *ebpf.Map
+	rb    *ringbuf.Reader // #56 — net_error_events channel
 }
 
 func OpenNetTracer(pid int) (*NetTracer, error) {
@@ -139,7 +163,67 @@ func OpenNetTracer(pid int) (*NetTracer, error) {
 		t.links = append(t.links, l)
 	}
 
+	// Net error probes (#56). Non-fatal — unlike the byte kprobes above, a
+	// kernel without these symbols (renamed, or CONFIG_KPROBES off) simply
+	// yields no net-error events; connection tracking is unaffected, so we log
+	// and continue rather than failing the whole tracer.
+	errKprobes := []struct{ sym, prog string }{
+		{"tcp_reset", "handle_tcp_reset"},
+		{"tcp_retransmit_skb", "handle_tcp_retransmit"},
+	}
+	for _, kp := range errKprobes {
+		p := coll.Programs[kp.prog]
+		if p == nil {
+			fmt.Fprintf(os.Stderr, "network: program %s missing; net errors degraded\n", kp.prog)
+			continue
+		}
+		l, err := link.Kprobe(kp.sym, p, nil)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "network: attach kprobe %s failed (%v); net errors degraded\n", kp.sym, err)
+			continue
+		}
+		t.links = append(t.links, l)
+	}
+
+	// Open the net-error ring buffer. This map is part of our own program, so
+	// a miss here means a corrupt object — fatal, matching io.go/heap.go.
+	errMap := coll.Maps["net_error_events"]
+	if errMap == nil {
+		t.Close()
+		return nil, errors.New("net_error_events ringbuf missing")
+	}
+	rb, err := ringbuf.NewReader(errMap)
+	if err != nil {
+		t.Close()
+		return nil, fmt.Errorf("net error ringbuf reader: %w", err)
+	}
+	t.rb = rb
+
 	return t, nil
+}
+
+// NextError blocks until the next net-error event arrives from the kernel.
+// Returns io.EOF once the tracer is closed. A short/garbled record is reported
+// as an error but does not close the stream — the caller keeps reading.
+func (t *NetTracer) NextError() (NetErrorRecord, error) {
+	var rec NetErrorRecord
+	if t == nil || t.rb == nil {
+		return rec, errors.New("tracer not initialized")
+	}
+	r, err := t.rb.Read()
+	if err != nil {
+		if errors.Is(err, ringbuf.ErrClosed) {
+			return rec, io.EOF
+		}
+		return rec, err
+	}
+	if len(r.RawSample) < 64 {
+		return rec, fmt.Errorf("short net error event: %d bytes", len(r.RawSample))
+	}
+	if err := binary.Read(bytes.NewReader(r.RawSample), binary.LittleEndian, &rec); err != nil {
+		return rec, fmt.Errorf("decode net error: %w", err)
+	}
+	return rec, nil
 }
 
 // SeedConnection inserts an entry into net_conn_map for a 5-tuple that was
@@ -210,6 +294,11 @@ func ipFromKey(b [16]byte, family uint16) net.IP {
 func (t *NetTracer) Close() error {
 	if t == nil {
 		return nil
+	}
+	// Close the reader first so a blocked NextError unblocks with io.EOF.
+	if t.rb != nil {
+		_ = t.rb.Close()
+		t.rb = nil
 	}
 	for _, l := range t.links {
 		_ = l.Close()

--- a/internal/bpf/programs/network.bpf.c
+++ b/internal/bpf/programs/network.bpf.c
@@ -5,6 +5,8 @@
 //   1. tracepoint sock:inet_sock_set_state → discovers 5-tuple + state
 //   2. kprobe   tcp_sendmsg                → Tx bytes
 //   3. kprobe   tcp_cleanup_rbuf           → Rx bytes
+//   4. kprobe   tcp_reset                  → connection refused / reset (#56)
+//   5. kprobe   tcp_retransmit_skb         → retransmit / timeout backoff (#56)
 //
 // Trick to avoid dereferencing `struct sock` (which would require vmlinux.h
 // or fragile manual offsets): the inet_sock_set_state tracepoint already
@@ -16,13 +18,28 @@
 // of the sock.
 //
 // Maps:
-//   net_target_pid   ARRAY[1]  struct target_filter (written by the Go loader)
-//   net_conn_map     HASH      net_key → net_val (state, RTT, tx/rx bytes)
-//   sock_to_key      HASH      sock_ptr → net_key (correlation)
+//   net_target_pid    ARRAY[1]  struct target_filter (written by the Go loader)
+//   net_conn_map      HASH      net_key → net_val (state, RTT, tx/rx, retransmits)
+//   sock_to_key       HASH      sock_ptr → net_key (correlation)
+//   net_error_events  RINGBUF   per-event channel → user-space (#56 net errors)
+//
+// Net errors (#56): tcp_reset fires on an incoming RST — we classify it as
+// "refused" (RST while we still track the conn as SYN_SENT) vs "reset"
+// (RST on an ESTABLISHED conn) from the state we already hold in net_conn_map.
+// tcp_retransmit_skb fires per retransmit, carrying the conn's running count
+// (backoff is visible as the count grows).
+//
+// Target filtering on these two probes is DIFFERENT from the byte kprobes:
+// RST handling and the retransmit timer run in softirq/timer context, where
+// the "current task" is whoever was interrupted — almost never our target, so
+// pid_is_target() would drop nearly every event. Instead these probes rely
+// purely on sock_to_key membership: that map is only ever populated under
+// pid_is_target() (in the process-context connect/accept path of
+// inet_sock_set_state), so a hit there already means "the target's socket".
 //
 // Limitations:
 //   - Pre-existing connections (opened before ptop attached) don't enter
-//     sock_to_key, so tx/rx stay 0 for them. New connections work.
+//     sock_to_key, so tx/rx and net errors stay absent for them. New ones work.
 //   - the pid filter resolves the *current* task; in softirq that is the
 //     interrupted task, so it may skip or misattribute on the softirq path.
 //     tcp_sendmsg/cleanup_rbuf run in process context, so OK.
@@ -82,7 +99,23 @@ struct net_val {
     __u64 tx_bytes;
     __u64 rx_bytes;
     __u32 state;
-    __u32 _pad;
+    __u32 retransmits; // #56 — running tcp_retransmit_skb count for this conn
+};
+
+// Net error kinds — must match netErrKind* in internal/bpf/network.go.
+#define NET_ERR_REFUSED    0 // RST received while the conn was still SYN_SENT
+#define NET_ERR_RESET      1 // RST received on an ESTABLISHED conn
+#define NET_ERR_RETRANSMIT 2 // tcp_retransmit_skb fired
+
+// net_error_event is published to user-space via the net_error_events ring
+// buffer. Fixed layout (64 bytes), read with binary.LittleEndian on the Go
+// side — keep in sync with NetErrorRecord in internal/bpf/network.go.
+struct net_error_event {
+    __u64 ts_ns;
+    struct net_key key;   // 5-tuple, to correlate with a connection (40 bytes)
+    __u32 kind;           // NET_ERR_*
+    __u32 retransmits;    // running retransmit count (RETRANSMIT kind)
+    __u64 detail_ns;      // latency-to-RST (refused/reset); 0 otherwise
 };
 
 struct {
@@ -107,6 +140,11 @@ struct {
     __type(value, struct net_key);
     __uint(max_entries, 4096);
 } sock_to_key SEC(".maps");
+
+struct {
+    __uint(type, BPF_MAP_TYPE_RINGBUF);
+    __uint(max_entries, 1 << 18); // 256KB — net errors are low-rate
+} net_error_events SEC(".maps");
 
 static __always_inline int is_net_target(void)
 {
@@ -214,5 +252,79 @@ int BPF_KPROBE(handle_tcp_cleanup_rbuf, void *sk, int copied)
     if (copied <= 0)
         return 0;
     add_bytes((__u64)(unsigned long)sk, (__u64)copied, 0);
+    return 0;
+}
+
+// emit_net_error reserves a ring-buffer slot and publishes one error event.
+// kp points at a stack copy of the 5-tuple (never into map memory).
+static __always_inline void emit_net_error(struct net_key *kp, __u32 kind,
+                                           __u32 retransmits, __u64 detail_ns)
+{
+    struct net_error_event *e = bpf_ringbuf_reserve(&net_error_events, sizeof(*e), 0);
+    if (!e)
+        return;
+    e->ts_ns       = bpf_ktime_get_ns();
+    e->key         = *kp;
+    e->kind        = kind;
+    e->retransmits = retransmits;
+    e->detail_ns   = detail_ns;
+    bpf_ringbuf_submit(e, 0);
+}
+
+// tcp_reset(struct sock *sk, ...) runs when an incoming RST tears the conn
+// down. PARM1 = sk. No pid filter here (softirq context) — sock_to_key
+// membership is the target filter (see the file header). The conn's CURRENT
+// state in net_conn_map distinguishes a refused connect (SYN_SENT) from a
+// mid-stream reset (ESTABLISHED): this kprobe fires before the subsequent
+// inet_sock_set_state(→CLOSE), so the pre-reset state is still recorded.
+SEC("kprobe/tcp_reset")
+int BPF_KPROBE(handle_tcp_reset, void *sk)
+{
+    __u64 skaddr = (__u64)(unsigned long)sk;
+    struct net_key *kp = bpf_map_lookup_elem(&sock_to_key, &skaddr);
+    if (!kp)
+        return 0;
+    struct net_key k = *kp; // stack copy before the second lookup (verifier)
+    struct net_val *v = bpf_map_lookup_elem(&net_conn_map, &k);
+    if (!v)
+        return 0;
+
+    __u64 now = bpf_ktime_get_ns();
+    __u32 kind;
+    __u64 detail = 0;
+    if (v->state == TCP_SYN_SENT) {
+        kind = NET_ERR_REFUSED;
+        if (v->syn_sent_ns)
+            detail = now - v->syn_sent_ns;
+    } else {
+        kind = NET_ERR_RESET;
+        if (v->established_ns)
+            detail = now - v->established_ns;
+    }
+    emit_net_error(&k, kind, v->retransmits, detail);
+    return 0;
+}
+
+// tcp_retransmit_skb(struct sock *sk, ...) fires once per retransmitted skb.
+// PARM1 = sk. Same softirq/timer-context reasoning as tcp_reset: filter by
+// sock_to_key membership, not the current task. Each fire bumps the conn's
+// running count and emits it (RTO backoff shows up as the count climbing).
+SEC("kprobe/tcp_retransmit_skb")
+int BPF_KPROBE(handle_tcp_retransmit, void *sk)
+{
+    __u64 skaddr = (__u64)(unsigned long)sk;
+    struct net_key *kp = bpf_map_lookup_elem(&sock_to_key, &skaddr);
+    if (!kp)
+        return 0;
+    struct net_key k = *kp;
+    struct net_val *v = bpf_map_lookup_elem(&net_conn_map, &k);
+    if (!v)
+        return 0;
+    // Increment as a statement, then read the field back: the BPF target
+    // rejects using the XADD return value as an rvalue ("Invalid usage of the
+    // XADD return value") on the default cpu. The read may race a concurrent
+    // bump, but a slightly-ahead retransmit counter is fine for display.
+    __sync_fetch_and_add(&v->retransmits, 1);
+    emit_net_error(&k, NET_ERR_RETRANSMIT, v->retransmits, 0);
     return 0;
 }

--- a/internal/serve/mapper.go
+++ b/internal/serve/mapper.go
@@ -47,6 +47,14 @@ func toEvent(pid int, buildID string, v interface{}) *pb.Event {
 		}
 		ev.Payload = &pb.Event_Network{Network: &pb.NetworkSnapshot{Conns: conns}}
 
+	case collector.NetError:
+		ev.TsUnixNano = tsNano(x.Timestamp)
+		ev.Category = pb.Category_CATEGORY_NETWORK
+		ev.Payload = &pb.Event_NetError{NetError: &pb.NetErrorEvent{
+			Kind: x.Kind, Remote: x.Remote,
+			Retransmits: x.Retransmits, DetailMs: x.DetailMs,
+		}}
+
 	case collector.MemStats:
 		ev.TsUnixNano = nowNano()
 		ev.Category = pb.Category_CATEGORY_MEMORY

--- a/pkg/collector/network_ebpf.go
+++ b/pkg/collector/network_ebpf.go
@@ -3,7 +3,9 @@
 package collector
 
 import (
+	"errors"
 	"fmt"
+	"io"
 	"os"
 	"sort"
 	"time"
@@ -12,15 +14,23 @@ import (
 )
 
 // NetworkEBPFCollector combines:
+//
 //   - tracepoint sock:inet_sock_set_state — discovers 5-tuple + state +
 //     handshake RTT (SYN_SENT → ESTABLISHED).
+//
 //   - kprobes on tcp_sendmsg/tcp_cleanup_rbuf — Tx/Rx bytes per connection,
 //     correlated via the auxiliary sock_to_key map (skaddr → 5-tuple)
 //     populated by the tracepoint itself.
 //
-// Publishes []NetConn every 500ms. Pre-existing connections (opened before
-// attach) don't appear — a tracepoint limitation, since it only fires on
-// state transitions.
+//   - kprobes on tcp_reset/tcp_retransmit_skb — network errors (#56): a
+//     received RST (classified refused vs reset from the tracked state) and
+//     retransmits, correlated through the same sock_to_key map and delivered
+//     per-event via a ring buffer.
+//
+// Publishes []NetConn every 500ms, plus a NetError per error event. Pre-existing
+// connections (opened before attach) don't appear — a tracepoint limitation,
+// since it only fires on state transitions; their errors likewise don't
+// correlate (no sock_to_key entry) and are skipped.
 type NetworkEBPFCollector struct {
 	tracer   *bpf.NetTracer
 	pid      int
@@ -31,7 +41,9 @@ type NetworkEBPFCollector struct {
 
 func NewNetworkEBPFCollector() *NetworkEBPFCollector {
 	return &NetworkEBPFCollector{
-		ch:       make(chan interface{}, 4),
+		// Buffered for the snapshot ticker plus bursty per-event net errors
+		// (matches the heap collector's depth); both senders drop on overflow.
+		ch:       make(chan interface{}, 64),
 		stop:     make(chan struct{}),
 		resolver: NewSocketResolver(),
 	}
@@ -49,6 +61,10 @@ func (c *NetworkEBPFCollector) Start(pid int) error {
 	// Without this, processes with keep-alive look empty until some transition.
 	c.bootstrapFromProc()
 	go c.publishLoop()
+	// Drain net-error events. tracer is passed explicitly (not read from the
+	// field) so Stop()'s `c.tracer = nil` can't race this goroutine; Close()
+	// shuts the ring-buffer reader, unblocking NextError with io.EOF.
+	go c.readLoop(tracer)
 	return nil
 }
 
@@ -85,6 +101,32 @@ func (c *NetworkEBPFCollector) publishLoop() {
 			case c.ch <- conns:
 			default:
 			}
+		}
+	}
+}
+
+// readLoop drains the net-error ring buffer, decoding each record into a
+// NetError and publishing it on the shared channel. It exits on io.EOF (the
+// tracer was closed). A garbled record is logged-by-skip — the stream
+// continues. Sends are non-blocking: under backpressure errors are dropped,
+// consistent with every other collector.
+func (c *NetworkEBPFCollector) readLoop(tracer *bpf.NetTracer) {
+	if tracer == nil {
+		return
+	}
+	for {
+		rec, err := tracer.NextError()
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				return
+			}
+			continue // transient (short/garbled record) — keep reading
+		}
+		ne := decodeNetError(time.Now(), rec.Key.DAddr, rec.Key.DPort,
+			rec.Key.Family, rec.Kind, rec.Retransmits, rec.DetailNs)
+		select {
+		case c.ch <- ne:
+		default:
 		}
 	}
 }

--- a/pkg/collector/network_error.go
+++ b/pkg/collector/network_error.go
@@ -1,0 +1,59 @@
+package collector
+
+import (
+	"fmt"
+	"net"
+	"time"
+)
+
+// Net error kind codes — must match NET_ERR_* in network.bpf.c and the
+// NetErr* constants in internal/bpf/network.go. Duplicated here (rather than
+// imported from internal/bpf) so this decode logic compiles and is unit-tested
+// on any OS, not only the linux+ebpf lane — the same split heap_agg.go uses.
+const (
+	netErrKindRefused    uint32 = 0
+	netErrKindReset      uint32 = 1
+	netErrKindRetransmit uint32 = 2
+)
+
+// netErrKind maps the kernel kind code to the public NetError.Kind string.
+func netErrKind(kind uint32) string {
+	switch kind {
+	case netErrKindRefused:
+		return "refused"
+	case netErrKindReset:
+		return "reset"
+	case netErrKindRetransmit:
+		return "retransmit"
+	default:
+		return "?"
+	}
+}
+
+// formatRemote renders "host:port" (IPv4) or "[host]:port" (IPv6) from raw
+// network-order address bytes, a host-order port, and the address family
+// (2=AF_INET, 10=AF_INET6). Mirrors ipFromKey+formatNetAddr in the ebpf-tagged
+// loader/collector, kept here so it stays testable off-Linux.
+func formatRemote(addr [16]byte, port uint16, family uint16) string {
+	if family == 2 { // AF_INET
+		ip := net.IPv4(addr[0], addr[1], addr[2], addr[3]).To4()
+		return fmt.Sprintf("%s:%d", ip.String(), port)
+	}
+	ip := make(net.IP, 16)
+	copy(ip, addr[:])
+	return fmt.Sprintf("[%s]:%d", ip.String(), port)
+}
+
+// decodeNetError builds a NetError from the raw fields of a net_error_event
+// record. ts is the wall-clock capture time (stamped by the collector when the
+// event is drained — the kernel ts_ns is monotonic, not wall-clock). daddr/
+// dport/family identify the peer; detailNs is converted to milliseconds.
+func decodeNetError(ts time.Time, daddr [16]byte, dport, family uint16, kind, retransmits uint32, detailNs uint64) NetError {
+	return NetError{
+		Timestamp:   ts,
+		Kind:        netErrKind(kind),
+		Remote:      formatRemote(daddr, dport, family),
+		Retransmits: retransmits,
+		DetailMs:    float64(detailNs) / 1e6,
+	}
+}

--- a/pkg/collector/network_error_test.go
+++ b/pkg/collector/network_error_test.go
@@ -1,0 +1,99 @@
+package collector
+
+import (
+	"testing"
+	"time"
+)
+
+func TestNetErrKind(t *testing.T) {
+	cases := map[uint32]string{
+		netErrKindRefused:    "refused",
+		netErrKindReset:      "reset",
+		netErrKindRetransmit: "retransmit",
+		99:                   "?",
+	}
+	for code, want := range cases {
+		if got := netErrKind(code); got != want {
+			t.Errorf("netErrKind(%d) = %q, want %q", code, got, want)
+		}
+	}
+}
+
+func TestFormatRemote(t *testing.T) {
+	tests := []struct {
+		name   string
+		addr   [16]byte
+		port   uint16
+		family uint16
+		want   string
+	}{
+		{
+			name:   "ipv4",
+			addr:   [16]byte{10, 0, 1, 5},
+			port:   5432,
+			family: 2,
+			want:   "10.0.1.5:5432",
+		},
+		{
+			name:   "ipv6 loopback",
+			addr:   [16]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1},
+			port:   443,
+			family: 10,
+			want:   "[::1]:443",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := formatRemote(tt.addr, tt.port, tt.family); got != tt.want {
+				t.Errorf("formatRemote = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDecodeNetError(t *testing.T) {
+	ts := time.Unix(1700000000, 0)
+	daddr := [16]byte{10, 0, 1, 5}
+
+	t.Run("refused carries latency-to-RST", func(t *testing.T) {
+		ne := decodeNetError(ts, daddr, 5432, 2, netErrKindRefused, 0, 1_500_000)
+		if ne.Kind != "refused" {
+			t.Errorf("Kind = %q, want refused", ne.Kind)
+		}
+		if ne.Remote != "10.0.1.5:5432" {
+			t.Errorf("Remote = %q", ne.Remote)
+		}
+		if ne.DetailMs != 1.5 {
+			t.Errorf("DetailMs = %v, want 1.5", ne.DetailMs)
+		}
+		if !ne.Timestamp.Equal(ts) {
+			t.Errorf("Timestamp = %v, want %v", ne.Timestamp, ts)
+		}
+	})
+
+	t.Run("reset distinguished from refused", func(t *testing.T) {
+		ne := decodeNetError(ts, daddr, 443, 2, netErrKindReset, 3, 42_000_000)
+		if ne.Kind != "reset" {
+			t.Errorf("Kind = %q, want reset", ne.Kind)
+		}
+		if ne.Retransmits != 3 {
+			t.Errorf("Retransmits = %d, want 3", ne.Retransmits)
+		}
+		if ne.DetailMs != 42 {
+			t.Errorf("DetailMs = %v, want 42", ne.DetailMs)
+		}
+	})
+
+	t.Run("retransmit carries running count, zero detail", func(t *testing.T) {
+		ne := decodeNetError(ts, daddr, 5432, 2, netErrKindRetransmit, 7, 0)
+		if ne.Kind != "retransmit" {
+			t.Errorf("Kind = %q, want retransmit", ne.Kind)
+		}
+		if ne.Retransmits != 7 {
+			t.Errorf("Retransmits = %d, want 7", ne.Retransmits)
+		}
+		if ne.DetailMs != 0 {
+			t.Errorf("DetailMs = %v, want 0", ne.DetailMs)
+		}
+	})
+}

--- a/pkg/collector/types.go
+++ b/pkg/collector/types.go
@@ -30,6 +30,21 @@ type NetConn struct {
 	RxBytes   uint64
 }
 
+// NetError is a kernel-observed network failure (#56), correlated to a
+// connection by its peer 5-tuple. Kind is "refused" (RST while still
+// connecting), "reset" (RST mid-stream), or "retransmit" (a tcp_retransmit_skb
+// fired). DetailMs is the latency from the relevant baseline to the RST
+// (SYN_SENT→RST for refused, ESTABLISHED→RST for reset); 0 for retransmit.
+// Retransmits is the connection's running retransmit count at event time — the
+// live count for "retransmit", or how many retransmits preceded an RST.
+type NetError struct {
+	Timestamp   time.Time
+	Kind        string
+	Remote      string // peer host:port
+	Retransmits uint32
+	DetailMs    float64
+}
+
 // ─── Memory ───────────────────────────────────────────────────────────────────
 
 type MemStats struct {

--- a/pkg/streampb/event.pb.go
+++ b/pkg/streampb/event.pb.go
@@ -271,6 +271,7 @@ type Event struct {
 	//	*Event_Timeline
 	//	*Event_Heap
 	//	*Event_HeapEvent
+	//	*Event_NetError
 	Payload       isEvent_Payload `protobuf_oneof:"payload"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
@@ -474,6 +475,15 @@ func (x *Event) GetHeapEvent() *HeapEvent {
 	return nil
 }
 
+func (x *Event) GetNetError() *NetErrorEvent {
+	if x != nil {
+		if x, ok := x.Payload.(*Event_NetError); ok {
+			return x.NetError
+		}
+	}
+	return nil
+}
+
 type isEvent_Payload interface {
 	isEvent_Payload()
 }
@@ -535,6 +545,10 @@ type Event_HeapEvent struct {
 	HeapEvent *HeapEvent `protobuf:"bytes,23,opt,name=heap_event,json=heapEvent,proto3,oneof"` // #53 — per alloc/free
 }
 
+type Event_NetError struct {
+	NetError *NetErrorEvent `protobuf:"bytes,24,opt,name=net_error,json=netError,proto3,oneof"` // #56 — detailed network error
+}
+
 func (*Event_Cpu) isEvent_Payload() {}
 
 func (*Event_Syscalls) isEvent_Payload() {}
@@ -562,6 +576,8 @@ func (*Event_Timeline) isEvent_Payload() {}
 func (*Event_Heap) isEvent_Payload() {}
 
 func (*Event_HeapEvent) isEvent_Payload() {}
+
+func (*Event_NetError) isEvent_Payload() {}
 
 // ─── CPU ──────────────────────────────────────────────────────────────────
 type CpuSample struct {
@@ -858,6 +874,81 @@ func (x *NetworkSnapshot) GetConns() []*NetConn {
 	return nil
 }
 
+// NetErrorEvent is a kernel-observed network failure (#56), correlated to a
+// connection by its peer 5-tuple. kind is "refused" (RST while still
+// connecting), "reset" (RST mid-stream), or "retransmit" (a tcp_retransmit_skb
+// fired). detail_ms is the latency from the relevant baseline to the RST
+// (SYN_SENT→RST for refused, ESTABLISHED→RST for reset); 0 for retransmit.
+// retransmits is the connection's running retransmit count at event time. The
+// event timestamp lives on the Event envelope.
+type NetErrorEvent struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Kind          string                 `protobuf:"bytes,1,opt,name=kind,proto3" json:"kind,omitempty"`
+	Remote        string                 `protobuf:"bytes,2,opt,name=remote,proto3" json:"remote,omitempty"` // peer host:port
+	Retransmits   uint32                 `protobuf:"varint,3,opt,name=retransmits,proto3" json:"retransmits,omitempty"`
+	DetailMs      float64                `protobuf:"fixed64,4,opt,name=detail_ms,json=detailMs,proto3" json:"detail_ms,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *NetErrorEvent) Reset() {
+	*x = NetErrorEvent{}
+	mi := &file_event_proto_msgTypes[8]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *NetErrorEvent) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*NetErrorEvent) ProtoMessage() {}
+
+func (x *NetErrorEvent) ProtoReflect() protoreflect.Message {
+	mi := &file_event_proto_msgTypes[8]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use NetErrorEvent.ProtoReflect.Descriptor instead.
+func (*NetErrorEvent) Descriptor() ([]byte, []int) {
+	return file_event_proto_rawDescGZIP(), []int{8}
+}
+
+func (x *NetErrorEvent) GetKind() string {
+	if x != nil {
+		return x.Kind
+	}
+	return ""
+}
+
+func (x *NetErrorEvent) GetRemote() string {
+	if x != nil {
+		return x.Remote
+	}
+	return ""
+}
+
+func (x *NetErrorEvent) GetRetransmits() uint32 {
+	if x != nil {
+		return x.Retransmits
+	}
+	return 0
+}
+
+func (x *NetErrorEvent) GetDetailMs() float64 {
+	if x != nil {
+		return x.DetailMs
+	}
+	return 0
+}
+
 // ─── Memory ─────────────────────────────────────────────────────────────────
 type MemStats struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
@@ -871,7 +962,7 @@ type MemStats struct {
 
 func (x *MemStats) Reset() {
 	*x = MemStats{}
-	mi := &file_event_proto_msgTypes[8]
+	mi := &file_event_proto_msgTypes[9]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -883,7 +974,7 @@ func (x *MemStats) String() string {
 func (*MemStats) ProtoMessage() {}
 
 func (x *MemStats) ProtoReflect() protoreflect.Message {
-	mi := &file_event_proto_msgTypes[8]
+	mi := &file_event_proto_msgTypes[9]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -896,7 +987,7 @@ func (x *MemStats) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use MemStats.ProtoReflect.Descriptor instead.
 func (*MemStats) Descriptor() ([]byte, []int) {
-	return file_event_proto_rawDescGZIP(), []int{8}
+	return file_event_proto_rawDescGZIP(), []int{9}
 }
 
 func (x *MemStats) GetRssBytes() uint64 {
@@ -945,7 +1036,7 @@ type HeapEvent struct {
 
 func (x *HeapEvent) Reset() {
 	*x = HeapEvent{}
-	mi := &file_event_proto_msgTypes[9]
+	mi := &file_event_proto_msgTypes[10]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -957,7 +1048,7 @@ func (x *HeapEvent) String() string {
 func (*HeapEvent) ProtoMessage() {}
 
 func (x *HeapEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_event_proto_msgTypes[9]
+	mi := &file_event_proto_msgTypes[10]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -970,7 +1061,7 @@ func (x *HeapEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use HeapEvent.ProtoReflect.Descriptor instead.
 func (*HeapEvent) Descriptor() ([]byte, []int) {
-	return file_event_proto_rawDescGZIP(), []int{9}
+	return file_event_proto_rawDescGZIP(), []int{10}
 }
 
 func (x *HeapEvent) GetOp() string {
@@ -1046,7 +1137,7 @@ type HeapCallSite struct {
 
 func (x *HeapCallSite) Reset() {
 	*x = HeapCallSite{}
-	mi := &file_event_proto_msgTypes[10]
+	mi := &file_event_proto_msgTypes[11]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1058,7 +1149,7 @@ func (x *HeapCallSite) String() string {
 func (*HeapCallSite) ProtoMessage() {}
 
 func (x *HeapCallSite) ProtoReflect() protoreflect.Message {
-	mi := &file_event_proto_msgTypes[10]
+	mi := &file_event_proto_msgTypes[11]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1071,7 +1162,7 @@ func (x *HeapCallSite) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use HeapCallSite.ProtoReflect.Descriptor instead.
 func (*HeapCallSite) Descriptor() ([]byte, []int) {
-	return file_event_proto_rawDescGZIP(), []int{10}
+	return file_event_proto_rawDescGZIP(), []int{11}
 }
 
 func (x *HeapCallSite) GetCallSite() uint64 {
@@ -1174,7 +1265,7 @@ type HeapSnapshot struct {
 
 func (x *HeapSnapshot) Reset() {
 	*x = HeapSnapshot{}
-	mi := &file_event_proto_msgTypes[11]
+	mi := &file_event_proto_msgTypes[12]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1186,7 +1277,7 @@ func (x *HeapSnapshot) String() string {
 func (*HeapSnapshot) ProtoMessage() {}
 
 func (x *HeapSnapshot) ProtoReflect() protoreflect.Message {
-	mi := &file_event_proto_msgTypes[11]
+	mi := &file_event_proto_msgTypes[12]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1199,7 +1290,7 @@ func (x *HeapSnapshot) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use HeapSnapshot.ProtoReflect.Descriptor instead.
 func (*HeapSnapshot) Descriptor() ([]byte, []int) {
-	return file_event_proto_rawDescGZIP(), []int{11}
+	return file_event_proto_rawDescGZIP(), []int{12}
 }
 
 func (x *HeapSnapshot) GetLiveHeapBytes() uint64 {
@@ -1245,7 +1336,7 @@ type ThreadInfo struct {
 
 func (x *ThreadInfo) Reset() {
 	*x = ThreadInfo{}
-	mi := &file_event_proto_msgTypes[12]
+	mi := &file_event_proto_msgTypes[13]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1257,7 +1348,7 @@ func (x *ThreadInfo) String() string {
 func (*ThreadInfo) ProtoMessage() {}
 
 func (x *ThreadInfo) ProtoReflect() protoreflect.Message {
-	mi := &file_event_proto_msgTypes[12]
+	mi := &file_event_proto_msgTypes[13]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1270,7 +1361,7 @@ func (x *ThreadInfo) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ThreadInfo.ProtoReflect.Descriptor instead.
 func (*ThreadInfo) Descriptor() ([]byte, []int) {
-	return file_event_proto_rawDescGZIP(), []int{12}
+	return file_event_proto_rawDescGZIP(), []int{13}
 }
 
 func (x *ThreadInfo) GetTid() int32 {
@@ -1324,7 +1415,7 @@ type ThreadSnapshot struct {
 
 func (x *ThreadSnapshot) Reset() {
 	*x = ThreadSnapshot{}
-	mi := &file_event_proto_msgTypes[13]
+	mi := &file_event_proto_msgTypes[14]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1336,7 +1427,7 @@ func (x *ThreadSnapshot) String() string {
 func (*ThreadSnapshot) ProtoMessage() {}
 
 func (x *ThreadSnapshot) ProtoReflect() protoreflect.Message {
-	mi := &file_event_proto_msgTypes[13]
+	mi := &file_event_proto_msgTypes[14]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1349,7 +1440,7 @@ func (x *ThreadSnapshot) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ThreadSnapshot.ProtoReflect.Descriptor instead.
 func (*ThreadSnapshot) Descriptor() ([]byte, []int) {
-	return file_event_proto_rawDescGZIP(), []int{13}
+	return file_event_proto_rawDescGZIP(), []int{14}
 }
 
 func (x *ThreadSnapshot) GetThreads() []*ThreadInfo {
@@ -1369,7 +1460,7 @@ type IoWaitSample struct {
 
 func (x *IoWaitSample) Reset() {
 	*x = IoWaitSample{}
-	mi := &file_event_proto_msgTypes[14]
+	mi := &file_event_proto_msgTypes[15]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1381,7 +1472,7 @@ func (x *IoWaitSample) String() string {
 func (*IoWaitSample) ProtoMessage() {}
 
 func (x *IoWaitSample) ProtoReflect() protoreflect.Message {
-	mi := &file_event_proto_msgTypes[14]
+	mi := &file_event_proto_msgTypes[15]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1394,7 +1485,7 @@ func (x *IoWaitSample) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use IoWaitSample.ProtoReflect.Descriptor instead.
 func (*IoWaitSample) Descriptor() ([]byte, []int) {
-	return file_event_proto_rawDescGZIP(), []int{14}
+	return file_event_proto_rawDescGZIP(), []int{15}
 }
 
 func (x *IoWaitSample) GetPct() float64 {
@@ -1416,7 +1507,7 @@ type IoThroughputSample struct {
 
 func (x *IoThroughputSample) Reset() {
 	*x = IoThroughputSample{}
-	mi := &file_event_proto_msgTypes[15]
+	mi := &file_event_proto_msgTypes[16]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1428,7 +1519,7 @@ func (x *IoThroughputSample) String() string {
 func (*IoThroughputSample) ProtoMessage() {}
 
 func (x *IoThroughputSample) ProtoReflect() protoreflect.Message {
-	mi := &file_event_proto_msgTypes[15]
+	mi := &file_event_proto_msgTypes[16]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1441,7 +1532,7 @@ func (x *IoThroughputSample) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use IoThroughputSample.ProtoReflect.Descriptor instead.
 func (*IoThroughputSample) Descriptor() ([]byte, []int) {
-	return file_event_proto_rawDescGZIP(), []int{15}
+	return file_event_proto_rawDescGZIP(), []int{16}
 }
 
 func (x *IoThroughputSample) GetReadBytesPerS() float64 {
@@ -1487,7 +1578,7 @@ type IoFileStats struct {
 
 func (x *IoFileStats) Reset() {
 	*x = IoFileStats{}
-	mi := &file_event_proto_msgTypes[16]
+	mi := &file_event_proto_msgTypes[17]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1499,7 +1590,7 @@ func (x *IoFileStats) String() string {
 func (*IoFileStats) ProtoMessage() {}
 
 func (x *IoFileStats) ProtoReflect() protoreflect.Message {
-	mi := &file_event_proto_msgTypes[16]
+	mi := &file_event_proto_msgTypes[17]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1512,7 +1603,7 @@ func (x *IoFileStats) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use IoFileStats.ProtoReflect.Descriptor instead.
 func (*IoFileStats) Descriptor() ([]byte, []int) {
-	return file_event_proto_rawDescGZIP(), []int{16}
+	return file_event_proto_rawDescGZIP(), []int{17}
 }
 
 func (x *IoFileStats) GetPath() string {
@@ -1575,7 +1666,7 @@ type LatencyBucket struct {
 
 func (x *LatencyBucket) Reset() {
 	*x = LatencyBucket{}
-	mi := &file_event_proto_msgTypes[17]
+	mi := &file_event_proto_msgTypes[18]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1587,7 +1678,7 @@ func (x *LatencyBucket) String() string {
 func (*LatencyBucket) ProtoMessage() {}
 
 func (x *LatencyBucket) ProtoReflect() protoreflect.Message {
-	mi := &file_event_proto_msgTypes[17]
+	mi := &file_event_proto_msgTypes[18]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1600,7 +1691,7 @@ func (x *LatencyBucket) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LatencyBucket.ProtoReflect.Descriptor instead.
 func (*LatencyBucket) Descriptor() ([]byte, []int) {
-	return file_event_proto_rawDescGZIP(), []int{17}
+	return file_event_proto_rawDescGZIP(), []int{18}
 }
 
 func (x *LatencyBucket) GetLabel() string {
@@ -1641,7 +1732,7 @@ type IoSnapshot struct {
 
 func (x *IoSnapshot) Reset() {
 	*x = IoSnapshot{}
-	mi := &file_event_proto_msgTypes[18]
+	mi := &file_event_proto_msgTypes[19]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1653,7 +1744,7 @@ func (x *IoSnapshot) String() string {
 func (*IoSnapshot) ProtoMessage() {}
 
 func (x *IoSnapshot) ProtoReflect() protoreflect.Message {
-	mi := &file_event_proto_msgTypes[18]
+	mi := &file_event_proto_msgTypes[19]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1666,7 +1757,7 @@ func (x *IoSnapshot) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use IoSnapshot.ProtoReflect.Descriptor instead.
 func (*IoSnapshot) Descriptor() ([]byte, []int) {
-	return file_event_proto_rawDescGZIP(), []int{18}
+	return file_event_proto_rawDescGZIP(), []int{19}
 }
 
 func (x *IoSnapshot) GetReadBytesPerS() float64 {
@@ -1748,7 +1839,7 @@ type FdEntry struct {
 
 func (x *FdEntry) Reset() {
 	*x = FdEntry{}
-	mi := &file_event_proto_msgTypes[19]
+	mi := &file_event_proto_msgTypes[20]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1760,7 +1851,7 @@ func (x *FdEntry) String() string {
 func (*FdEntry) ProtoMessage() {}
 
 func (x *FdEntry) ProtoReflect() protoreflect.Message {
-	mi := &file_event_proto_msgTypes[19]
+	mi := &file_event_proto_msgTypes[20]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1773,7 +1864,7 @@ func (x *FdEntry) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use FdEntry.ProtoReflect.Descriptor instead.
 func (*FdEntry) Descriptor() ([]byte, []int) {
-	return file_event_proto_rawDescGZIP(), []int{19}
+	return file_event_proto_rawDescGZIP(), []int{20}
 }
 
 func (x *FdEntry) GetFd() int32 {
@@ -1834,7 +1925,7 @@ type FdSnapshot struct {
 
 func (x *FdSnapshot) Reset() {
 	*x = FdSnapshot{}
-	mi := &file_event_proto_msgTypes[20]
+	mi := &file_event_proto_msgTypes[21]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1846,7 +1937,7 @@ func (x *FdSnapshot) String() string {
 func (*FdSnapshot) ProtoMessage() {}
 
 func (x *FdSnapshot) ProtoReflect() protoreflect.Message {
-	mi := &file_event_proto_msgTypes[20]
+	mi := &file_event_proto_msgTypes[21]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1859,7 +1950,7 @@ func (x *FdSnapshot) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use FdSnapshot.ProtoReflect.Descriptor instead.
 func (*FdSnapshot) Descriptor() ([]byte, []int) {
-	return file_event_proto_rawDescGZIP(), []int{20}
+	return file_event_proto_rawDescGZIP(), []int{21}
 }
 
 func (x *FdSnapshot) GetFds() []*FdEntry {
@@ -1880,7 +1971,7 @@ type FdEvent struct {
 
 func (x *FdEvent) Reset() {
 	*x = FdEvent{}
-	mi := &file_event_proto_msgTypes[21]
+	mi := &file_event_proto_msgTypes[22]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1892,7 +1983,7 @@ func (x *FdEvent) String() string {
 func (*FdEvent) ProtoMessage() {}
 
 func (x *FdEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_event_proto_msgTypes[21]
+	mi := &file_event_proto_msgTypes[22]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1905,7 +1996,7 @@ func (x *FdEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use FdEvent.ProtoReflect.Descriptor instead.
 func (*FdEvent) Descriptor() ([]byte, []int) {
-	return file_event_proto_rawDescGZIP(), []int{21}
+	return file_event_proto_rawDescGZIP(), []int{22}
 }
 
 func (x *FdEvent) GetMessage() string {
@@ -1931,7 +2022,7 @@ type LockEntry struct {
 
 func (x *LockEntry) Reset() {
 	*x = LockEntry{}
-	mi := &file_event_proto_msgTypes[22]
+	mi := &file_event_proto_msgTypes[23]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1943,7 +2034,7 @@ func (x *LockEntry) String() string {
 func (*LockEntry) ProtoMessage() {}
 
 func (x *LockEntry) ProtoReflect() protoreflect.Message {
-	mi := &file_event_proto_msgTypes[22]
+	mi := &file_event_proto_msgTypes[23]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1956,7 +2047,7 @@ func (x *LockEntry) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LockEntry.ProtoReflect.Descriptor instead.
 func (*LockEntry) Descriptor() ([]byte, []int) {
-	return file_event_proto_rawDescGZIP(), []int{22}
+	return file_event_proto_rawDescGZIP(), []int{23}
 }
 
 func (x *LockEntry) GetUaddr() uint64 {
@@ -2017,7 +2108,7 @@ type LockSnapshot struct {
 
 func (x *LockSnapshot) Reset() {
 	*x = LockSnapshot{}
-	mi := &file_event_proto_msgTypes[23]
+	mi := &file_event_proto_msgTypes[24]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2029,7 +2120,7 @@ func (x *LockSnapshot) String() string {
 func (*LockSnapshot) ProtoMessage() {}
 
 func (x *LockSnapshot) ProtoReflect() protoreflect.Message {
-	mi := &file_event_proto_msgTypes[23]
+	mi := &file_event_proto_msgTypes[24]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2042,7 +2133,7 @@ func (x *LockSnapshot) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LockSnapshot.ProtoReflect.Descriptor instead.
 func (*LockSnapshot) Descriptor() ([]byte, []int) {
-	return file_event_proto_rawDescGZIP(), []int{23}
+	return file_event_proto_rawDescGZIP(), []int{24}
 }
 
 func (x *LockSnapshot) GetLocks() []*LockEntry {
@@ -2063,7 +2154,7 @@ type TimelineEvent struct {
 
 func (x *TimelineEvent) Reset() {
 	*x = TimelineEvent{}
-	mi := &file_event_proto_msgTypes[24]
+	mi := &file_event_proto_msgTypes[25]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2075,7 +2166,7 @@ func (x *TimelineEvent) String() string {
 func (*TimelineEvent) ProtoMessage() {}
 
 func (x *TimelineEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_event_proto_msgTypes[24]
+	mi := &file_event_proto_msgTypes[25]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2088,7 +2179,7 @@ func (x *TimelineEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TimelineEvent.ProtoReflect.Descriptor instead.
 func (*TimelineEvent) Descriptor() ([]byte, []int) {
-	return file_event_proto_rawDescGZIP(), []int{24}
+	return file_event_proto_rawDescGZIP(), []int{25}
 }
 
 func (x *TimelineEvent) GetMessage() string {
@@ -2113,7 +2204,7 @@ const file_event_proto_rawDesc = "" +
 	"\x04line\x18\x03 \x01(\x05R\x04line\x12\x16\n" +
 	"\x06module\x18\x04 \x01(\tR\x06module\x12\x16\n" +
 	"\x06offset\x18\x05 \x01(\x04R\x06offset\x12\x19\n" +
-	"\bbuild_id\x18\x06 \x01(\tR\abuildId\"\xe4\x06\n" +
+	"\bbuild_id\x18\x06 \x01(\tR\abuildId\"\x9b\a\n" +
 	"\x05Event\x12 \n" +
 	"\fts_unix_nano\x18\x01 \x01(\x03R\n" +
 	"tsUnixNano\x12\x10\n" +
@@ -2136,7 +2227,8 @@ const file_event_proto_rawDesc = "" +
 	"\btimeline\x18\x15 \x01(\v2\x16.ptop.v1.TimelineEventH\x00R\btimeline\x12+\n" +
 	"\x04heap\x18\x16 \x01(\v2\x15.ptop.v1.HeapSnapshotH\x00R\x04heap\x123\n" +
 	"\n" +
-	"heap_event\x18\x17 \x01(\v2\x12.ptop.v1.HeapEventH\x00R\theapEventB\t\n" +
+	"heap_event\x18\x17 \x01(\v2\x12.ptop.v1.HeapEventH\x00R\theapEvent\x125\n" +
+	"\tnet_error\x18\x18 \x01(\v2\x16.ptop.v1.NetErrorEventH\x00R\bnetErrorB\t\n" +
 	"\apayload\"(\n" +
 	"\tCpuSample\x12\x1b\n" +
 	"\tusage_pct\x18\x01 \x01(\x01R\busagePct\"V\n" +
@@ -2158,7 +2250,12 @@ const file_event_proto_rawDesc = "" +
 	"\btx_bytes\x18\a \x01(\x04R\atxBytes\x12\x19\n" +
 	"\brx_bytes\x18\b \x01(\x04R\arxBytes\"9\n" +
 	"\x0fNetworkSnapshot\x12&\n" +
-	"\x05conns\x18\x01 \x03(\v2\x10.ptop.v1.NetConnR\x05conns\"\x89\x01\n" +
+	"\x05conns\x18\x01 \x03(\v2\x10.ptop.v1.NetConnR\x05conns\"z\n" +
+	"\rNetErrorEvent\x12\x12\n" +
+	"\x04kind\x18\x01 \x01(\tR\x04kind\x12\x16\n" +
+	"\x06remote\x18\x02 \x01(\tR\x06remote\x12 \n" +
+	"\vretransmits\x18\x03 \x01(\rR\vretransmits\x12\x1b\n" +
+	"\tdetail_ms\x18\x04 \x01(\x01R\bdetailMs\"\x89\x01\n" +
 	"\bMemStats\x12\x1b\n" +
 	"\trss_bytes\x18\x01 \x01(\x04R\brssBytes\x12\x1d\n" +
 	"\n" +
@@ -2292,7 +2389,7 @@ func file_event_proto_rawDescGZIP() []byte {
 }
 
 var file_event_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
-var file_event_proto_msgTypes = make([]protoimpl.MessageInfo, 25)
+var file_event_proto_msgTypes = make([]protoimpl.MessageInfo, 26)
 var file_event_proto_goTypes = []any{
 	(Category)(0),              // 0: ptop.v1.Category
 	(*StackRef)(nil),           // 1: ptop.v1.StackRef
@@ -2303,23 +2400,24 @@ var file_event_proto_goTypes = []any{
 	(*SyscallSnapshot)(nil),    // 6: ptop.v1.SyscallSnapshot
 	(*NetConn)(nil),            // 7: ptop.v1.NetConn
 	(*NetworkSnapshot)(nil),    // 8: ptop.v1.NetworkSnapshot
-	(*MemStats)(nil),           // 9: ptop.v1.MemStats
-	(*HeapEvent)(nil),          // 10: ptop.v1.HeapEvent
-	(*HeapCallSite)(nil),       // 11: ptop.v1.HeapCallSite
-	(*HeapSnapshot)(nil),       // 12: ptop.v1.HeapSnapshot
-	(*ThreadInfo)(nil),         // 13: ptop.v1.ThreadInfo
-	(*ThreadSnapshot)(nil),     // 14: ptop.v1.ThreadSnapshot
-	(*IoWaitSample)(nil),       // 15: ptop.v1.IoWaitSample
-	(*IoThroughputSample)(nil), // 16: ptop.v1.IoThroughputSample
-	(*IoFileStats)(nil),        // 17: ptop.v1.IoFileStats
-	(*LatencyBucket)(nil),      // 18: ptop.v1.LatencyBucket
-	(*IoSnapshot)(nil),         // 19: ptop.v1.IoSnapshot
-	(*FdEntry)(nil),            // 20: ptop.v1.FdEntry
-	(*FdSnapshot)(nil),         // 21: ptop.v1.FdSnapshot
-	(*FdEvent)(nil),            // 22: ptop.v1.FdEvent
-	(*LockEntry)(nil),          // 23: ptop.v1.LockEntry
-	(*LockSnapshot)(nil),       // 24: ptop.v1.LockSnapshot
-	(*TimelineEvent)(nil),      // 25: ptop.v1.TimelineEvent
+	(*NetErrorEvent)(nil),      // 9: ptop.v1.NetErrorEvent
+	(*MemStats)(nil),           // 10: ptop.v1.MemStats
+	(*HeapEvent)(nil),          // 11: ptop.v1.HeapEvent
+	(*HeapCallSite)(nil),       // 12: ptop.v1.HeapCallSite
+	(*HeapSnapshot)(nil),       // 13: ptop.v1.HeapSnapshot
+	(*ThreadInfo)(nil),         // 14: ptop.v1.ThreadInfo
+	(*ThreadSnapshot)(nil),     // 15: ptop.v1.ThreadSnapshot
+	(*IoWaitSample)(nil),       // 16: ptop.v1.IoWaitSample
+	(*IoThroughputSample)(nil), // 17: ptop.v1.IoThroughputSample
+	(*IoFileStats)(nil),        // 18: ptop.v1.IoFileStats
+	(*LatencyBucket)(nil),      // 19: ptop.v1.LatencyBucket
+	(*IoSnapshot)(nil),         // 20: ptop.v1.IoSnapshot
+	(*FdEntry)(nil),            // 21: ptop.v1.FdEntry
+	(*FdSnapshot)(nil),         // 22: ptop.v1.FdSnapshot
+	(*FdEvent)(nil),            // 23: ptop.v1.FdEvent
+	(*LockEntry)(nil),          // 24: ptop.v1.LockEntry
+	(*LockSnapshot)(nil),       // 25: ptop.v1.LockSnapshot
+	(*TimelineEvent)(nil),      // 26: ptop.v1.TimelineEvent
 }
 var file_event_proto_depIdxs = []int32{
 	0,  // 0: ptop.v1.Event.category:type_name -> ptop.v1.Category
@@ -2327,30 +2425,31 @@ var file_event_proto_depIdxs = []int32{
 	4,  // 2: ptop.v1.Event.cpu:type_name -> ptop.v1.CpuSample
 	6,  // 3: ptop.v1.Event.syscalls:type_name -> ptop.v1.SyscallSnapshot
 	8,  // 4: ptop.v1.Event.network:type_name -> ptop.v1.NetworkSnapshot
-	9,  // 5: ptop.v1.Event.memory:type_name -> ptop.v1.MemStats
-	14, // 6: ptop.v1.Event.threads:type_name -> ptop.v1.ThreadSnapshot
-	15, // 7: ptop.v1.Event.io_wait:type_name -> ptop.v1.IoWaitSample
-	16, // 8: ptop.v1.Event.io_throughput:type_name -> ptop.v1.IoThroughputSample
-	19, // 9: ptop.v1.Event.io:type_name -> ptop.v1.IoSnapshot
-	21, // 10: ptop.v1.Event.fds:type_name -> ptop.v1.FdSnapshot
-	22, // 11: ptop.v1.Event.fd_event:type_name -> ptop.v1.FdEvent
-	24, // 12: ptop.v1.Event.locks:type_name -> ptop.v1.LockSnapshot
-	25, // 13: ptop.v1.Event.timeline:type_name -> ptop.v1.TimelineEvent
-	12, // 14: ptop.v1.Event.heap:type_name -> ptop.v1.HeapSnapshot
-	10, // 15: ptop.v1.Event.heap_event:type_name -> ptop.v1.HeapEvent
-	5,  // 16: ptop.v1.SyscallSnapshot.stats:type_name -> ptop.v1.SyscallStat
-	7,  // 17: ptop.v1.NetworkSnapshot.conns:type_name -> ptop.v1.NetConn
-	11, // 18: ptop.v1.HeapSnapshot.top_call_sites:type_name -> ptop.v1.HeapCallSite
-	13, // 19: ptop.v1.ThreadSnapshot.threads:type_name -> ptop.v1.ThreadInfo
-	17, // 20: ptop.v1.IoSnapshot.top_files:type_name -> ptop.v1.IoFileStats
-	18, // 21: ptop.v1.IoSnapshot.latency_buckets:type_name -> ptop.v1.LatencyBucket
-	20, // 22: ptop.v1.FdSnapshot.fds:type_name -> ptop.v1.FdEntry
-	23, // 23: ptop.v1.LockSnapshot.locks:type_name -> ptop.v1.LockEntry
-	24, // [24:24] is the sub-list for method output_type
-	24, // [24:24] is the sub-list for method input_type
-	24, // [24:24] is the sub-list for extension type_name
-	24, // [24:24] is the sub-list for extension extendee
-	0,  // [0:24] is the sub-list for field type_name
+	10, // 5: ptop.v1.Event.memory:type_name -> ptop.v1.MemStats
+	15, // 6: ptop.v1.Event.threads:type_name -> ptop.v1.ThreadSnapshot
+	16, // 7: ptop.v1.Event.io_wait:type_name -> ptop.v1.IoWaitSample
+	17, // 8: ptop.v1.Event.io_throughput:type_name -> ptop.v1.IoThroughputSample
+	20, // 9: ptop.v1.Event.io:type_name -> ptop.v1.IoSnapshot
+	22, // 10: ptop.v1.Event.fds:type_name -> ptop.v1.FdSnapshot
+	23, // 11: ptop.v1.Event.fd_event:type_name -> ptop.v1.FdEvent
+	25, // 12: ptop.v1.Event.locks:type_name -> ptop.v1.LockSnapshot
+	26, // 13: ptop.v1.Event.timeline:type_name -> ptop.v1.TimelineEvent
+	13, // 14: ptop.v1.Event.heap:type_name -> ptop.v1.HeapSnapshot
+	11, // 15: ptop.v1.Event.heap_event:type_name -> ptop.v1.HeapEvent
+	9,  // 16: ptop.v1.Event.net_error:type_name -> ptop.v1.NetErrorEvent
+	5,  // 17: ptop.v1.SyscallSnapshot.stats:type_name -> ptop.v1.SyscallStat
+	7,  // 18: ptop.v1.NetworkSnapshot.conns:type_name -> ptop.v1.NetConn
+	12, // 19: ptop.v1.HeapSnapshot.top_call_sites:type_name -> ptop.v1.HeapCallSite
+	14, // 20: ptop.v1.ThreadSnapshot.threads:type_name -> ptop.v1.ThreadInfo
+	18, // 21: ptop.v1.IoSnapshot.top_files:type_name -> ptop.v1.IoFileStats
+	19, // 22: ptop.v1.IoSnapshot.latency_buckets:type_name -> ptop.v1.LatencyBucket
+	21, // 23: ptop.v1.FdSnapshot.fds:type_name -> ptop.v1.FdEntry
+	24, // 24: ptop.v1.LockSnapshot.locks:type_name -> ptop.v1.LockEntry
+	25, // [25:25] is the sub-list for method output_type
+	25, // [25:25] is the sub-list for method input_type
+	25, // [25:25] is the sub-list for extension type_name
+	25, // [25:25] is the sub-list for extension extendee
+	0,  // [0:25] is the sub-list for field type_name
 }
 
 func init() { file_event_proto_init() }
@@ -2373,6 +2472,7 @@ func file_event_proto_init() {
 		(*Event_Timeline)(nil),
 		(*Event_Heap)(nil),
 		(*Event_HeapEvent)(nil),
+		(*Event_NetError)(nil),
 	}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
@@ -2380,7 +2480,7 @@ func file_event_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_event_proto_rawDesc), len(file_event_proto_rawDesc)),
 			NumEnums:      1,
-			NumMessages:   25,
+			NumMessages:   26,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/proto/event.proto
+++ b/proto/event.proto
@@ -75,9 +75,9 @@ message Event {
     // #52 capabilities:
     HeapSnapshot heap = 22; // #53 — periodic heap aggregate
     HeapEvent heap_event = 23; // #53 — per alloc/free
-    // 24+ reserved for the remaining #52 capabilities (pre-encryption payload,
-    // signals, detailed net errors, fs semantics, security/LSM, exec-context
-    // enrichment).
+    NetErrorEvent net_error = 24; // #56 — detailed network error
+    // 25+ reserved for the remaining #52 capabilities (pre-encryption payload,
+    // signals, fs semantics, security/LSM, exec-context enrichment).
   }
 }
 
@@ -109,6 +109,20 @@ message NetConn {
 }
 message NetworkSnapshot {
   repeated NetConn conns = 1;
+}
+
+// NetErrorEvent is a kernel-observed network failure (#56), correlated to a
+// connection by its peer 5-tuple. kind is "refused" (RST while still
+// connecting), "reset" (RST mid-stream), or "retransmit" (a tcp_retransmit_skb
+// fired). detail_ms is the latency from the relevant baseline to the RST
+// (SYN_SENT→RST for refused, ESTABLISHED→RST for reset); 0 for retransmit.
+// retransmits is the connection's running retransmit count at event time. The
+// event timestamp lives on the Event envelope.
+message NetErrorEvent {
+  string kind = 1;
+  string remote = 2; // peer host:port
+  uint32 retransmits = 3;
+  double detail_ms = 4;
 }
 
 // ─── Memory ─────────────────────────────────────────────────────────────────


### PR DESCRIPTION
Part of #52. Core of **#56** (detailed network errors with root cause) — **PR1 of 2** (capture engine + gRPC stream, no TUI). PR2 adds the F3 panel, stacked on this branch.

## What

Surface TCP network failures as first-class events with their kernel origin, not just a failed syscall return. Reuses the existing `sock_to_key` correlation map in `network.bpf.c`, so there is **no new BPF program** (`BPF_SRCS` unchanged).

### Captured (this PR)
- **Connection refused** — RST received while we still track the conn as `SYN_SENT`.
- **Reset mid-stream** — RST on an `ESTABLISHED` conn (distinguished purely by the pre-reset state already in `net_conn_map`; the `tcp_reset` kprobe fires before the `→CLOSE` transition).
- **Retransmit / timeout backoff** — each `tcp_retransmit_skb`, carrying the connection's running retransmit count.

### eBPF design notes
- New `net_error_events` RINGBUF + a `retransmits` counter on `net_val`.
- `tcp_reset` / `tcp_retransmit_skb` run in **softirq/timer context**, so they filter by **`sock_to_key` membership** (only ever populated under `pid_is_target()` in the process-context connect path) rather than the interrupted current task — pid-filtering there would drop nearly every event.
- Attached **non-fatally**: a kernel missing the symbols simply yields no net errors; connection tracking is unaffected.

## Go data path
- `NetErrorRecord` + ring-buffer reader (`NextError`) in `bpf/network.go`.
- A `readLoop` in `NetworkEBPFCollector` decodes records into the new `collector.NetError` and publishes them (channel buffer 4→64, drop-on-overflow like every other collector). The tracer is passed explicitly so `Stop()` can't race it.
- Decode/format helpers live in the build-tag-free `network_error.go` so they stay unit-tested off-Linux (mirrors `heap_agg.go`).

## Stream
- `NetErrorEvent` proto message + `oneof` field **24** (additive → `buf breaking` safe) + mapper case.

## Deferred (documented follow-ups)
ICMP unreachable, EPIPE+FIN broken pipe (→ #58), recvfrom read/write timeout, SSL handshake failure (→ #55), and timeout give-up time. The running retransmit count is the MVP timeout signal.

## Testing
- Pure-Go unit test for `decodeNetError` / `formatRemote` / `netErrKind` (no eBPF).
- Verified locally: default + `-tags=ebpf` (darwin stub) build/vet/test, `GOOS=linux` non-ebpf build/vet, `make proto` clean. The real `linux && ebpf` loader compiles only on CI (clang `make gen`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)