### PR TITLE
tui: F3 network anomalies panel for net errors (#56)

### DIFF
--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -84,6 +84,7 @@ type FDEventMsg collector.FDEvent
 type SyscallsMsg map[string]uint64
 type IOEBPFMsg collector.IOEBPFSnapshot
 type NetMsg []collector.NetConn
+type NetErrorMsg collector.NetError
 type LockGraphMsg []collector.LockEntry
 type LockTimelineMsg collector.TimelineEvent
 
@@ -108,6 +109,7 @@ type Model struct {
 	CPUHistory     []float64
 	SyscallCounts  map[string]uint64
 	NetConns       []collector.NetConn
+	NetErrors      []collector.NetError // eBPF RST/retransmit anomalies (#56), newest-first
 	MemStats       collector.MemStats
 	HeapStats      collector.HeapStats // eBPF malloc/free pairing (#53); empty without eBPF
 	HeapLiveHist   []float64           // live-heap bytes history for the F1 sparkline
@@ -419,6 +421,26 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case NetMsg:
 		m.NetConns = []collector.NetConn(v)
 		m.usingMockNet = false
+		return m, waitForNetEBPF(m.collectors.NetworkEBPF)
+
+	case NetErrorMsg:
+		// Real kernel network error (#56) — record it for the F3 Anomalies
+		// panel (newest-first, capped) and surface it in the net timeline feed
+		// (F3 events / F7). Only the real eBPF collector emits these.
+		ne := collector.NetError(v)
+		m.usingMockNet = false
+		m.NetErrors = append([]collector.NetError{ne}, m.NetErrors...)
+		if len(m.NetErrors) > 40 {
+			m.NetErrors = m.NetErrors[:40]
+		}
+		m.Timeline = append([]collector.TimelineEvent{{
+			Timestamp: ne.Timestamp,
+			Category:  "net",
+			Message:   netErrorMessage(ne),
+		}}, m.Timeline...)
+		if len(m.Timeline) > 120 {
+			m.Timeline = m.Timeline[:120]
+		}
 		return m, waitForNetEBPF(m.collectors.NetworkEBPF)
 
 	case LockGraphMsg:
@@ -1228,9 +1250,11 @@ func waitForNetEBPF(c *collector.NetworkEBPFCollector) tea.Cmd {
 		if ch == nil {
 			return TickMsg(time.Now())
 		}
-		v := <-ch
-		if conns, ok := v.([]collector.NetConn); ok {
-			return NetMsg(conns)
+		switch v := (<-ch).(type) {
+		case []collector.NetConn:
+			return NetMsg(v)
+		case collector.NetError:
+			return NetErrorMsg(v)
 		}
 		return TickMsg(time.Now())
 	}

--- a/internal/tui/net_view_test.go
+++ b/internal/tui/net_view_test.go
@@ -1,0 +1,108 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/trentas/ptop/pkg/collector"
+)
+
+// TestNetErrorMsgUpdatesState verifies a NetErrorMsg lands in the model
+// (newest-first), is mirrored into the net timeline feed, marks the network
+// source as real, and that F3 then renders the anomaly in the Anomalies panel.
+func TestNetErrorMsgUpdatesState(t *testing.T) {
+	m := NewModel(Config{PID: 1, FPS: 5, NoEBPF: true})
+	ne := collector.NetError{
+		Timestamp: time.Now(),
+		Kind:      "refused",
+		Remote:    "10.0.1.5:5432",
+		DetailMs:  1.5,
+	}
+	nm, _ := m.Update(NetErrorMsg(ne))
+	mm := nm.(Model)
+
+	if len(mm.NetErrors) != 1 || mm.NetErrors[0].Remote != ne.Remote {
+		t.Fatalf("NetErrors not recorded: %+v", mm.NetErrors)
+	}
+	if mm.usingMockNet {
+		t.Errorf("a real net error should clear usingMockNet")
+	}
+	// The error is mirrored into the timeline under the "net" category.
+	netTL := filterTimelineByCategory(mm.Timeline, "net")
+	if len(netTL) == 0 || !strings.Contains(netTL[0].Message, "refused") {
+		t.Errorf("net error not synthesized into the timeline: %+v", netTL)
+	}
+
+	mm.Width, mm.Height = 180, 50
+	mm.ActiveTab = TabNetwork
+	out := mm.View()
+	for _, want := range []string{"ANOMALIES", "refused", "10.0.1.5:5432"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("F3 network view missing %q with a net error present", want)
+		}
+	}
+}
+
+// TestNetErrorsNewestFirstCapped confirms the panel keeps the most recent
+// errors first and bounds the retained list.
+func TestNetErrorsNewestFirstCapped(t *testing.T) {
+	m := NewModel(Config{PID: 1, FPS: 5, NoEBPF: true})
+	for i := 0; i < 60; i++ {
+		nm, _ := m.Update(NetErrorMsg(collector.NetError{
+			Timestamp:   time.Now(),
+			Kind:        "retransmit",
+			Remote:      "1.2.3.4:443",
+			Retransmits: uint32(i),
+		}))
+		m = nm.(Model)
+	}
+	mm := m
+	if len(mm.NetErrors) != 40 {
+		t.Errorf("NetErrors len = %d, want cap 40", len(mm.NetErrors))
+	}
+	// Newest-first: the last appended (Retransmits=59) is at the head.
+	if mm.NetErrors[0].Retransmits != 59 {
+		t.Errorf("head Retransmits = %d, want 59 (newest-first)", mm.NetErrors[0].Retransmits)
+	}
+}
+
+// TestNetErrorMessage covers the one-line rendering per error kind.
+func TestNetErrorMessage(t *testing.T) {
+	cases := []struct {
+		name string
+		e    collector.NetError
+		want string
+	}{
+		{"refused with timing", collector.NetError{Kind: "refused", Remote: "10.0.1.5:5432", DetailMs: 1.5},
+			"refused → 10.0.1.5:5432 (RST 1.5ms)"},
+		{"refused no timing", collector.NetError{Kind: "refused", Remote: "10.0.1.5:5432"},
+			"refused → 10.0.1.5:5432"},
+		{"reset mid-stream", collector.NetError{Kind: "reset", Remote: "1.2.3.4:443", DetailMs: 42},
+			"reset → 1.2.3.4:443 mid-stream (42.0ms)"},
+		{"retransmit count", collector.NetError{Kind: "retransmit", Remote: "1.2.3.4:443", Retransmits: 7},
+			"retransmit ×7 → 1.2.3.4:443"},
+		{"unknown kind", collector.NetError{Kind: "weird", Remote: "h:1"}, "weird → h:1"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := netErrorMessage(c.e); got != c.want {
+				t.Errorf("netErrorMessage = %q, want %q", got, c.want)
+			}
+		})
+	}
+}
+
+// TestNetAnomaliesHonestSource confirms the panel never invents anomalies:
+// a real (non-mock) source with no errors reads healthy; a mock source says
+// the capability needs eBPF.
+func TestNetAnomaliesHonestSource(t *testing.T) {
+	real := Model{usingMockNet: false}
+	if got := renderNetAnomalies(real, 40, 5); !strings.Contains(got, "no network errors") {
+		t.Errorf("real source, no errors = %q, want healthy", got)
+	}
+	mock := Model{usingMockNet: true}
+	if got := renderNetAnomalies(mock, 40, 5); !strings.Contains(got, "eBPF") {
+		t.Errorf("mock source = %q, want eBPF hint", got)
+	}
+}

--- a/internal/tui/snapshot.go
+++ b/internal/tui/snapshot.go
@@ -30,6 +30,7 @@ type SnapshotData struct {
 	CPUHistory     []float64                 `json:"cpu_history"`
 	SyscallCounts  map[string]uint64         `json:"syscall_counts"`
 	NetConns       []collector.NetConn       `json:"network_connections"`
+	NetErrors      []collector.NetError      `json:"network_errors"`
 	MemStats       collector.MemStats        `json:"memory"`
 	HeapStats      collector.HeapStats       `json:"heap"`
 	Threads        []collector.ThreadInfo    `json:"threads"`
@@ -54,6 +55,7 @@ func buildSnapshot(m Model) Snapshot {
 			CPUHistory:     append([]float64(nil), m.CPUHistory...),
 			SyscallCounts:  copyUintMap(m.SyscallCounts),
 			NetConns:       append([]collector.NetConn(nil), m.NetConns...),
+			NetErrors:      append([]collector.NetError(nil), m.NetErrors...),
 			MemStats:       m.MemStats,
 			HeapStats:      m.HeapStats,
 			Threads:        append([]collector.ThreadInfo(nil), m.Threads...),

--- a/internal/tui/view_network.go
+++ b/internal/tui/view_network.go
@@ -5,6 +5,8 @@ import (
 	"strings"
 
 	"github.com/charmbracelet/lipgloss"
+
+	"github.com/trentas/ptop/pkg/collector"
 )
 
 // renderNetworkView (F3) — assets/mockup.jsx → NetworkView
@@ -12,6 +14,8 @@ import (
 //   ┌── Active Connections (left) ──────────────┬── Network Events ─┐
 //   │ TYPE REMOTE       STATE   LAT      TX/RX   │ 12:34 NET TCP …   │
 //   │ ...                                         │                   │
+//   ├── Anomalies ────────────────────────┤                          │
+//   │ ⚠ refused → 10.0.1.5:5432 (RST 1.5ms)│                          │
 //   ├── Latency Trend ────────────────────┤                          │
 //   │ remote        ▇▇▇▇▇▇  42ms          │                          │
 //   └─────────────────────────────────────┴──────────────────────────┘
@@ -22,22 +26,78 @@ func renderNetworkView(m Model, w, h int) string {
 	leftW := w * 2 / 3
 	rightW := w - leftW
 
-	leftHs := splitFlex([]float64{1.0, 1.5}, h)
+	leftHs := splitFlex([]float64{1.0, 0.7, 1.3}, h)
 
 	conns := Panel("Active Connections",
 		renderNetMini(m.NetConns, leftW-2, leftHs[0]-3, true),
 		leftW, leftHs[0])
 
+	anomalies := Panel("Anomalies",
+		renderNetAnomalies(m, leftW-2, leftHs[1]-3),
+		leftW, leftHs[1])
+
 	latency := Panel("Latency Trend",
 		renderNetLatencyTrend(m, leftW-2),
-		leftW, leftHs[1])
+		leftW, leftHs[2])
 
 	stream := Panel("Network Events",
 		renderTimelineCompact(filterTimelineByCategory(m.Timeline, "net"), rightW-2, h-3),
 		rightW, h)
 
-	left := lipgloss.JoinVertical(lipgloss.Left, conns, latency)
+	left := lipgloss.JoinVertical(lipgloss.Left, conns, anomalies, latency)
 	return lipgloss.JoinHorizontal(lipgloss.Top, left, stream)
+}
+
+// renderNetAnomalies lists recent kernel network errors (#56) newest-first.
+// Errors only ever come from the real eBPF collector — never simulated — so a
+// mock network source honestly reports that they're unavailable rather than
+// inventing anomalies.
+func renderNetAnomalies(m Model, w, h int) string {
+	if len(m.NetErrors) == 0 {
+		if m.usingMockNet {
+			return MutedStyle.Render("(net errors need eBPF)")
+		}
+		return GreenStyle.Render("✓ no network errors")
+	}
+	lines := []string{}
+	for _, e := range m.NetErrors {
+		if h > 0 && len(lines) >= h {
+			break
+		}
+		style := lipgloss.NewStyle().Foreground(netErrorColor(e.Kind)).Background(ColorPanel)
+		lines = append(lines, style.Render(truncate("⚠ "+netErrorMessage(e), w)))
+	}
+	return strings.Join(lines, "\n")
+}
+
+// netErrorMessage renders a NetError as a one-line cause + peer + timing, used
+// both by the Anomalies panel and the synthesized net-timeline entry.
+func netErrorMessage(e collector.NetError) string {
+	switch e.Kind {
+	case "refused":
+		if e.DetailMs > 0 {
+			return fmt.Sprintf("refused → %s (RST %.1fms)", e.Remote, e.DetailMs)
+		}
+		return fmt.Sprintf("refused → %s", e.Remote)
+	case "reset":
+		if e.DetailMs > 0 {
+			return fmt.Sprintf("reset → %s mid-stream (%.1fms)", e.Remote, e.DetailMs)
+		}
+		return fmt.Sprintf("reset → %s mid-stream", e.Remote)
+	case "retransmit":
+		return fmt.Sprintf("retransmit ×%d → %s", e.Retransmits, e.Remote)
+	default:
+		return fmt.Sprintf("%s → %s", e.Kind, e.Remote)
+	}
+}
+
+// netErrorColor maps an error kind to a severity color: a fatal RST is red,
+// a retransmit (recoverable backoff) is amber.
+func netErrorColor(kind string) lipgloss.Color {
+	if kind == "retransmit" {
+		return ColorAmber
+	}
+	return ColorRed
 }
 
 func renderNetLatencyTrend(m Model, w int) string {


### PR DESCRIPTION
Part of #52, completes **#56**. **PR2 of 2** — the TUI surface for the kernel network errors PR1 (#78) added to the collector + gRPC stream. **Stacked on `feat/net-errors`** (#78).

> ⚠️ **Merge order**: merge #78 first, then **retarget this PR to `main` before #78's branch is deleted** (this repo auto-closes dependent PRs when the base branch is deleted on merge).

## What

Extends **F3 Network** with the failures #56 asks for: a recent errors/anomalies list with cause + timing.

- **model**: `NetErrorMsg` + a capped (40), newest-first `m.NetErrors`. `waitForNetEBPF` now demuxes both `[]NetConn` and `NetError` off the shared collector channel, each re-arming. Every error is also synthesized into the `"net"` timeline, so it appears in the F3 events feed **and** F7 Timeline.
- **view_network**: a new **`▸ Anomalies`** sub-panel in F3's left column, one severity-colored line per recent error (red for an RST refused/reset, amber for a retransmit) rendered by `netErrorMessage` (e.g. `⚠ refused → 10.0.1.5:5432 (RST 1.5ms)`). The mockup is silent on a F3 errors row, so this reuses F5's existing anomaly-box idiom.
- **snapshot**: `NetErrors` added to the JSON/JSONL export.

## Honesty about the source

Net errors are **never simulated** — they only ever come from the real eBPF collector. So the panel reads:
- `(net errors need eBPF)` when the network source is mock,
- `✓ no network errors` when the source is real but nothing has failed,
- the error lines when real errors arrive.

(No separate `?`-overlay row: net errors ride the existing **network** eBPF source, not a new collector.)

## Testing
- `TestNetErrorMsgUpdatesState` (msg → state + timeline synth + F3 render), `TestNetErrorsNewestFirstCapped`, `TestNetErrorMessage` (per-kind rendering), `TestNetAnomaliesHonestSource`.
- Verified: default + `-tags=ebpf` (darwin stub) + `GOOS=linux` non-ebpf build/vet/test, full TUI suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)