### PR TITLE
io: filesystem semantics — denials, deletes, renames (#57)

### DIFF
--- a/internal/bpf/io.go
+++ b/internal/bpf/io.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"os"
 
 	"github.com/cilium/ebpf"
 	"github.com/cilium/ebpf/link"
@@ -36,12 +37,35 @@ const (
 	IOOpWrite uint32 = 1
 )
 
-// IOTracer loads io.bpf.o, attaches sys_enter/exit_read/write tracepoints,
-// opens a ring buffer reader and exposes Next() to deliver parsed events.
+// FSEventRecord is the 1:1 layout of struct fs_event in programs/io.bpf.c (#57).
+// Fixed size 536 bytes; binary.LittleEndian parses it directly from the fs_events
+// ring buffer. Path/NewPath are NUL-terminated C strings in fixed buffers
+// (decoded + trimmed on the collector side).
+type FSEventRecord struct {
+	TsNs    uint64
+	TGID    uint32
+	Ret     int32 // syscall return: negative errno on failure, >=0 on success
+	Op      uint32
+	_       uint32 // pad
+	Path    [256]byte
+	NewPath [256]byte
+}
+
+// FS op codes — must match FS_OP_* in programs/io.bpf.c.
+const (
+	FSOpOpenDenied uint32 = 0
+	FSOpUnlink     uint32 = 1
+	FSOpRename     uint32 = 2
+)
+
+// IOTracer loads io.bpf.o, attaches the read/write tracepoints (throughput) and
+// the fs-semantics tracepoints (#57), and opens two ring buffer readers: Next()
+// delivers throughput events, NextFSEvent() delivers fs events.
 type IOTracer struct {
 	coll  *ebpf.Collection
 	links []link.Link
 	rb    *ringbuf.Reader
+	fsrb  *ringbuf.Reader // #57 — fs_events channel
 }
 
 func OpenIOTracer(pid int) (*IOTracer, error) {
@@ -101,6 +125,43 @@ func OpenIOTracer(pid int) (*IOTracer, error) {
 		t.links = append(t.links, l)
 	}
 
+	// fs-semantics tracepoints (#57). Attached NON-fatally: the legacy
+	// open/unlink/rename/renameat tracepoints don't exist on arm64 (only the
+	// *at variants do), and a kernel could lack one — losing it just narrows fs
+	// capture, it must not kill the throughput tracer. The *at variants exist on
+	// every supported arch and cover all libc-routed filesystem calls.
+	fsAttachments := []struct {
+		group, name, prog string
+	}{
+		{"syscalls", "sys_enter_openat", "handle_enter_openat"},
+		{"syscalls", "sys_exit_openat", "handle_exit_openat"},
+		{"syscalls", "sys_enter_open", "handle_enter_open"},
+		{"syscalls", "sys_exit_open", "handle_exit_open"},
+		{"syscalls", "sys_enter_unlinkat", "handle_enter_unlinkat"},
+		{"syscalls", "sys_exit_unlinkat", "handle_exit_unlinkat"},
+		{"syscalls", "sys_enter_unlink", "handle_enter_unlink"},
+		{"syscalls", "sys_exit_unlink", "handle_exit_unlink"},
+		{"syscalls", "sys_enter_renameat2", "handle_enter_renameat2"},
+		{"syscalls", "sys_exit_renameat2", "handle_exit_renameat2"},
+		{"syscalls", "sys_enter_renameat", "handle_enter_renameat"},
+		{"syscalls", "sys_exit_renameat", "handle_exit_renameat"},
+		{"syscalls", "sys_enter_rename", "handle_enter_rename"},
+		{"syscalls", "sys_exit_rename", "handle_exit_rename"},
+	}
+	for _, a := range fsAttachments {
+		prog := coll.Programs[a.prog]
+		if prog == nil {
+			fmt.Fprintf(os.Stderr, "io: program %s missing; fs semantics degraded\n", a.prog)
+			continue
+		}
+		l, err := link.Tracepoint(a.group, a.name, prog, nil)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "io: attach %s/%s failed (%v); fs semantics degraded\n", a.group, a.name, err)
+			continue
+		}
+		t.links = append(t.links, l)
+	}
+
 	// Open ring buffer reader. Reads block until an event arrives or Close.
 	eventsMap := coll.Maps["io_events"]
 	if eventsMap == nil {
@@ -113,6 +174,20 @@ func OpenIOTracer(pid int) (*IOTracer, error) {
 		return nil, fmt.Errorf("ringbuf reader: %w", err)
 	}
 	t.rb = rb
+
+	// fs_events ring buffer (#57). Part of our own program — a miss means a
+	// corrupt object, so it's fatal (matching io_events above).
+	fsMap := coll.Maps["fs_events"]
+	if fsMap == nil {
+		t.Close()
+		return nil, errors.New("fs_events ringbuf missing")
+	}
+	fsrb, err := ringbuf.NewReader(fsMap)
+	if err != nil {
+		t.Close()
+		return nil, fmt.Errorf("fs ringbuf reader: %w", err)
+	}
+	t.fsrb = fsrb
 
 	return t, nil
 }
@@ -140,13 +215,42 @@ func (t *IOTracer) Next() (IOEvent, error) {
 	return ev, nil
 }
 
+// NextFSEvent blocks until the next fs-semantics event (#57) arrives from the
+// kernel. Returns io.EOF once the tracer is closed. A short/garbled record is
+// reported as an error but does not close the stream — the caller keeps reading.
+func (t *IOTracer) NextFSEvent() (FSEventRecord, error) {
+	var rec FSEventRecord
+	if t == nil || t.fsrb == nil {
+		return rec, errors.New("tracer not initialized")
+	}
+	r, err := t.fsrb.Read()
+	if err != nil {
+		if errors.Is(err, ringbuf.ErrClosed) {
+			return rec, io.EOF
+		}
+		return rec, err
+	}
+	if len(r.RawSample) < 536 {
+		return rec, fmt.Errorf("short fs event: %d bytes", len(r.RawSample))
+	}
+	if err := binary.Read(bytes.NewReader(r.RawSample), binary.LittleEndian, &rec); err != nil {
+		return rec, fmt.Errorf("decode fs event: %w", err)
+	}
+	return rec, nil
+}
+
 func (t *IOTracer) Close() error {
 	if t == nil {
 		return nil
 	}
+	// Close the readers first so blocked Next/NextFSEvent unblock with io.EOF.
 	if t.rb != nil {
 		_ = t.rb.Close()
 		t.rb = nil
+	}
+	if t.fsrb != nil {
+		_ = t.fsrb.Close()
+		t.fsrb = nil
 	}
 	for _, l := range t.links {
 		_ = l.Close()

--- a/internal/bpf/programs/io.bpf.c
+++ b/internal/bpf/programs/io.bpf.c
@@ -1,15 +1,21 @@
 // SPDX-License-Identifier: GPL-2.0
 //
-// io.bpf.c — traces synchronous I/O syscalls (read/write/pread64/pwrite64)
-// of the target PID, measures per-call latency and emits events via ring buffer.
+// io.bpf.c — traces synchronous I/O syscalls (read/write) of the target PID,
+// measures per-call latency, AND captures filesystem *semantics* (#57):
+// permission denials (open/openat → EACCES/EPERM), deletes (unlink/unlinkat),
+// and renames (rename/renameat2) with their real paths. Both rides the same
+// process-context target filter (is_io_target) but uses separate maps + a
+// separate ring buffer so the fs-event path is independent of the throughput
+// path. Events are emitted via ring buffers.
 //
 // Maps:
 //   io_target_pid       ARRAY[1]   struct target_filter (written by the Go loader)
 //   io_inflight_map     HASH       tgid_pid → {ts_ns, fd, op, count_req}
-//                                  tracks an in-flight syscall to correlate
+//                                  tracks an in-flight read/write to correlate
 //                                  enter/exit
-//   io_events           RINGBUF    channel to user-space — each event contains
-//                                  fd, op type, bytes read/written, latency
+//   io_events           RINGBUF    throughput channel — fd, op, bytes, latency
+//   fs_inflight_map     HASH       tgid_pid → {op, path ptr, newpath ptr} (#57)
+//   fs_events           RINGBUF    fs-semantics channel — op, ret, path(s) (#57)
 //
 // Why syscall-level (not block-level)?
 //   block:block_rq_* gives REAL disk latency (excludes cache). But resolving
@@ -162,5 +168,211 @@ int handle_exit_write(struct sys_exit_args *ctx)
     if (!is_io_target())
         return 0;
     exit_io(ctx->ret);
+    return 0;
+}
+
+// ─── #57 filesystem semantics: permission denials, deletes, renames ───────────
+//
+// These syscalls run in process context, so they reuse is_io_target(). We stash
+// the user-space path pointer(s) at sys_enter and read the string at sys_exit
+// (where the return value — hence EACCES/EPERM — is known). The user path buffer
+// is still mapped at exit (same task), so reading the pointer there is valid —
+// the proven libbpf-tools opensnoop approach, which avoids carrying a large
+// string through the inflight map.
+
+#define FS_OP_OPEN_DENIED 0 // open/openat returned EACCES/EPERM
+#define FS_OP_UNLINK      1 // unlink/unlinkat
+#define FS_OP_RENAME      2 // rename/renameat/renameat2
+
+#define EACCES 13
+#define EPERM  1
+
+#define FS_PATH_MAX 256
+
+// Generic sys_enter layout: common header (8B) + syscall nr (widened to 8B) +
+// up to 6 args, each widened to unsigned long in the tracepoint record (the
+// same widening the read/write sys_enter_rw_args above relies on).
+struct sys_enter_args {
+    unsigned long long _pad;
+    long id;
+    unsigned long args[6];
+};
+
+// fs_inflight stashes the user path pointer(s) between sys_enter and sys_exit.
+// Keyed by pid_tgid — a thread is in exactly one syscall at a time, so no
+// overwrite races. Tiny value (pointers only); the string is read at exit.
+struct fs_inflight {
+    __u32 op;
+    __u64 path;    // const char __user *
+    __u64 newpath; // const char __user * (RENAME); 0 otherwise
+};
+
+// fs_event is published to user-space via the fs_events ring buffer. Fixed
+// layout (536 bytes), read with binary.LittleEndian on the Go side — keep in
+// sync with FSEventRecord in internal/bpf/io.go.
+struct fs_event {
+    __u64 ts_ns;
+    __u32 tgid;
+    __s32 ret; // syscall return: negative errno on failure, >=0 on success
+    __u32 op;  // FS_OP_*
+    __u32 _pad;
+    char  path[FS_PATH_MAX];
+    char  newpath[FS_PATH_MAX]; // RENAME destination; "" otherwise
+};
+
+struct {
+    __uint(type, BPF_MAP_TYPE_HASH);
+    __type(key, __u64);
+    __type(value, struct fs_inflight);
+    __uint(max_entries, 10240);
+} fs_inflight_map SEC(".maps");
+
+struct {
+    __uint(type, BPF_MAP_TYPE_RINGBUF);
+    __uint(max_entries, 1 << 19); // 512KB — fs events are low-rate
+} fs_events SEC(".maps");
+
+static __always_inline void fs_enter(__u32 op, __u64 path, __u64 newpath)
+{
+    if (!is_io_target())
+        return;
+    __u64 pid_tgid = bpf_get_current_pid_tgid();
+    struct fs_inflight inf = {
+        .op      = op,
+        .path    = path,
+        .newpath = newpath,
+    };
+    bpf_map_update_elem(&fs_inflight_map, &pid_tgid, &inf, BPF_ANY);
+}
+
+// fs_exit publishes the event when warranted. For OPEN we only surface denials
+// (EACCES/EPERM); unlink/rename always publish — a failed delete/rename is still
+// notable — carrying the errno in ret. The inflight lookup is itself the target
+// filter (only target threads ever stash an entry), so no is_io_target() here.
+static __always_inline void fs_exit(long ret)
+{
+    __u64 pid_tgid = bpf_get_current_pid_tgid();
+    struct fs_inflight *inf = bpf_map_lookup_elem(&fs_inflight_map, &pid_tgid);
+    if (!inf)
+        return;
+    __u32 op = inf->op;
+    __u64 path = inf->path;
+    __u64 newpath = inf->newpath;
+    bpf_map_delete_elem(&fs_inflight_map, &pid_tgid);
+
+    if (op == FS_OP_OPEN_DENIED && ret != -EACCES && ret != -EPERM)
+        return;
+
+    struct fs_event *e = bpf_ringbuf_reserve(&fs_events, sizeof(*e), 0);
+    if (!e)
+        return;
+    e->ts_ns      = bpf_ktime_get_ns();
+    e->tgid       = (__u32)(pid_tgid >> 32);
+    e->ret        = (__s32)ret;
+    e->op         = op;
+    e->_pad       = 0;
+    e->path[0]    = '\0';
+    e->newpath[0] = '\0';
+    if (path)
+        bpf_probe_read_user_str(e->path, sizeof(e->path), (const void *)path);
+    if (newpath)
+        bpf_probe_read_user_str(e->newpath, sizeof(e->newpath), (const void *)newpath);
+    bpf_ringbuf_submit(e, 0);
+}
+
+// open(filename, …) → args[0]; openat(dfd, filename, …) → args[1]. Modern glibc
+// routes open()→openat, and arm64 has no open/unlink/rename — the Go loader
+// attaches the legacy variants non-fatally for raw-syscall callers on x86_64.
+SEC("tracepoint/syscalls/sys_enter_openat")
+int handle_enter_openat(struct sys_enter_args *ctx)
+{
+    fs_enter(FS_OP_OPEN_DENIED, ctx->args[1], 0);
+    return 0;
+}
+SEC("tracepoint/syscalls/sys_exit_openat")
+int handle_exit_openat(struct sys_exit_args *ctx)
+{
+    fs_exit(ctx->ret);
+    return 0;
+}
+
+SEC("tracepoint/syscalls/sys_enter_open")
+int handle_enter_open(struct sys_enter_args *ctx)
+{
+    fs_enter(FS_OP_OPEN_DENIED, ctx->args[0], 0);
+    return 0;
+}
+SEC("tracepoint/syscalls/sys_exit_open")
+int handle_exit_open(struct sys_exit_args *ctx)
+{
+    fs_exit(ctx->ret);
+    return 0;
+}
+
+// unlink(pathname) → args[0]; unlinkat(dfd, pathname, flag) → args[1].
+SEC("tracepoint/syscalls/sys_enter_unlinkat")
+int handle_enter_unlinkat(struct sys_enter_args *ctx)
+{
+    fs_enter(FS_OP_UNLINK, ctx->args[1], 0);
+    return 0;
+}
+SEC("tracepoint/syscalls/sys_exit_unlinkat")
+int handle_exit_unlinkat(struct sys_exit_args *ctx)
+{
+    fs_exit(ctx->ret);
+    return 0;
+}
+
+SEC("tracepoint/syscalls/sys_enter_unlink")
+int handle_enter_unlink(struct sys_enter_args *ctx)
+{
+    fs_enter(FS_OP_UNLINK, ctx->args[0], 0);
+    return 0;
+}
+SEC("tracepoint/syscalls/sys_exit_unlink")
+int handle_exit_unlink(struct sys_exit_args *ctx)
+{
+    fs_exit(ctx->ret);
+    return 0;
+}
+
+// rename(old, new) → args[0],args[1]; renameat/renameat2(olddfd, old, newdfd,
+// new, …) → args[1],args[3].
+SEC("tracepoint/syscalls/sys_enter_renameat2")
+int handle_enter_renameat2(struct sys_enter_args *ctx)
+{
+    fs_enter(FS_OP_RENAME, ctx->args[1], ctx->args[3]);
+    return 0;
+}
+SEC("tracepoint/syscalls/sys_exit_renameat2")
+int handle_exit_renameat2(struct sys_exit_args *ctx)
+{
+    fs_exit(ctx->ret);
+    return 0;
+}
+
+SEC("tracepoint/syscalls/sys_enter_renameat")
+int handle_enter_renameat(struct sys_enter_args *ctx)
+{
+    fs_enter(FS_OP_RENAME, ctx->args[1], ctx->args[3]);
+    return 0;
+}
+SEC("tracepoint/syscalls/sys_exit_renameat")
+int handle_exit_renameat(struct sys_exit_args *ctx)
+{
+    fs_exit(ctx->ret);
+    return 0;
+}
+
+SEC("tracepoint/syscalls/sys_enter_rename")
+int handle_enter_rename(struct sys_enter_args *ctx)
+{
+    fs_enter(FS_OP_RENAME, ctx->args[0], ctx->args[1]);
+    return 0;
+}
+SEC("tracepoint/syscalls/sys_exit_rename")
+int handle_exit_rename(struct sys_exit_args *ctx)
+{
+    fs_exit(ctx->ret);
     return 0;
 }

--- a/internal/serve/mapper.go
+++ b/internal/serve/mapper.go
@@ -115,6 +115,14 @@ func toEvent(pid int, buildID string, v interface{}) *pb.Event {
 			LatencyBuckets: latencyBuckets(x.Buckets),
 		}}
 
+	case collector.FSEvent:
+		ev.TsUnixNano = tsNano(x.Timestamp)
+		ev.Category = pb.Category_CATEGORY_IO
+		ev.Payload = &pb.Event_FsEvent{FsEvent: &pb.FSEvent{
+			Op: x.Op, Path: x.Path, NewPath: x.NewPath,
+			Errno: x.Errno, Err: x.Err,
+		}}
+
 	case []collector.FDEntry:
 		ev.TsUnixNano = nowNano()
 		ev.Category = pb.Category_CATEGORY_FD

--- a/internal/tui/fs_view_test.go
+++ b/internal/tui/fs_view_test.go
@@ -1,0 +1,116 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/trentas/ptop/pkg/collector"
+)
+
+// TestFSEventMsgUpdatesState verifies an FSEventMsg lands in the model
+// (newest-first), is mirrored into the I/O timeline feed, marks the io-files
+// source as real, and that F5 then renders a denial in the Anomalies panel.
+func TestFSEventMsgUpdatesState(t *testing.T) {
+	m := NewModel(Config{PID: 1, FPS: 5, NoEBPF: true})
+	fe := collector.FSEvent{
+		Timestamp: time.Now(),
+		Op:        "denied",
+		Path:      "/etc/shadow",
+		Errno:     13,
+		Err:       "EACCES",
+	}
+	nm, _ := m.Update(FSEventMsg(fe))
+	mm := nm.(Model)
+
+	if len(mm.FSEvents) != 1 || mm.FSEvents[0].Path != fe.Path {
+		t.Fatalf("FSEvents not recorded: %+v", mm.FSEvents)
+	}
+	if mm.usingMockIOFiles {
+		t.Errorf("a real fs event should clear usingMockIOFiles")
+	}
+	// The event is mirrored into the timeline under the "io" category.
+	ioTL := filterTimelineByCategory(mm.Timeline, "io")
+	if len(ioTL) == 0 || !strings.Contains(ioTL[0].Message, "denied") {
+		t.Errorf("fs event not synthesized into the timeline: %+v", ioTL)
+	}
+
+	mm.Width, mm.Height = 180, 50
+	mm.ActiveTab = TabIO
+	out := mm.View()
+	for _, want := range []string{"ANOMALIES", "denied", "/etc/shadow", "EACCES"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("F5 I/O view missing %q with a denial present", want)
+		}
+	}
+}
+
+// TestFSEventsNewestFirstCapped confirms the list keeps the most recent events
+// first and bounds the retained slice.
+func TestFSEventsNewestFirstCapped(t *testing.T) {
+	m := NewModel(Config{PID: 1, FPS: 5, NoEBPF: true})
+	for i := 0; i < 60; i++ {
+		op := "deleted"
+		if i%2 == 0 {
+			op = "denied"
+		}
+		nm, _ := m.Update(FSEventMsg(collector.FSEvent{
+			Timestamp: time.Now(),
+			Op:        op,
+			Path:      "/tmp/f",
+			Errno:     int32(i), // tag for ordering assertion
+		}))
+		m = nm.(Model)
+	}
+	mm := m
+	if len(mm.FSEvents) != 40 {
+		t.Errorf("FSEvents len = %d, want cap 40", len(mm.FSEvents))
+	}
+	if mm.FSEvents[0].Errno != 59 {
+		t.Errorf("head Errno = %d, want 59 (newest-first)", mm.FSEvents[0].Errno)
+	}
+}
+
+// TestFSEventMessage covers the one-line rendering per op.
+func TestFSEventMessage(t *testing.T) {
+	cases := []struct {
+		name string
+		e    collector.FSEvent
+		want string
+	}{
+		{"denied", collector.FSEvent{Op: "denied", Path: "/etc/shadow", Errno: 13, Err: "EACCES"},
+			"denied /etc/shadow (EACCES)"},
+		{"deleted ok", collector.FSEvent{Op: "deleted", Path: "/tmp/cache.bin"},
+			"deleted /tmp/cache.bin"},
+		{"delete failed", collector.FSEvent{Op: "deleted", Path: "/tmp/busy", Errno: 16, Err: "EBUSY"},
+			"delete failed /tmp/busy (EBUSY)"},
+		{"renamed ok", collector.FSEvent{Op: "renamed", Path: "/data/a.tmp", NewPath: "/data/a.db"},
+			"renamed /data/a.tmp → /data/a.db"},
+		{"unknown op", collector.FSEvent{Op: "weird", Path: "/x"}, "weird /x"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := fsEventMessage(c.e); got != c.want {
+				t.Errorf("fsEventMessage = %q, want %q", got, c.want)
+			}
+		})
+	}
+}
+
+// TestIOAnomaliesHonestSource confirms the panel never invents fs anomalies:
+// a real (non-mock) io-files source with no denials reads healthy; only the
+// mock source shows the simulated polling heuristic.
+func TestIOAnomaliesHonestSource(t *testing.T) {
+	real := Model{usingMockIOFiles: false}
+	got := renderIOAnomalies(real, 40, 5)
+	if !strings.Contains(got, "no permission denials") {
+		t.Errorf("real source, no denials = %q, want healthy", got)
+	}
+	if strings.Contains(got, "polling") {
+		t.Errorf("real source must not show the simulated polling line: %q", got)
+	}
+	mock := Model{usingMockIOFiles: true}
+	if got := renderIOAnomalies(mock, 40, 5); !strings.Contains(got, "polling") {
+		t.Errorf("mock source = %q, want the simulated polling line", got)
+	}
+}

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -83,6 +83,7 @@ type TimelineMsg collector.TimelineEvent
 type FDEventMsg collector.FDEvent
 type SyscallsMsg map[string]uint64
 type IOEBPFMsg collector.IOEBPFSnapshot
+type FSEventMsg collector.FSEvent
 type NetMsg []collector.NetConn
 type NetErrorMsg collector.NetError
 type LockGraphMsg []collector.LockEntry
@@ -115,6 +116,7 @@ type Model struct {
 	HeapLiveHist   []float64           // live-heap bytes history for the F1 sparkline
 	Threads        []collector.ThreadInfo
 	IOStats        collector.IOStats
+	FSEvents       []collector.FSEvent // eBPF fs semantics (#57): denials/deletes/renames, newest-first
 	IOReadHist     []float64
 	IOWriteHist    []float64
 	FDs            []collector.FDEntry
@@ -469,6 +471,27 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.IOStats.LatencyBuckets = s.Buckets
 		}
 		m.usingMockIOFiles = false
+		return m, waitForIOEBPF(m.collectors.IOEBPF)
+
+	case FSEventMsg:
+		// Real kernel filesystem event (#57) — record it for the F5 Anomalies
+		// panel (denials, newest-first, capped) and surface every fs event in
+		// the I/O timeline feed (F5 events / F7). Only the real eBPF io collector
+		// emits these, so a fs event also proves the io-files source is real.
+		fe := collector.FSEvent(v)
+		m.usingMockIOFiles = false
+		m.FSEvents = append([]collector.FSEvent{fe}, m.FSEvents...)
+		if len(m.FSEvents) > 40 {
+			m.FSEvents = m.FSEvents[:40]
+		}
+		m.Timeline = append([]collector.TimelineEvent{{
+			Timestamp: fe.Timestamp,
+			Category:  "io",
+			Message:   fsEventMessage(fe),
+		}}, m.Timeline...)
+		if len(m.Timeline) > 120 {
+			m.Timeline = m.Timeline[:120]
+		}
 		return m, waitForIOEBPF(m.collectors.IOEBPF)
 
 	case IOThroughputMsg:
@@ -1269,9 +1292,11 @@ func waitForIOEBPF(c *collector.IOEBPFCollector) tea.Cmd {
 		if ch == nil {
 			return TickMsg(time.Now())
 		}
-		v := <-ch
-		if s, ok := v.(collector.IOEBPFSnapshot); ok {
-			return IOEBPFMsg(s)
+		switch v := (<-ch).(type) {
+		case collector.IOEBPFSnapshot:
+			return IOEBPFMsg(v)
+		case collector.FSEvent:
+			return FSEventMsg(v)
 		}
 		return TickMsg(time.Now())
 	}

--- a/internal/tui/snapshot.go
+++ b/internal/tui/snapshot.go
@@ -35,6 +35,7 @@ type SnapshotData struct {
 	HeapStats      collector.HeapStats       `json:"heap"`
 	Threads        []collector.ThreadInfo    `json:"threads"`
 	IOStats        collector.IOStats         `json:"io"`
+	FSEvents       []collector.FSEvent       `json:"fs_events"`
 	IOReadHist     []float64                 `json:"io_read_history"`
 	IOWriteHist    []float64                 `json:"io_write_history"`
 	FDs            []collector.FDEntry       `json:"fds"`
@@ -60,6 +61,7 @@ func buildSnapshot(m Model) Snapshot {
 			HeapStats:      m.HeapStats,
 			Threads:        append([]collector.ThreadInfo(nil), m.Threads...),
 			IOStats:        m.IOStats,
+			FSEvents:       append([]collector.FSEvent(nil), m.FSEvents...),
 			IOReadHist:     append([]float64(nil), m.IOReadHist...),
 			IOWriteHist:    append([]float64(nil), m.IOWriteHist...),
 			FDs:            append([]collector.FDEntry(nil), m.FDs...),

--- a/internal/tui/view_io.go
+++ b/internal/tui/view_io.go
@@ -46,7 +46,7 @@ func renderIOView(m Model, w, h int) string {
 		rightW, rightHs[0])
 
 	anomalies := Panel("Anomalies",
-		renderIOAnomalies(m.IOStats),
+		renderIOAnomalies(m, rightW-2, rightHs[1]-3),
 		rightW, rightHs[1])
 
 	events := Panel("I/O Events",
@@ -239,20 +239,78 @@ func renderIOStats(s collector.IOStats, w int) string {
 	return strings.Join(lines, "\n")
 }
 
-func renderIOAnomalies(s collector.IOStats) string {
+// renderIOAnomalies surfaces, newest-first: real permission denials (#57, only
+// the eBPF io collector emits them), then the IOStats-derived fsync/I/O-wait
+// threshold anomalies. The "/proc/self/status polling" heuristic is simulated,
+// so it only appears in mock mode. With a real source and nothing wrong, it
+// honestly reports a healthy filesystem rather than inventing a warning.
+func renderIOAnomalies(m Model, w, h int) string {
 	lines := []string{}
-	if s.Fsyncs > 15 {
+	room := func() bool { return h <= 0 || len(lines) < h }
+
+	// Permission denials are the headline anomaly. Deletes/renames are events,
+	// not anomalies — they flow to the I/O Events feed, not here.
+	for _, e := range m.FSEvents {
+		if e.Op != "denied" || !room() {
+			continue
+		}
+		style := lipgloss.NewStyle().Foreground(fsEventColor(e.Op)).Background(ColorPanel)
+		lines = append(lines, style.Render(truncate("⚠ "+fsEventMessage(e), w)))
+	}
+
+	s := m.IOStats
+	if s.Fsyncs > 15 && room() {
 		lines = append(lines, RedStyle.Render("⚠ high fsync freq → /data/db"))
 	}
-	lines = append(lines, AmberStyle.Render("⚠ /proc/self/status: polling (×12/s)"))
-	if s.IOWaitPct > 15 {
+	if s.IOWaitPct > 15 && room() {
 		lines = append(lines, RedStyle.Render(fmt.Sprintf("⚠ I/O wait %.1f%% → disk saturated", s.IOWaitPct)))
 	}
-	if len(lines) == 1 {
-		// only the polling one — so add an OK
-		lines = append([]string{GreenStyle.Render("✓ throughput stable")}, lines...)
+	if m.usingMockIOFiles && room() {
+		lines = append(lines, AmberStyle.Render("⚠ /proc/self/status: polling (×12/s)"))
+	}
+
+	if len(lines) == 0 {
+		if m.usingMockIOFiles {
+			return GreenStyle.Render("✓ throughput stable")
+		}
+		return GreenStyle.Render("✓ no permission denials")
 	}
 	return strings.Join(lines, "\n")
+}
+
+// fsEventMessage renders an FSEvent as a one-line cause + path(s), used both by
+// the F5 Anomalies panel (denials) and the synthesized I/O-timeline entry
+// (every fs event).
+func fsEventMessage(e collector.FSEvent) string {
+	switch e.Op {
+	case "denied":
+		return fmt.Sprintf("denied %s (%s)", e.Path, e.Err)
+	case "deleted":
+		if e.Errno != 0 {
+			return fmt.Sprintf("delete failed %s (%s)", e.Path, e.Err)
+		}
+		return fmt.Sprintf("deleted %s", e.Path)
+	case "renamed":
+		if e.Errno != 0 {
+			return fmt.Sprintf("rename failed %s → %s (%s)", e.Path, e.NewPath, e.Err)
+		}
+		return fmt.Sprintf("renamed %s → %s", e.Path, e.NewPath)
+	default:
+		return fmt.Sprintf("%s %s", e.Op, e.Path)
+	}
+}
+
+// fsEventColor maps an fs op to a severity color: a denial is red (a blocked
+// access), a delete amber (destructive), a rename muted (benign bookkeeping).
+func fsEventColor(op string) lipgloss.Color {
+	switch op {
+	case "denied":
+		return ColorRed
+	case "deleted":
+		return ColorAmber
+	default:
+		return ColorMuted
+	}
 }
 
 func thresholdColor(value, warn float64) lipgloss.Color {

--- a/pkg/collector/fs_decode.go
+++ b/pkg/collector/fs_decode.go
@@ -1,0 +1,95 @@
+package collector
+
+import (
+	"bytes"
+	"fmt"
+	"time"
+)
+
+// Filesystem op codes — must match FS_OP_* in internal/bpf/programs/io.bpf.c and
+// the FSOp* constants in internal/bpf/io.go. Duplicated here (rather than
+// imported from internal/bpf) so this decode logic compiles and is unit-tested
+// on any OS, not only the linux+ebpf lane — the same split network_error.go uses.
+const (
+	fsOpOpenDenied uint32 = 0
+	fsOpUnlink     uint32 = 1
+	fsOpRename     uint32 = 2
+)
+
+// fsOpName maps the kernel op code to the public FSEvent.Op verb.
+func fsOpName(op uint32) string {
+	switch op {
+	case fsOpOpenDenied:
+		return "denied"
+	case fsOpUnlink:
+		return "deleted"
+	case fsOpRename:
+		return "renamed"
+	default:
+		return "?"
+	}
+}
+
+// errnoName maps a positive errno to its symbolic name. Covers the errors that
+// actually show up on the open/unlink/rename paths; anything else falls back to
+// a numeric form so the value is never lost.
+func errnoName(errno int32) string {
+	switch errno {
+	case 0:
+		return ""
+	case 1:
+		return "EPERM"
+	case 2:
+		return "ENOENT"
+	case 13:
+		return "EACCES"
+	case 16:
+		return "EBUSY"
+	case 17:
+		return "EEXIST"
+	case 18:
+		return "EXDEV"
+	case 20:
+		return "ENOTDIR"
+	case 21:
+		return "EISDIR"
+	case 30:
+		return "EROFS"
+	case 36:
+		return "ENAMETOOLONG"
+	case 39:
+		return "ENOTEMPTY"
+	case 40:
+		return "ELOOP"
+	default:
+		return fmt.Sprintf("errno %d", errno)
+	}
+}
+
+// cstr decodes a NUL-terminated C string from a fixed kernel buffer, trimming at
+// the first NUL (or the whole buffer if unterminated).
+func cstr(b []byte) string {
+	if i := bytes.IndexByte(b, 0); i >= 0 {
+		return string(b[:i])
+	}
+	return string(b)
+}
+
+// decodeFSEvent builds an FSEvent from the raw fields of a fs_event record. ts
+// is the wall-clock capture time (stamped by the collector when the event is
+// drained — the kernel ts_ns is monotonic, not wall-clock). ret is the syscall
+// return: >=0 on success (Errno 0), negative errno on failure.
+func decodeFSEvent(ts time.Time, op uint32, ret int32, path, newpath []byte) FSEvent {
+	var errno int32
+	if ret < 0 {
+		errno = -ret
+	}
+	return FSEvent{
+		Timestamp: ts,
+		Op:        fsOpName(op),
+		Path:      cstr(path),
+		NewPath:   cstr(newpath),
+		Errno:     errno,
+		Err:       errnoName(errno),
+	}
+}

--- a/pkg/collector/fs_decode_test.go
+++ b/pkg/collector/fs_decode_test.go
@@ -1,0 +1,105 @@
+package collector
+
+import (
+	"testing"
+	"time"
+)
+
+func TestFSOpName(t *testing.T) {
+	cases := map[uint32]string{
+		fsOpOpenDenied: "denied",
+		fsOpUnlink:     "deleted",
+		fsOpRename:     "renamed",
+		99:             "?",
+	}
+	for code, want := range cases {
+		if got := fsOpName(code); got != want {
+			t.Errorf("fsOpName(%d) = %q, want %q", code, got, want)
+		}
+	}
+}
+
+func TestErrnoName(t *testing.T) {
+	cases := map[int32]string{
+		0:  "",
+		1:  "EPERM",
+		2:  "ENOENT",
+		13: "EACCES",
+		39: "ENOTEMPTY",
+		// Unknown errno falls back to a numeric form (never lost).
+		77: "errno 77",
+	}
+	for errno, want := range cases {
+		if got := errnoName(errno); got != want {
+			t.Errorf("errnoName(%d) = %q, want %q", errno, got, want)
+		}
+	}
+}
+
+func TestCstr(t *testing.T) {
+	// NUL-terminated: trim at the first NUL.
+	buf := make([]byte, 16)
+	copy(buf, "/etc/shadow")
+	if got := cstr(buf); got != "/etc/shadow" {
+		t.Errorf("cstr = %q, want /etc/shadow", got)
+	}
+	// Unterminated: the whole buffer is the string.
+	full := []byte("abcd")
+	if got := cstr(full); got != "abcd" {
+		t.Errorf("cstr(unterminated) = %q, want abcd", got)
+	}
+	// Empty (leading NUL) → "".
+	if got := cstr(make([]byte, 8)); got != "" {
+		t.Errorf("cstr(empty) = %q, want \"\"", got)
+	}
+}
+
+// pathBuf builds a fixed [256]byte kernel buffer from a string (NUL-padded).
+func pathBuf(s string) []byte {
+	b := make([]byte, 256)
+	copy(b, s)
+	return b
+}
+
+func TestDecodeFSEvent(t *testing.T) {
+	ts := time.Unix(1700000000, 0)
+
+	t.Run("open denial carries errno name", func(t *testing.T) {
+		fe := decodeFSEvent(ts, fsOpOpenDenied, -13, pathBuf("/etc/shadow"), pathBuf(""))
+		if fe.Op != "denied" {
+			t.Errorf("Op = %q, want denied", fe.Op)
+		}
+		if fe.Path != "/etc/shadow" {
+			t.Errorf("Path = %q", fe.Path)
+		}
+		if fe.Errno != 13 || fe.Err != "EACCES" {
+			t.Errorf("Errno/Err = %d/%q, want 13/EACCES", fe.Errno, fe.Err)
+		}
+		if fe.NewPath != "" {
+			t.Errorf("NewPath = %q, want empty", fe.NewPath)
+		}
+		if !fe.Timestamp.Equal(ts) {
+			t.Errorf("Timestamp = %v, want %v", fe.Timestamp, ts)
+		}
+	})
+
+	t.Run("successful delete has zero errno", func(t *testing.T) {
+		fe := decodeFSEvent(ts, fsOpUnlink, 0, pathBuf("/tmp/cache.bin"), pathBuf(""))
+		if fe.Op != "deleted" || fe.Path != "/tmp/cache.bin" {
+			t.Errorf("unexpected: %+v", fe)
+		}
+		if fe.Errno != 0 || fe.Err != "" {
+			t.Errorf("Errno/Err = %d/%q, want 0/\"\"", fe.Errno, fe.Err)
+		}
+	})
+
+	t.Run("rename carries both paths", func(t *testing.T) {
+		fe := decodeFSEvent(ts, fsOpRename, 0, pathBuf("/data/a.tmp"), pathBuf("/data/a.db"))
+		if fe.Op != "renamed" {
+			t.Errorf("Op = %q, want renamed", fe.Op)
+		}
+		if fe.Path != "/data/a.tmp" || fe.NewPath != "/data/a.db" {
+			t.Errorf("paths = %q → %q", fe.Path, fe.NewPath)
+		}
+	})
+}

--- a/pkg/collector/io_ebpf.go
+++ b/pkg/collector/io_ebpf.go
@@ -51,7 +51,9 @@ const ioPathCacheTTL = 2 * time.Second
 
 func NewIOEBPFCollector() *IOEBPFCollector {
 	return &IOEBPFCollector{
-		ch:      make(chan interface{}, 16),
+		// Buffered for the 500ms snapshot ticker plus bursty per-event fs
+		// events (#57); all senders drop on overflow.
+		ch:      make(chan interface{}, 64),
 		stop:    make(chan struct{}),
 		files:   make(map[string]*ioFileAgg),
 		pathFor: make(map[uint32]pathCacheEntry),
@@ -72,8 +74,12 @@ func (c *IOEBPFCollector) Start(pid int) error {
 	}
 	c.tracer = tracer
 	c.pid = pid
-	go c.readLoop()    // consumes ringbuf, populates c.files
+	go c.readLoop()    // consumes io_events ringbuf, populates c.files
 	go c.publishLoop() // every 500ms publishes a snapshot of the aggregates
+	// Drain fs-semantics events (#57). tracer is passed explicitly (not read
+	// from the field) so Stop()'s `c.tracer = nil` can't race this goroutine;
+	// Close() shuts the fs ring-buffer reader, unblocking NextFSEvent with io.EOF.
+	go c.fsReadLoop(tracer)
 	return nil
 }
 
@@ -103,6 +109,31 @@ func (c *IOEBPFCollector) readLoop() {
 			continue
 		}
 		c.processEvent(ev)
+	}
+}
+
+// fsReadLoop drains the fs-semantics ring buffer (#57), decoding each record
+// into an FSEvent and publishing it on the shared channel. It exits on io.EOF
+// (the tracer was closed). A garbled record is logged-by-skip — the stream
+// continues. Sends are non-blocking: under backpressure fs events are dropped,
+// consistent with every other collector.
+func (c *IOEBPFCollector) fsReadLoop(tracer *bpf.IOTracer) {
+	if tracer == nil {
+		return
+	}
+	for {
+		rec, err := tracer.NextFSEvent()
+		if err != nil {
+			if err == io.EOF {
+				return
+			}
+			continue // transient (short/garbled record) — keep reading
+		}
+		fe := decodeFSEvent(time.Now(), rec.Op, rec.Ret, rec.Path[:], rec.NewPath[:])
+		select {
+		case c.ch <- fe:
+		default:
+		}
 	}
 }
 

--- a/pkg/collector/types.go
+++ b/pkg/collector/types.go
@@ -170,6 +170,22 @@ type IOEvent struct {
 	FD        int
 }
 
+// FSEvent is a kernel-observed filesystem *semantic* event (#57): a permission
+// denial on open/openat ("denied"), a delete ("deleted"), or a rename
+// ("renamed"), captured with the real path(s). Op carries the semantic verb;
+// Errno/Err carry the syscall result (0/"" on success — deletes and renames are
+// emitted on success too, denials only on EACCES/EPERM). NewPath is the rename
+// destination, "" otherwise. Emitted only by the eBPF io collector (never
+// simulated); paths are kernel-truncated to 255 bytes.
+type FSEvent struct {
+	Timestamp time.Time
+	Op        string // "denied" | "deleted" | "renamed"
+	Path      string
+	NewPath   string // rename destination; "" otherwise
+	Errno     int32  // 0 on success; positive errno (EACCES=13, EPERM=1, …)
+	Err       string // "EACCES" | "EPERM" | "ENOENT" | "" …
+}
+
 type IOFileStats struct {
 	Path      string
 	Type      string // "db" | "log" | "cfg" | "tmp" | "proc"

--- a/pkg/streampb/event.pb.go
+++ b/pkg/streampb/event.pb.go
@@ -272,6 +272,7 @@ type Event struct {
 	//	*Event_Heap
 	//	*Event_HeapEvent
 	//	*Event_NetError
+	//	*Event_FsEvent
 	Payload       isEvent_Payload `protobuf_oneof:"payload"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
@@ -484,6 +485,15 @@ func (x *Event) GetNetError() *NetErrorEvent {
 	return nil
 }
 
+func (x *Event) GetFsEvent() *FSEvent {
+	if x != nil {
+		if x, ok := x.Payload.(*Event_FsEvent); ok {
+			return x.FsEvent
+		}
+	}
+	return nil
+}
+
 type isEvent_Payload interface {
 	isEvent_Payload()
 }
@@ -549,6 +559,10 @@ type Event_NetError struct {
 	NetError *NetErrorEvent `protobuf:"bytes,24,opt,name=net_error,json=netError,proto3,oneof"` // #56 — detailed network error
 }
 
+type Event_FsEvent struct {
+	FsEvent *FSEvent `protobuf:"bytes,25,opt,name=fs_event,json=fsEvent,proto3,oneof"` // #57 — filesystem semantics (denial/delete/rename)
+}
+
 func (*Event_Cpu) isEvent_Payload() {}
 
 func (*Event_Syscalls) isEvent_Payload() {}
@@ -578,6 +592,8 @@ func (*Event_Heap) isEvent_Payload() {}
 func (*Event_HeapEvent) isEvent_Payload() {}
 
 func (*Event_NetError) isEvent_Payload() {}
+
+func (*Event_FsEvent) isEvent_Payload() {}
 
 // ─── CPU ──────────────────────────────────────────────────────────────────
 type CpuSample struct {
@@ -1823,6 +1839,89 @@ func (x *IoSnapshot) GetLatencyBuckets() []*LatencyBucket {
 	return nil
 }
 
+// ─── Filesystem semantics (#57) ─────────────────────────────────────────────
+// FSEvent is a kernel-observed filesystem semantic event: a permission denial on
+// open/openat (op="denied", err EACCES/EPERM), a delete (op="deleted"), or a
+// rename (op="renamed"). new_path is the rename destination ("" otherwise);
+// errno/err carry the syscall result (0/"" on success — deletes and renames are
+// emitted on success too, denials only on failure). Category on the envelope is
+// IO; the event timestamp lives on the envelope.
+type FSEvent struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Op            string                 `protobuf:"bytes,1,opt,name=op,proto3" json:"op,omitempty"` // "denied" | "deleted" | "renamed"
+	Path          string                 `protobuf:"bytes,2,opt,name=path,proto3" json:"path,omitempty"`
+	NewPath       string                 `protobuf:"bytes,3,opt,name=new_path,json=newPath,proto3" json:"new_path,omitempty"` // rename destination; "" otherwise
+	Errno         int32                  `protobuf:"varint,4,opt,name=errno,proto3" json:"errno,omitempty"`                   // 0 on success; positive errno (EACCES=13, …)
+	Err           string                 `protobuf:"bytes,5,opt,name=err,proto3" json:"err,omitempty"`                        // "EACCES" | "EPERM" | "ENOENT" | "" …
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *FSEvent) Reset() {
+	*x = FSEvent{}
+	mi := &file_event_proto_msgTypes[20]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *FSEvent) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*FSEvent) ProtoMessage() {}
+
+func (x *FSEvent) ProtoReflect() protoreflect.Message {
+	mi := &file_event_proto_msgTypes[20]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use FSEvent.ProtoReflect.Descriptor instead.
+func (*FSEvent) Descriptor() ([]byte, []int) {
+	return file_event_proto_rawDescGZIP(), []int{20}
+}
+
+func (x *FSEvent) GetOp() string {
+	if x != nil {
+		return x.Op
+	}
+	return ""
+}
+
+func (x *FSEvent) GetPath() string {
+	if x != nil {
+		return x.Path
+	}
+	return ""
+}
+
+func (x *FSEvent) GetNewPath() string {
+	if x != nil {
+		return x.NewPath
+	}
+	return ""
+}
+
+func (x *FSEvent) GetErrno() int32 {
+	if x != nil {
+		return x.Errno
+	}
+	return 0
+}
+
+func (x *FSEvent) GetErr() string {
+	if x != nil {
+		return x.Err
+	}
+	return ""
+}
+
 // ─── File descriptors ───────────────────────────────────────────────────────
 type FdEntry struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
@@ -1839,7 +1938,7 @@ type FdEntry struct {
 
 func (x *FdEntry) Reset() {
 	*x = FdEntry{}
-	mi := &file_event_proto_msgTypes[20]
+	mi := &file_event_proto_msgTypes[21]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1851,7 +1950,7 @@ func (x *FdEntry) String() string {
 func (*FdEntry) ProtoMessage() {}
 
 func (x *FdEntry) ProtoReflect() protoreflect.Message {
-	mi := &file_event_proto_msgTypes[20]
+	mi := &file_event_proto_msgTypes[21]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1864,7 +1963,7 @@ func (x *FdEntry) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use FdEntry.ProtoReflect.Descriptor instead.
 func (*FdEntry) Descriptor() ([]byte, []int) {
-	return file_event_proto_rawDescGZIP(), []int{20}
+	return file_event_proto_rawDescGZIP(), []int{21}
 }
 
 func (x *FdEntry) GetFd() int32 {
@@ -1925,7 +2024,7 @@ type FdSnapshot struct {
 
 func (x *FdSnapshot) Reset() {
 	*x = FdSnapshot{}
-	mi := &file_event_proto_msgTypes[21]
+	mi := &file_event_proto_msgTypes[22]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1937,7 +2036,7 @@ func (x *FdSnapshot) String() string {
 func (*FdSnapshot) ProtoMessage() {}
 
 func (x *FdSnapshot) ProtoReflect() protoreflect.Message {
-	mi := &file_event_proto_msgTypes[21]
+	mi := &file_event_proto_msgTypes[22]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1950,7 +2049,7 @@ func (x *FdSnapshot) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use FdSnapshot.ProtoReflect.Descriptor instead.
 func (*FdSnapshot) Descriptor() ([]byte, []int) {
-	return file_event_proto_rawDescGZIP(), []int{21}
+	return file_event_proto_rawDescGZIP(), []int{22}
 }
 
 func (x *FdSnapshot) GetFds() []*FdEntry {
@@ -1971,7 +2070,7 @@ type FdEvent struct {
 
 func (x *FdEvent) Reset() {
 	*x = FdEvent{}
-	mi := &file_event_proto_msgTypes[22]
+	mi := &file_event_proto_msgTypes[23]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1983,7 +2082,7 @@ func (x *FdEvent) String() string {
 func (*FdEvent) ProtoMessage() {}
 
 func (x *FdEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_event_proto_msgTypes[22]
+	mi := &file_event_proto_msgTypes[23]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1996,7 +2095,7 @@ func (x *FdEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use FdEvent.ProtoReflect.Descriptor instead.
 func (*FdEvent) Descriptor() ([]byte, []int) {
-	return file_event_proto_rawDescGZIP(), []int{22}
+	return file_event_proto_rawDescGZIP(), []int{23}
 }
 
 func (x *FdEvent) GetMessage() string {
@@ -2022,7 +2121,7 @@ type LockEntry struct {
 
 func (x *LockEntry) Reset() {
 	*x = LockEntry{}
-	mi := &file_event_proto_msgTypes[23]
+	mi := &file_event_proto_msgTypes[24]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2034,7 +2133,7 @@ func (x *LockEntry) String() string {
 func (*LockEntry) ProtoMessage() {}
 
 func (x *LockEntry) ProtoReflect() protoreflect.Message {
-	mi := &file_event_proto_msgTypes[23]
+	mi := &file_event_proto_msgTypes[24]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2047,7 +2146,7 @@ func (x *LockEntry) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LockEntry.ProtoReflect.Descriptor instead.
 func (*LockEntry) Descriptor() ([]byte, []int) {
-	return file_event_proto_rawDescGZIP(), []int{23}
+	return file_event_proto_rawDescGZIP(), []int{24}
 }
 
 func (x *LockEntry) GetUaddr() uint64 {
@@ -2108,7 +2207,7 @@ type LockSnapshot struct {
 
 func (x *LockSnapshot) Reset() {
 	*x = LockSnapshot{}
-	mi := &file_event_proto_msgTypes[24]
+	mi := &file_event_proto_msgTypes[25]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2120,7 +2219,7 @@ func (x *LockSnapshot) String() string {
 func (*LockSnapshot) ProtoMessage() {}
 
 func (x *LockSnapshot) ProtoReflect() protoreflect.Message {
-	mi := &file_event_proto_msgTypes[24]
+	mi := &file_event_proto_msgTypes[25]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2133,7 +2232,7 @@ func (x *LockSnapshot) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LockSnapshot.ProtoReflect.Descriptor instead.
 func (*LockSnapshot) Descriptor() ([]byte, []int) {
-	return file_event_proto_rawDescGZIP(), []int{24}
+	return file_event_proto_rawDescGZIP(), []int{25}
 }
 
 func (x *LockSnapshot) GetLocks() []*LockEntry {
@@ -2154,7 +2253,7 @@ type TimelineEvent struct {
 
 func (x *TimelineEvent) Reset() {
 	*x = TimelineEvent{}
-	mi := &file_event_proto_msgTypes[25]
+	mi := &file_event_proto_msgTypes[26]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2166,7 +2265,7 @@ func (x *TimelineEvent) String() string {
 func (*TimelineEvent) ProtoMessage() {}
 
 func (x *TimelineEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_event_proto_msgTypes[25]
+	mi := &file_event_proto_msgTypes[26]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2179,7 +2278,7 @@ func (x *TimelineEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TimelineEvent.ProtoReflect.Descriptor instead.
 func (*TimelineEvent) Descriptor() ([]byte, []int) {
-	return file_event_proto_rawDescGZIP(), []int{25}
+	return file_event_proto_rawDescGZIP(), []int{26}
 }
 
 func (x *TimelineEvent) GetMessage() string {
@@ -2204,7 +2303,7 @@ const file_event_proto_rawDesc = "" +
 	"\x04line\x18\x03 \x01(\x05R\x04line\x12\x16\n" +
 	"\x06module\x18\x04 \x01(\tR\x06module\x12\x16\n" +
 	"\x06offset\x18\x05 \x01(\x04R\x06offset\x12\x19\n" +
-	"\bbuild_id\x18\x06 \x01(\tR\abuildId\"\x9b\a\n" +
+	"\bbuild_id\x18\x06 \x01(\tR\abuildId\"\xca\a\n" +
 	"\x05Event\x12 \n" +
 	"\fts_unix_nano\x18\x01 \x01(\x03R\n" +
 	"tsUnixNano\x12\x10\n" +
@@ -2228,7 +2327,8 @@ const file_event_proto_rawDesc = "" +
 	"\x04heap\x18\x16 \x01(\v2\x15.ptop.v1.HeapSnapshotH\x00R\x04heap\x123\n" +
 	"\n" +
 	"heap_event\x18\x17 \x01(\v2\x12.ptop.v1.HeapEventH\x00R\theapEvent\x125\n" +
-	"\tnet_error\x18\x18 \x01(\v2\x16.ptop.v1.NetErrorEventH\x00R\bnetErrorB\t\n" +
+	"\tnet_error\x18\x18 \x01(\v2\x16.ptop.v1.NetErrorEventH\x00R\bnetError\x12-\n" +
+	"\bfs_event\x18\x19 \x01(\v2\x10.ptop.v1.FSEventH\x00R\afsEventB\t\n" +
 	"\apayload\"(\n" +
 	"\tCpuSample\x12\x1b\n" +
 	"\tusage_pct\x18\x01 \x01(\x01R\busagePct\"V\n" +
@@ -2334,7 +2434,13 @@ const file_event_proto_rawDesc = "" +
 	"\x05opens\x18\x06 \x01(\x04R\x05opens\x12\x1e\n" +
 	"\vio_wait_pct\x18\a \x01(\x01R\tioWaitPct\x121\n" +
 	"\ttop_files\x18\b \x03(\v2\x14.ptop.v1.IoFileStatsR\btopFiles\x12?\n" +
-	"\x0flatency_buckets\x18\t \x03(\v2\x16.ptop.v1.LatencyBucketR\x0elatencyBuckets\"\x9c\x01\n" +
+	"\x0flatency_buckets\x18\t \x03(\v2\x16.ptop.v1.LatencyBucketR\x0elatencyBuckets\"p\n" +
+	"\aFSEvent\x12\x0e\n" +
+	"\x02op\x18\x01 \x01(\tR\x02op\x12\x12\n" +
+	"\x04path\x18\x02 \x01(\tR\x04path\x12\x19\n" +
+	"\bnew_path\x18\x03 \x01(\tR\anewPath\x12\x14\n" +
+	"\x05errno\x18\x04 \x01(\x05R\x05errno\x12\x10\n" +
+	"\x03err\x18\x05 \x01(\tR\x03err\"\x9c\x01\n" +
 	"\aFdEntry\x12\x0e\n" +
 	"\x02fd\x18\x01 \x01(\x05R\x02fd\x12\x12\n" +
 	"\x04type\x18\x02 \x01(\tR\x04type\x12\x12\n" +
@@ -2389,7 +2495,7 @@ func file_event_proto_rawDescGZIP() []byte {
 }
 
 var file_event_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
-var file_event_proto_msgTypes = make([]protoimpl.MessageInfo, 26)
+var file_event_proto_msgTypes = make([]protoimpl.MessageInfo, 27)
 var file_event_proto_goTypes = []any{
 	(Category)(0),              // 0: ptop.v1.Category
 	(*StackRef)(nil),           // 1: ptop.v1.StackRef
@@ -2412,12 +2518,13 @@ var file_event_proto_goTypes = []any{
 	(*IoFileStats)(nil),        // 18: ptop.v1.IoFileStats
 	(*LatencyBucket)(nil),      // 19: ptop.v1.LatencyBucket
 	(*IoSnapshot)(nil),         // 20: ptop.v1.IoSnapshot
-	(*FdEntry)(nil),            // 21: ptop.v1.FdEntry
-	(*FdSnapshot)(nil),         // 22: ptop.v1.FdSnapshot
-	(*FdEvent)(nil),            // 23: ptop.v1.FdEvent
-	(*LockEntry)(nil),          // 24: ptop.v1.LockEntry
-	(*LockSnapshot)(nil),       // 25: ptop.v1.LockSnapshot
-	(*TimelineEvent)(nil),      // 26: ptop.v1.TimelineEvent
+	(*FSEvent)(nil),            // 21: ptop.v1.FSEvent
+	(*FdEntry)(nil),            // 22: ptop.v1.FdEntry
+	(*FdSnapshot)(nil),         // 23: ptop.v1.FdSnapshot
+	(*FdEvent)(nil),            // 24: ptop.v1.FdEvent
+	(*LockEntry)(nil),          // 25: ptop.v1.LockEntry
+	(*LockSnapshot)(nil),       // 26: ptop.v1.LockSnapshot
+	(*TimelineEvent)(nil),      // 27: ptop.v1.TimelineEvent
 }
 var file_event_proto_depIdxs = []int32{
 	0,  // 0: ptop.v1.Event.category:type_name -> ptop.v1.Category
@@ -2430,26 +2537,27 @@ var file_event_proto_depIdxs = []int32{
 	16, // 7: ptop.v1.Event.io_wait:type_name -> ptop.v1.IoWaitSample
 	17, // 8: ptop.v1.Event.io_throughput:type_name -> ptop.v1.IoThroughputSample
 	20, // 9: ptop.v1.Event.io:type_name -> ptop.v1.IoSnapshot
-	22, // 10: ptop.v1.Event.fds:type_name -> ptop.v1.FdSnapshot
-	23, // 11: ptop.v1.Event.fd_event:type_name -> ptop.v1.FdEvent
-	25, // 12: ptop.v1.Event.locks:type_name -> ptop.v1.LockSnapshot
-	26, // 13: ptop.v1.Event.timeline:type_name -> ptop.v1.TimelineEvent
+	23, // 10: ptop.v1.Event.fds:type_name -> ptop.v1.FdSnapshot
+	24, // 11: ptop.v1.Event.fd_event:type_name -> ptop.v1.FdEvent
+	26, // 12: ptop.v1.Event.locks:type_name -> ptop.v1.LockSnapshot
+	27, // 13: ptop.v1.Event.timeline:type_name -> ptop.v1.TimelineEvent
 	13, // 14: ptop.v1.Event.heap:type_name -> ptop.v1.HeapSnapshot
 	11, // 15: ptop.v1.Event.heap_event:type_name -> ptop.v1.HeapEvent
 	9,  // 16: ptop.v1.Event.net_error:type_name -> ptop.v1.NetErrorEvent
-	5,  // 17: ptop.v1.SyscallSnapshot.stats:type_name -> ptop.v1.SyscallStat
-	7,  // 18: ptop.v1.NetworkSnapshot.conns:type_name -> ptop.v1.NetConn
-	12, // 19: ptop.v1.HeapSnapshot.top_call_sites:type_name -> ptop.v1.HeapCallSite
-	14, // 20: ptop.v1.ThreadSnapshot.threads:type_name -> ptop.v1.ThreadInfo
-	18, // 21: ptop.v1.IoSnapshot.top_files:type_name -> ptop.v1.IoFileStats
-	19, // 22: ptop.v1.IoSnapshot.latency_buckets:type_name -> ptop.v1.LatencyBucket
-	21, // 23: ptop.v1.FdSnapshot.fds:type_name -> ptop.v1.FdEntry
-	24, // 24: ptop.v1.LockSnapshot.locks:type_name -> ptop.v1.LockEntry
-	25, // [25:25] is the sub-list for method output_type
-	25, // [25:25] is the sub-list for method input_type
-	25, // [25:25] is the sub-list for extension type_name
-	25, // [25:25] is the sub-list for extension extendee
-	0,  // [0:25] is the sub-list for field type_name
+	21, // 17: ptop.v1.Event.fs_event:type_name -> ptop.v1.FSEvent
+	5,  // 18: ptop.v1.SyscallSnapshot.stats:type_name -> ptop.v1.SyscallStat
+	7,  // 19: ptop.v1.NetworkSnapshot.conns:type_name -> ptop.v1.NetConn
+	12, // 20: ptop.v1.HeapSnapshot.top_call_sites:type_name -> ptop.v1.HeapCallSite
+	14, // 21: ptop.v1.ThreadSnapshot.threads:type_name -> ptop.v1.ThreadInfo
+	18, // 22: ptop.v1.IoSnapshot.top_files:type_name -> ptop.v1.IoFileStats
+	19, // 23: ptop.v1.IoSnapshot.latency_buckets:type_name -> ptop.v1.LatencyBucket
+	22, // 24: ptop.v1.FdSnapshot.fds:type_name -> ptop.v1.FdEntry
+	25, // 25: ptop.v1.LockSnapshot.locks:type_name -> ptop.v1.LockEntry
+	26, // [26:26] is the sub-list for method output_type
+	26, // [26:26] is the sub-list for method input_type
+	26, // [26:26] is the sub-list for extension type_name
+	26, // [26:26] is the sub-list for extension extendee
+	0,  // [0:26] is the sub-list for field type_name
 }
 
 func init() { file_event_proto_init() }
@@ -2473,6 +2581,7 @@ func file_event_proto_init() {
 		(*Event_Heap)(nil),
 		(*Event_HeapEvent)(nil),
 		(*Event_NetError)(nil),
+		(*Event_FsEvent)(nil),
 	}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
@@ -2480,7 +2589,7 @@ func file_event_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_event_proto_rawDesc), len(file_event_proto_rawDesc)),
 			NumEnums:      1,
-			NumMessages:   26,
+			NumMessages:   27,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/proto/event.proto
+++ b/proto/event.proto
@@ -76,8 +76,9 @@ message Event {
     HeapSnapshot heap = 22; // #53 — periodic heap aggregate
     HeapEvent heap_event = 23; // #53 — per alloc/free
     NetErrorEvent net_error = 24; // #56 — detailed network error
-    // 25+ reserved for the remaining #52 capabilities (pre-encryption payload,
-    // signals, fs semantics, security/LSM, exec-context enrichment).
+    FSEvent fs_event = 25; // #57 — filesystem semantics (denial/delete/rename)
+    // 26+ reserved for the remaining #52 capabilities (pre-encryption payload,
+    // signals, security/LSM, exec-context enrichment).
   }
 }
 
@@ -230,6 +231,21 @@ message IoSnapshot {
   double io_wait_pct = 7;
   repeated IoFileStats top_files = 8;
   repeated LatencyBucket latency_buckets = 9;
+}
+
+// ─── Filesystem semantics (#57) ─────────────────────────────────────────────
+// FSEvent is a kernel-observed filesystem semantic event: a permission denial on
+// open/openat (op="denied", err EACCES/EPERM), a delete (op="deleted"), or a
+// rename (op="renamed"). new_path is the rename destination ("" otherwise);
+// errno/err carry the syscall result (0/"" on success — deletes and renames are
+// emitted on success too, denials only on failure). Category on the envelope is
+// IO; the event timestamp lives on the envelope.
+message FSEvent {
+  string op = 1; // "denied" | "deleted" | "renamed"
+  string path = 2;
+  string new_path = 3; // rename destination; "" otherwise
+  int32 errno = 4; // 0 on success; positive errno (EACCES=13, …)
+  string err = 5; // "EACCES" | "EPERM" | "ENOENT" | "" …
 }
 
 // ─── File descriptors ───────────────────────────────────────────────────────


### PR DESCRIPTION
Closes #57 — part of the #52 epic (expand collector capture surface).

## What

Goes beyond throughput/top-files to capture filesystem **events with meaning**,
surfaced on the gRPC/JSONL event stream and in F5 I/O:

- **Permission denials** — `open`/`openat` returning `EACCES`/`EPERM`, with the resolved path.
- **Deletes** — `unlink`/`unlinkat`, with path (emitted on success *and* failure).
- **Renames** — `rename`/`renameat2`, with both paths.

## Shape — extend `io.bpf.c`, no new program

Like #56 grew `network.bpf.c`, this extends the existing IO program rather than
adding a new `.bpf.c` (no `BPF_SRCS` change, no new collector/source). The fs
syscalls run in process context, so they reuse the existing `is_io_target()`
filter. A separate `fs_events` ring buffer + `fs_inflight` map keep the
fs-semantics path independent of the read/write throughput path. The proven
opensnoop trick is used: stash the user path pointer at `sys_enter`, read the
string at `sys_exit` (where the errno is known) into the ring-buffer event.

## Stream + TUI

- `FSEvent{op, path, new_path, errno, err}` — oneof field **25**, envelope
  `CATEGORY_IO` (additive → buf-breaking safe). `fs_decode.go` is build-tag-free
  and unit-tested.
- **F5 I/O**: the **Anomalies** panel surfaces permission denials (red, newest-first);
  every fs event also feeds the **I/O Events** timeline (and F7). Honest about its
  source — denials are never simulated (mock io-files shows nothing rather than inventing).
- Snapshot/JSONL export includes `fs_events`.

## Validation

- `go vet` + `go test -race` (default + `-tags=ebpf` stub lane) green; `buf lint/format/generate`; `GOOS=linux go vet`.
- **Real eBPF lane in privileged Docker** (`make gen` + `-tags=ebpf`): all three
  event types captured end-to-end with correct paths + errno (`denied /secret`
  → EACCES, `deleted`, `renamed`). BPF compiled with no codegen traps; arm64
  legacy-tracepoint absence degrades gracefully (the `*at` variants cover all
  libc-routed calls).

## Deferred (documented in code)
openat paths relative to a non-AT_FDCWD dirfd are shown as the raw arg; paths
>255B truncated; chmod/chown/mkdir/rmdir out of scope; optional call-site ref
deferred (could ride a stack ref like heap later).

🤖 Generated with [Claude Code](https://claude.com/claude-code)