### PR TITLE
tls: pre-encryption network payload via libssl uprobes (#55)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,7 +77,9 @@ ptop/
 │   │   │   ├── threads.bpf.c      sched_switch
 │   │   │   ├── memory.bpf.c       mmap/brk/page-fault
 │   │   │   ├── heap.bpf.c         libc malloc/free uprobes → lifetime + leak
-│   │   │   └── futex.bpf.c        futex wait/wake → lock graph
+│   │   │   ├── futex.bpf.c        futex wait/wake → lock graph
+│   │   │   ├── signal.bpf.c       signal_generate → signals with origin (#58)
+│   │   │   └── tls.bpf.c          libssl SSL_write/read uprobes → plaintext (#55)
 │   │   ├── available.go           runtime feature flag (build-tag based)
 │   │   ├── target.go              pid-namespace target resolver (shared)
 │   │   ├── caps.go                CAP_BPF / CAP_PERFMON detection
@@ -89,6 +91,7 @@ ptop/
 │   │   ├── io.go                  VFS syscall tracker loader
 │   │   ├── memory.go              memory counter loader
 │   │   ├── heap.go                libc allocator uprobe loader (#53)
+│   │   ├── tls.go                 libssl uprobe loader → TLS plaintext (#55)
 │   │   ├── threads.go             sched_switch loader
 │   │   ├── futex.go               futex wait/wake loader
 │   │   └── *_stub.go              stubs for non-Linux / no-ebpf builds
@@ -136,6 +139,7 @@ ptop/
 │       ├── mem_proc.go            /proc/<pid>/statm + faults
 │       ├── mem_ebpf.go            kprobe + syscall tracepoints
 │       ├── heap_ebpf.go           libc malloc/free pairing → live-heap + leak (#53)
+│       ├── tls_ebpf.go            libssl uprobe → TLS payload (#55, opt-in --tls)
 │       ├── iowait_proc.go         /proc/<pid>/stat field 42
 │       ├── io_proc.go             /proc/<pid>/io throughput
 │       ├── io_ebpf.go             top files + per-op latency
@@ -331,8 +335,19 @@ ptop --pid <PID> --export   save JSON snapshot on exit (also bound to 'e')
 ptop --pid <PID> --no-ebpf  degraded mode: /proc only, no eBPF
 ptop --pid <PID> --serve unix:///run/ptop.sock   headless: stream events over gRPC, no TUI
 ptop --pid <PID> --serve tcp://127.0.0.1:50051   headless over TCP (loopback)
+ptop --pid <PID> --tls       TLS payload metadata (libssl uprobes) — OFF by default (#55)
+ptop --pid <PID> --tls-bytes 256   also capture ≤256 plaintext bytes/call (implies --tls)
 ptop --version              print version + commit + build date
 ```
+
+`--tls` opts into pre-encryption/post-decryption payload capture via uprobes on
+the target's libssl (`SSL_write`/`SSL_read`, resolved by symbol — Go targets have
+no libssl). It is **stream/export-only** (no live TUI panel): events flow to
+`--serve`/`--export`. `--tls` alone captures only metadata (direction, fd, byte
+count); the actual **plaintext** is captured only with `--tls-bytes N` (default
+0, capped at 4096/call) — it can include credentials/PII, so it's a deliberate
+second opt-in with a stderr warning. The `--serve` privilege boundary (unix
+0600 / TCP loopback-only) guards the resulting plaintext.
 
 `--serve <addr>` runs headless (no TUI): it builds the same collector `Set` and
 streams `streampb.Event`s over the `EventStreamService` gRPC service to any number of
@@ -377,5 +392,12 @@ Version metadata is injected via `-ldflags` at release time
   `0600` (owner-only) and removed on exit. For TCP, binding all interfaces
   (`0.0.0.0`/`::`) is refused — the stream exposes process internals, so bind
   loopback or a specific interface IP.
+- TLS payload capture (`--tls`/`--tls-bytes`, #55) observes plaintext and is
+  **off by default**. It attaches no uprobes unless `--tls` is passed, and emits
+  payload bytes only with the additional `--tls-bytes N` (capped 4096/call) —
+  never on by default, with a stderr warning when active. The captured plaintext
+  rides the same `--serve`/`--export` surface, so the socket/file restrictions
+  above are what keep it private. Resolve by symbol (version-drift safe); a Go or
+  static target has no libssl, so capture is simply unavailable there.
 
 See [`SECURITY.md`](SECURITY.md) for vulnerability reporting.

--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,8 @@ BPF_SRCS := \
 	internal/bpf/programs/memory.bpf.c \
 	internal/bpf/programs/heap.bpf.c \
 	internal/bpf/programs/futex.bpf.c \
-	internal/bpf/programs/signal.bpf.c
+	internal/bpf/programs/signal.bpf.c \
+	internal/bpf/programs/tls.bpf.c
 
 BPF_OBJS := $(BPF_SRCS:.c=.o)
 

--- a/README.md
+++ b/README.md
@@ -92,7 +92,21 @@ sudo ./bin/ptop --pid <PID>            # full mode (eBPF)
 ./bin/ptop --pid <PID> --no-ebpf       # /proc-only, no root
 sudo ./bin/ptop --pid <PID> --fps 10   # higher render rate
 sudo ./bin/ptop --pid <PID> --export   # save JSON snapshot on exit
+
+# Stream events headless (no TUI) over gRPC + JSONL
+sudo ./bin/ptop --pid <PID> --serve unix:///run/ptop.sock --export
+
+# Capture TLS plaintext around libssl (OFF by default; sensitive — see below)
+sudo ./bin/ptop --pid <PID> --tls-bytes 256 --serve unix:///run/ptop.sock --export
 ```
+
+> **TLS payload capture** (`--tls` / `--tls-bytes N`): uprobes the target's
+> libssl (`SSL_write`/`SSL_read`) to record plaintext before encryption / after
+> decryption — handy for debugging your own service's encrypted traffic without
+> a MITM proxy. It is **off by default**, **stream/export-only** (no live panel),
+> and the payload bytes (which may contain credentials/PII) are captured only
+> with `--tls-bytes N` (capped at 4096/call). Go and statically-linked targets
+> have no libssl, so capture is unavailable there.
 
 ### Keys
 

--- a/cmd/ptop/main.go
+++ b/cmd/ptop/main.go
@@ -31,6 +31,8 @@ func main() {
 	noEBPF := flag.Bool("no-ebpf", false, "Degraded mode: use only /proc, no eBPF (useful for development)")
 	export := flag.Bool("export", false, "Save JSON snapshot on exit (equivalent to the 'e' key)")
 	serveAddr := flag.String("serve", "", "Headless mode: stream events over gRPC instead of the TUI (unix:///path or tcp://host:port)")
+	tls := flag.Bool("tls", false, "Capture TLS payload metadata (direction/fd/byte count) via libssl uprobes — OFF by default (#55)")
+	tlsBytes := flag.Int("tls-bytes", 0, "Also capture up to N bytes of PLAINTEXT per TLS call (implies --tls; 0=metadata only, max 4096). Sensitive: may include credentials/PII")
 	showVer := flag.Bool("version", false, "Print version and exit")
 	flag.Parse()
 
@@ -77,17 +79,36 @@ func main() {
 		}
 	}
 
+	// TLS payload capture (#55) is opt-in. --tls-bytes implies --tls. Clamp the
+	// per-call byte cap to [0, 4096] and warn loudly when plaintext is captured,
+	// since it can include credentials/PII.
+	tlsEnabled := *tls || *tlsBytes > 0
+	tlsCap := *tlsBytes
+	if tlsCap < 0 {
+		tlsCap = 0
+	}
+	if tlsCap > 4096 {
+		fmt.Fprintf(os.Stderr, "[ptop] --tls-bytes %d clamped to 4096 (per-call cap)\n", *tlsBytes)
+		tlsCap = 4096
+	}
+	if tlsEnabled && tlsCap > 0 {
+		fmt.Fprintf(os.Stderr, "[ptop] ⚠ TLS plaintext capture ON (--tls-bytes %d): events carry decrypted\n", tlsCap)
+		fmt.Fprintln(os.Stderr, "       payload bytes (credentials/PII). Keep the stream/export private.")
+	}
+
 	// Headless mode: serve the collector stream over gRPC instead of the TUI.
 	if *serveAddr != "" {
-		runServe(*serveAddr, *pid, *noEBPF, *export)
+		runServe(*serveAddr, *pid, *noEBPF, *export, tlsEnabled, tlsCap)
 		return
 	}
 
 	cfg := tui.Config{
-		PID:    *pid,
-		FPS:    *fps,
-		NoEBPF: *noEBPF,
-		Export: *export,
+		PID:         *pid,
+		FPS:         *fps,
+		NoEBPF:      *noEBPF,
+		Export:      *export,
+		TLS:         tlsEnabled,
+		TLSMaxBytes: tlsCap,
 	}
 
 	m := tui.NewModel(cfg)
@@ -116,7 +137,7 @@ func main() {
 // SIGTERM. The Set's lifecycle is owned here: serve.Run only stops the server,
 // so we stop the collectors after it returns. With export, it also writes an
 // event-level JSONL (distinct from the TUI's state-snapshot ptop-export-*.jsonl).
-func runServe(addr string, pid int, noEBPF, export bool) {
+func runServe(addr string, pid int, noEBPF, export, tlsEnabled bool, tlsBytes int) {
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
 
@@ -125,7 +146,9 @@ func runServe(addr string, pid int, noEBPF, export bool) {
 		opts.JSONLPath = fmt.Sprintf("ptop-events-%s.jsonl", time.Now().Format("20060102-150405"))
 	}
 
-	set := collector.NewSet(collector.SetConfig{PID: pid, NoEBPF: noEBPF})
+	set := collector.NewSet(collector.SetConfig{
+		PID: pid, NoEBPF: noEBPF, TLS: tlsEnabled, TLSMaxBytes: tlsBytes,
+	})
 	defer set.Stop()
 
 	// The heap collector owns the stack tracer + symbolizer, so it backs stack

--- a/internal/bpf/programs/tls.bpf.c
+++ b/internal/bpf/programs/tls.bpf.c
@@ -1,0 +1,192 @@
+// SPDX-License-Identifier: GPL-2.0
+//
+// tls.bpf.c — pre-encryption / post-decryption TLS payload capture (#55).
+//
+// Uprobes the target's TLS library (OpenSSL/BoringSSL libssl) to observe the
+// PLAINTEXT around encryption, attached by symbol from the Go loader (see
+// internal/bpf/tls.go), exactly like the heap collector uprobes libc:
+//   uprobe   SSL_write(ssl, buf, num)  → plaintext is in buf at entry (to send)
+//   uprobe   SSL_read(ssl, buf, num)   → stash buf; the kernel fills it later
+//   uretprobe SSL_read(ret)            → buf now holds `ret` decrypted bytes
+//   uprobe   SSL_set_fd(ssl, fd)       → remember ssl→fd for connection corr.
+//
+// PRIVACY: this captures plaintext (credentials, PII). It is OFF unless the
+// user passes --tls, and the actual bytes are copied only when --tls-bytes N
+// is set (tls_cfg holds N, capped at TLS_MAX_DATA). With N=0 only metadata
+// (direction, fd, byte count) is emitted — never the payload. See #55 / README.
+//
+// Maps:
+//   tls_target_pid  ARRAY[1]  struct target_filter (Go loader writes it)
+//   tls_cfg         ARRAY[1]  __u32 — max plaintext bytes to copy (0 = none)
+//   tls_ssl_fd      HASH      ssl_ptr → fd (from SSL_set_fd)
+//   tls_read_args   HASH      pid_tgid → {ssl, buf} (SSL_read entry→ret)
+//   tls_events      RINGBUF   per-call payload events → user-space
+
+#include <linux/bpf.h>
+#include <linux/ptrace.h>
+#include <bpf/bpf_helpers.h>
+#include <bpf/bpf_tracing.h>
+#include "target.bpf.h"
+
+char LICENSE[] SEC("license") = "GPL";
+
+#define TLS_DIR_WRITE 0 // SSL_write — plaintext being sent (pre-encryption)
+#define TLS_DIR_READ  1 // SSL_read  — plaintext received (post-decryption)
+
+// Hard cap on bytes copied per call. The configured --tls-bytes is clamped to
+// this; the event carries a fixed buffer of this size (only `captured` valid).
+#define TLS_MAX_DATA 4096
+
+struct read_args {
+    __u64 ssl;
+    __u64 buf;
+};
+
+// tls_event is published to user-space via the tls_events ring buffer. Fixed
+// layout, read with binary.LittleEndian on the Go side — keep in sync with
+// TLSEventRecord in internal/bpf/tls.go. Only the first `captured` bytes of
+// data are valid.
+struct tls_event {
+    __u64 ts_ns;
+    __u32 tgid;
+    __u32 pid; // tid
+    __s32 fd;  // owning socket fd (−1 if SSL_set_fd wasn't seen)
+    __u32 dir; // TLS_DIR_*
+    __s32 len; // plaintext byte count for the call (num / read retval)
+    __u32 captured;
+    char  data[TLS_MAX_DATA];
+};
+
+struct {
+    __uint(type, BPF_MAP_TYPE_ARRAY);
+    __type(key, __u32);
+    __type(value, struct target_filter);
+    __uint(max_entries, 1);
+} tls_target_pid SEC(".maps");
+
+struct {
+    __uint(type, BPF_MAP_TYPE_ARRAY);
+    __type(key, __u32);
+    __type(value, __u32); // max plaintext bytes to copy (0 = metadata only)
+    __uint(max_entries, 1);
+} tls_cfg SEC(".maps");
+
+struct {
+    __uint(type, BPF_MAP_TYPE_HASH);
+    __type(key, __u64);  // ssl pointer
+    __type(value, __s32); // fd
+    __uint(max_entries, 4096);
+} tls_ssl_fd SEC(".maps");
+
+struct {
+    __uint(type, BPF_MAP_TYPE_HASH);
+    __type(key, __u64); // pid_tgid
+    __type(value, struct read_args);
+    __uint(max_entries, 10240);
+} tls_read_args SEC(".maps");
+
+struct {
+    __uint(type, BPF_MAP_TYPE_RINGBUF);
+    __uint(max_entries, 1 << 21); // 2MB — opt-in, payloads can be large
+} tls_events SEC(".maps");
+
+static __always_inline int is_tls_target(void)
+{
+    return pid_is_target(&tls_target_pid);
+}
+
+// emit_payload reserves a ring-buffer slot and publishes one TLS payload event.
+// It copies up to min(len, configured-cap) plaintext bytes from buf — and zero
+// bytes when the cap is 0 (metadata-only mode).
+static __always_inline void emit_payload(__u32 dir, __u64 ssl, __u64 buf, __s64 len)
+{
+    if (len <= 0)
+        return;
+
+    __u32 zero = 0;
+    __u32 *cfgp = bpf_map_lookup_elem(&tls_cfg, &zero);
+    __u64 cap = cfgp ? (__u64)*cfgp : 0; // map-derived → verifier can't bound it
+
+    // captured = min(len, cap), then masked to [0, TLS_MAX_DATA-1]. The mask is
+    // the SOLE bound — we deliberately do NOT clamp cap first, because clang
+    // would then prove captured ≤ TLS_MAX_DATA-1 and eliminate the mask, leaving
+    // the verifier with an unbounded length ("R2 min value is negative"). The Go
+    // loader clamps tls_cfg to TLS_MAX_DATA-1, so the mask never truncates.
+    __u32 captured = 0;
+    if (len > 0) {
+        __u64 n = (__u64)len;
+        if (n > cap)
+            n = cap;
+        captured = (__u32)n & (TLS_MAX_DATA - 1);
+    }
+
+    struct tls_event *e = bpf_ringbuf_reserve(&tls_events, sizeof(*e), 0);
+    if (!e)
+        return;
+    __u64 pt = bpf_get_current_pid_tgid();
+    e->ts_ns    = bpf_ktime_get_ns();
+    e->tgid     = (__u32)(pt >> 32);
+    e->pid      = (__u32)pt;
+    __s32 *fdp  = bpf_map_lookup_elem(&tls_ssl_fd, &ssl);
+    e->fd       = fdp ? *fdp : -1;
+    e->dir      = dir;
+    e->len      = (__s32)len;
+    e->captured = captured;
+    if (captured > 0)
+        bpf_probe_read_user(e->data, captured, (const void *)buf);
+    bpf_ringbuf_submit(e, 0);
+}
+
+// SSL_write(SSL *ssl, const void *buf, int num): the plaintext to send is in
+// buf at entry. PARM1=ssl, PARM2=buf, PARM3=num.
+SEC("uprobe/SSL_write")
+int BPF_KPROBE(uprobe_ssl_write, void *ssl, void *buf, int num)
+{
+    if (!is_tls_target())
+        return 0;
+    emit_payload(TLS_DIR_WRITE, (__u64)(unsigned long)ssl, (__u64)(unsigned long)buf, num);
+    return 0;
+}
+
+// SSL_read(SSL *ssl, void *buf, int num): buf is filled by the time SSL_read
+// returns, so we stash {ssl, buf} at entry and read it in the uretprobe.
+SEC("uprobe/SSL_read")
+int BPF_KPROBE(uprobe_ssl_read, void *ssl, void *buf, int num)
+{
+    if (!is_tls_target())
+        return 0;
+    __u64 pt = bpf_get_current_pid_tgid();
+    struct read_args ra = {
+        .ssl = (__u64)(unsigned long)ssl,
+        .buf = (__u64)(unsigned long)buf,
+    };
+    bpf_map_update_elem(&tls_read_args, &pt, &ra, BPF_ANY);
+    return 0;
+}
+
+SEC("uretprobe/SSL_read")
+int BPF_KRETPROBE(uretprobe_ssl_read, int ret)
+{
+    __u64 pt = bpf_get_current_pid_tgid();
+    struct read_args *ra = bpf_map_lookup_elem(&tls_read_args, &pt);
+    if (!ra)
+        return 0;
+    __u64 ssl = ra->ssl;
+    __u64 buf = ra->buf;
+    bpf_map_delete_elem(&tls_read_args, &pt);
+    emit_payload(TLS_DIR_READ, ssl, buf, ret);
+    return 0;
+}
+
+// SSL_set_fd(SSL *ssl, int fd): remember the socket fd for connection
+// correlation (no SSL-struct offsets needed — purely symbol-based).
+SEC("uprobe/SSL_set_fd")
+int BPF_KPROBE(uprobe_ssl_set_fd, void *ssl, int fd)
+{
+    if (!is_tls_target())
+        return 0;
+    __u64 key = (__u64)(unsigned long)ssl;
+    __s32 v = fd;
+    bpf_map_update_elem(&tls_ssl_fd, &key, &v, BPF_ANY);
+    return 0;
+}

--- a/internal/bpf/tls.go
+++ b/internal/bpf/tls.go
@@ -1,0 +1,266 @@
+//go:build linux && ebpf
+
+package bpf
+
+import (
+	"bufio"
+	"bytes"
+	_ "embed"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/cilium/ebpf"
+	"github.com/cilium/ebpf/link"
+	"github.com/cilium/ebpf/ringbuf"
+	"github.com/cilium/ebpf/rlimit"
+)
+
+//go:embed programs/tls.bpf.o
+var tlsBPFObj []byte
+
+// tlsMaxData mirrors TLS_MAX_DATA in programs/tls.bpf.c — the hard per-call
+// capture cap and the fixed size of the event's data buffer.
+const tlsMaxData = 4096
+
+// TLS payload directions — mirror TLS_DIR_* in programs/tls.bpf.c.
+const (
+	TLSDirWrite uint32 = 0
+	TLSDirRead  uint32 = 1
+)
+
+// TLSEventRecord is the 1:1 layout of struct tls_event in programs/tls.bpf.c
+// (#55). Fixed size 4128 bytes; binary.LittleEndian parses it from the ring
+// buffer. Only the first Captured bytes of Data are valid.
+type TLSEventRecord struct {
+	TsNs     uint64
+	TGID     uint32
+	PID      uint32
+	FD       int32
+	Dir      uint32
+	Len      int32
+	Captured uint32
+	Data     [tlsMaxData]byte
+}
+
+// TLSTracer loads tls.bpf.o and attaches uprobes on the target's libssl
+// (SSL_write/SSL_read/SSL_set_fd), exposing Next() to deliver parsed payload
+// events. Capture is bounded by maxBytes (0 = metadata only).
+type TLSTracer struct {
+	coll  *ebpf.Collection
+	links []link.Link
+	rb    *ringbuf.Reader
+}
+
+// OpenTLSTracer resolves the target's libssl, writes the target filter + the
+// capture cap, attaches the SSL uprobes (best-effort; at least one of
+// SSL_write/SSL_read must attach), and opens the event ring buffer. Returns an
+// error when no libssl is mapped (no OpenSSL/BoringSSL, static, or Go target),
+// leaving the collector inactive.
+func OpenTLSTracer(pid, maxBytes int) (*TLSTracer, error) {
+	if pid <= 0 {
+		return nil, errors.New("invalid pid")
+	}
+	if err := rlimit.RemoveMemlock(); err != nil {
+		return nil, fmt.Errorf("rlimit: %w", err)
+	}
+
+	libsslPath, err := resolveLibSSL(pid)
+	if err != nil {
+		return nil, err
+	}
+
+	spec, err := ebpf.LoadCollectionSpecFromReader(bytes.NewReader(tlsBPFObj))
+	if err != nil {
+		return nil, fmt.Errorf("parse tls BPF object: %w", err)
+	}
+	coll, err := ebpf.NewCollection(spec)
+	if err != nil {
+		return nil, fmt.Errorf("load tls collection: %w", err)
+	}
+	t := &TLSTracer{coll: coll}
+
+	targetMap := coll.Maps["tls_target_pid"]
+	if targetMap == nil {
+		t.Close()
+		return nil, errors.New("tls_target_pid map missing")
+	}
+	tf, err := resolveTarget(pid)
+	if err != nil {
+		t.Close()
+		return nil, err
+	}
+	if err := writeTargetFilter(targetMap, tf); err != nil {
+		t.Close()
+		return nil, fmt.Errorf("set tls_target_pid: %w", err)
+	}
+
+	// Capture cap (--tls-bytes), clamped to the buffer size. 0 = metadata only.
+	cfgMap := coll.Maps["tls_cfg"]
+	if cfgMap == nil {
+		t.Close()
+		return nil, errors.New("tls_cfg map missing")
+	}
+	cap32 := uint32(maxBytes)
+	if maxBytes < 0 {
+		cap32 = 0
+	}
+	// Clamp to TLS_MAX_DATA-1: the BPF side bounds the copy with a mask of
+	// (TLS_MAX_DATA-1), so a cap of exactly TLS_MAX_DATA would mask to 0.
+	if cap32 > tlsMaxData-1 {
+		cap32 = tlsMaxData - 1
+	}
+	var key uint32
+	if err := cfgMap.Update(&key, &cap32, ebpf.UpdateAny); err != nil {
+		t.Close()
+		return nil, fmt.Errorf("set tls_cfg: %w", err)
+	}
+
+	ex, err := link.OpenExecutable(libsslPath)
+	if err != nil {
+		t.Close()
+		return nil, fmt.Errorf("open libssl %s: %w", libsslPath, err)
+	}
+
+	opts := &link.UprobeOptions{PID: pid}
+	probes := []struct {
+		sym, prog string
+		ret       bool
+	}{
+		{"SSL_write", "uprobe_ssl_write", false},
+		{"SSL_read", "uprobe_ssl_read", false},
+		{"SSL_read", "uretprobe_ssl_read", true},
+		{"SSL_set_fd", "uprobe_ssl_set_fd", false},
+	}
+	var haveWrite, haveRead bool
+	for _, p := range probes {
+		prog := coll.Programs[p.prog]
+		if prog == nil {
+			t.Close()
+			return nil, fmt.Errorf("program %s missing", p.prog)
+		}
+		var l link.Link
+		if p.ret {
+			l, err = ex.Uretprobe(p.sym, prog, opts)
+		} else {
+			l, err = ex.Uprobe(p.sym, prog, opts)
+		}
+		if err != nil {
+			// Tolerate a missing symbol (BoringSSL/version drift); we only
+			// need one of SSL_write/SSL_read to be useful.
+			fmt.Fprintf(os.Stderr, "warning: tls uprobe %s (%s): %v\n", p.sym, p.prog, err)
+			continue
+		}
+		t.links = append(t.links, l)
+		if p.sym == "SSL_write" {
+			haveWrite = true
+		}
+		if p.sym == "SSL_read" && !p.ret {
+			haveRead = true
+		}
+	}
+	if !haveWrite && !haveRead {
+		t.Close()
+		return nil, fmt.Errorf("could not attach SSL_write/SSL_read uprobes on %s", libsslPath)
+	}
+
+	eventsMap := coll.Maps["tls_events"]
+	if eventsMap == nil {
+		t.Close()
+		return nil, errors.New("tls_events ringbuf missing")
+	}
+	rb, err := ringbuf.NewReader(eventsMap)
+	if err != nil {
+		t.Close()
+		return nil, fmt.Errorf("ringbuf reader: %w", err)
+	}
+	t.rb = rb
+
+	return t, nil
+}
+
+// Next blocks until the next TLS payload event arrives. Returns io.EOF when the
+// tracer is closed; a short/garbled record is reported as an error without
+// closing the stream.
+func (t *TLSTracer) Next() (TLSEventRecord, error) {
+	var ev TLSEventRecord
+	if t == nil || t.rb == nil {
+		return ev, errors.New("tracer not initialized")
+	}
+	rec, err := t.rb.Read()
+	if err != nil {
+		if errors.Is(err, ringbuf.ErrClosed) {
+			return ev, io.EOF
+		}
+		return ev, err
+	}
+	if len(rec.RawSample) < 4128 {
+		return ev, fmt.Errorf("short tls event: %d bytes", len(rec.RawSample))
+	}
+	if err := binary.Read(bytes.NewReader(rec.RawSample), binary.LittleEndian, &ev); err != nil {
+		return ev, fmt.Errorf("decode tls event: %w", err)
+	}
+	return ev, nil
+}
+
+func (t *TLSTracer) Close() error {
+	if t == nil {
+		return nil
+	}
+	if t.rb != nil {
+		_ = t.rb.Close()
+		t.rb = nil
+	}
+	for _, l := range t.links {
+		_ = l.Close()
+	}
+	t.links = nil
+	if t.coll != nil {
+		t.coll.Close()
+		t.coll = nil
+	}
+	return nil
+}
+
+// resolveLibSSL finds the libssl mapped into pid and returns the file path to
+// attach uprobes against, preferring the target's mount-namespace view (so the
+// symbol offsets match the running library). Errors when none is mapped (no
+// OpenSSL/BoringSSL, statically linked, or a Go target whose crypto/tls is pure
+// Go) — the caller then leaves the TLS collector inactive.
+func resolveLibSSL(pid int) (string, error) {
+	f, err := os.Open(fmt.Sprintf("/proc/%d/maps", pid))
+	if err != nil {
+		return "", fmt.Errorf("open maps of %d: %w", pid, err)
+	}
+	defer f.Close()
+
+	var path string
+	sc := bufio.NewScanner(f)
+	for sc.Scan() {
+		fields := strings.Fields(sc.Text())
+		if len(fields) < 6 {
+			continue
+		}
+		p := strings.Join(fields[5:], " ")
+		if strings.HasPrefix(filepath.Base(p), "libssl.so") {
+			path = p
+			break
+		}
+	}
+	if err := sc.Err(); err != nil {
+		return "", err
+	}
+	if path == "" {
+		return "", errors.New("no libssl mapped (no OpenSSL/BoringSSL, static, or Go crypto/tls)")
+	}
+
+	rooted := fmt.Sprintf("/proc/%d/root%s", pid, path)
+	if _, e := os.Stat(rooted); e == nil {
+		return rooted, nil
+	}
+	return path, nil
+}

--- a/internal/bpf/tls_stub.go
+++ b/internal/bpf/tls_stub.go
@@ -1,0 +1,36 @@
+//go:build !linux || !ebpf
+
+package bpf
+
+import (
+	"errors"
+	"io"
+)
+
+var errTLSStub = errors.New("eBPF tls tracer not available in this build")
+
+const tlsMaxData = 4096
+
+const (
+	TLSDirWrite uint32 = 0
+	TLSDirRead  uint32 = 1
+)
+
+// TLSEventRecord mirrors the real layout so non-ebpf builds of internal/bpf
+// still compile standalone (matches io_stub.go and the other tracer stubs).
+type TLSEventRecord struct {
+	TsNs     uint64
+	TGID     uint32
+	PID      uint32
+	FD       int32
+	Dir      uint32
+	Len      int32
+	Captured uint32
+	Data     [tlsMaxData]byte
+}
+
+type TLSTracer struct{}
+
+func OpenTLSTracer(int, int) (*TLSTracer, error) { return nil, errTLSStub }
+func (*TLSTracer) Next() (TLSEventRecord, error) { return TLSEventRecord{}, io.EOF }
+func (*TLSTracer) Close() error                  { return nil }

--- a/internal/serve/mapper.go
+++ b/internal/serve/mapper.go
@@ -55,6 +55,13 @@ func toEvent(pid int, buildID string, v interface{}) *pb.Event {
 			Retransmits: x.Retransmits, DetailMs: x.DetailMs,
 		}}
 
+	case collector.TLSPayload:
+		ev.TsUnixNano = tsNano(x.Timestamp)
+		ev.Category = pb.Category_CATEGORY_NETWORK
+		ev.Payload = &pb.Event_Tls{Tls: &pb.TLSPayloadEvent{
+			Dir: x.Dir, Fd: int32(x.FD), Len: int32(x.Len), Data: x.Data,
+		}}
+
 	case collector.MemStats:
 		ev.TsUnixNano = nowNano()
 		ev.Category = pb.Category_CATEGORY_MEMORY

--- a/internal/tui/help.go
+++ b/internal/tui/help.go
@@ -127,6 +127,20 @@ func renderHelpOverlayWithStatus(m Model, w, h int) string {
 			}
 			return statusRowNA("signals", "needs eBPF (signal_generate tracepoint)")
 		}(),
+		// TLS payload (#55) is opt-in (--tls) and stream/export-only. "off" when
+		// not requested; "real via eBPF (libssl)" when attached; "unavailable"
+		// when requested but no libssl is mapped (Go/static target).
+		func() string {
+			if m.tlsSource != "" {
+				return statusRow("tls", false, m.tlsSource+" (libssl)")
+			}
+			if m.cfg.TLS {
+				return statusRowNA("tls", "no libssl mapped (Go/static target)")
+			}
+			return keyStyle.Render(padRight("tls", 14)) + descStyle.Render(" ") +
+				lipgloss.NewStyle().Foreground(ColorMuted).Background(ColorPanel).Render("○ off") +
+				sourceStyle.Render(" — enable with --tls")
+		}(),
 		statusRow("threads", m.usingMockThreads, m.threadsSource),
 		statusRow("io-wait", m.usingMockIOWait, sourceProcOrEmpty(!m.usingMockIOWait)),
 		statusRow("io-throughput", m.usingMockIOThrough, sourceProcOrEmpty(!m.usingMockIOThrough)),

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -67,6 +67,9 @@ type Config struct {
 	FPS    int
 	NoEBPF bool
 	Export bool
+	// TLS payload capture (#55) — opt-in, stream/export-only (no live panel).
+	TLS         bool
+	TLSMaxBytes int
 }
 
 // ─── Bubbletea messages ──────────────────────────────────────────────────────
@@ -87,6 +90,7 @@ type FSEventMsg collector.FSEvent
 type NetMsg []collector.NetConn
 type NetErrorMsg collector.NetError
 type SignalMsg collector.SignalEvent
+type TLSPayloadMsg collector.TLSPayload
 type LockGraphMsg []collector.LockEntry
 type LockTimelineMsg collector.TimelineEvent
 
@@ -125,6 +129,7 @@ type Model struct {
 	FDEvents       []collector.FDEvent
 	Timeline       []collector.TimelineEvent
 	Signals        []collector.SignalEvent // eBPF signals delivered to the target (#58), newest-first
+	TLSPayloads    []collector.TLSPayload  // eBPF TLS payloads (#55), newest-first; stream/export-only, no live panel
 	LockGraph      []collector.LockEntry
 
 	// UI state
@@ -185,6 +190,7 @@ type Model struct {
 	heapSource     string
 	locksSource    string
 	signalsSource  string
+	tlsSource      string
 
 	// Stable caches to avoid visual reordering between ticks.
 	// topSyscallNames is recomputed every `topRefreshInterval`; between refreshes
@@ -223,7 +229,9 @@ func NewModel(cfg Config) Model {
 	// duplicated. PID <= 0 yields an empty Set: every Mock* stays true and the
 	// model simulates everything. eBPF start failures are logged to stderr by
 	// the Set (before the alt-screen) and fall back to /proc where possible.
-	m.collectors = collector.NewSet(collector.SetConfig{PID: cfg.PID, NoEBPF: cfg.NoEBPF})
+	m.collectors = collector.NewSet(collector.SetConfig{
+		PID: cfg.PID, NoEBPF: cfg.NoEBPF, TLS: cfg.TLS, TLSMaxBytes: cfg.TLSMaxBytes,
+	})
 
 	// Mirror the Set's source labels + mock state into the model fields the
 	// help overlay (?) reads. Source "" means no real source started → mock.
@@ -236,6 +244,7 @@ func NewModel(cfg Config) Model {
 	m.netSource = m.collectors.Sources.Net
 	m.locksSource = m.collectors.Sources.Locks
 	m.signalsSource = m.collectors.Sources.Signals
+	m.tlsSource = m.collectors.Sources.TLS
 
 	m.usingMockFDs = m.collectors.MockFDs()
 	m.usingMockCPU = m.collectors.MockCPU()
@@ -309,6 +318,9 @@ func (m Model) Init() tea.Cmd {
 	}
 	if m.collectors.SignalEBPF != nil {
 		cmds = append(cmds, waitForSignalEBPF(m.collectors.SignalEBPF))
+	}
+	if m.collectors.TLSEBPF != nil {
+		cmds = append(cmds, waitForTLSEBPF(m.collectors.TLSEBPF))
 	}
 	if m.exportFile != nil {
 		cmds = append(cmds, exportTick())
@@ -470,6 +482,18 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.Timeline = m.Timeline[:120]
 		}
 		return m, waitForSignalEBPF(m.collectors.SignalEBPF)
+
+	case TLSPayloadMsg:
+		// Real TLS payload (#55). Stream/export-only — there is no live panel
+		// (plaintext in an interactive view is a privacy footgun), but we retain
+		// a capped, newest-first buffer so `--tls --export` includes it in the
+		// snapshot. Plaintext bytes are present only when --tls-bytes was set.
+		p := collector.TLSPayload(v)
+		m.TLSPayloads = append([]collector.TLSPayload{p}, m.TLSPayloads...)
+		if len(m.TLSPayloads) > 40 {
+			m.TLSPayloads = m.TLSPayloads[:40]
+		}
+		return m, waitForTLSEBPF(m.collectors.TLSEBPF)
 
 	case LockGraphMsg:
 		m.LockGraph = []collector.LockEntry(v)
@@ -1204,6 +1228,22 @@ func waitForSignalEBPF(c *collector.SignalEBPFCollector) tea.Cmd {
 		}
 		if s, ok := (<-ch).(collector.SignalEvent); ok {
 			return SignalMsg(s)
+		}
+		return TickMsg(time.Now())
+	}
+}
+
+func waitForTLSEBPF(c *collector.TLSEBPFCollector) tea.Cmd {
+	if c == nil {
+		return nil
+	}
+	return func() tea.Msg {
+		ch := c.Subscribe()
+		if ch == nil {
+			return TickMsg(time.Now())
+		}
+		if p, ok := (<-ch).(collector.TLSPayload); ok {
+			return TLSPayloadMsg(p)
 		}
 		return TickMsg(time.Now())
 	}

--- a/internal/tui/snapshot.go
+++ b/internal/tui/snapshot.go
@@ -43,6 +43,7 @@ type SnapshotData struct {
 	FDEvents       []collector.FDEvent       `json:"fd_events"`
 	Timeline       []collector.TimelineEvent `json:"timeline"`
 	Signals        []collector.SignalEvent   `json:"signals"`
+	TLSPayloads    []collector.TLSPayload    `json:"tls_payloads,omitempty"`
 }
 
 // buildSnapshot extracts a Snapshot from the current model state.
@@ -70,6 +71,7 @@ func buildSnapshot(m Model) Snapshot {
 			FDEvents:       append([]collector.FDEvent(nil), m.FDEvents...),
 			Timeline:       append([]collector.TimelineEvent(nil), m.Timeline...),
 			Signals:        append([]collector.SignalEvent(nil), m.Signals...),
+			TLSPayloads:    append([]collector.TLSPayload(nil), m.TLSPayloads...),
 		},
 	}
 }

--- a/internal/tui/tls_test.go
+++ b/internal/tui/tls_test.go
@@ -1,0 +1,47 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/trentas/ptop/pkg/collector"
+)
+
+// TestTLSPayloadMsgCappedNewestFirst confirms TLS payloads are retained
+// newest-first and bounded, and flow into the snapshot export (the only place
+// they surface — there is no live panel).
+func TestTLSPayloadMsgCappedNewestFirst(t *testing.T) {
+	m := NewModel(Config{PID: 1, FPS: 5, NoEBPF: true})
+	for i := 0; i < 60; i++ {
+		nm, _ := m.Update(TLSPayloadMsg(collector.TLSPayload{
+			Timestamp: time.Now(), Dir: "write", FD: i, Len: 10,
+		}))
+		m = nm.(Model)
+	}
+	if len(m.TLSPayloads) != 40 {
+		t.Errorf("TLSPayloads len = %d, want cap 40", len(m.TLSPayloads))
+	}
+	if m.TLSPayloads[0].FD != 59 {
+		t.Errorf("head FD = %d, want 59 (newest-first)", m.TLSPayloads[0].FD)
+	}
+	snap := buildSnapshot(m)
+	if len(snap.Data.TLSPayloads) != 40 {
+		t.Errorf("snapshot TLSPayloads len = %d, want 40", len(snap.Data.TLSPayloads))
+	}
+}
+
+// TestTLSHelpRows confirms the help overlay is honest about the TLS source:
+// "off" + the enable hint when not requested, and "libssl" when attached.
+func TestTLSHelpRows(t *testing.T) {
+	off := Model{Width: 120, Height: 44}
+	if out := renderHelpOverlayWithStatus(off, 120, 44); !strings.Contains(out, "enable with --tls") {
+		t.Errorf("help (TLS off) missing the --tls enable hint")
+	}
+
+	on := Model{Width: 120, Height: 44, tlsSource: "eBPF"}
+	on.cfg.TLS = true
+	if out := renderHelpOverlayWithStatus(on, 120, 44); !strings.Contains(out, "libssl") {
+		t.Errorf("help (TLS attached) missing the libssl source label")
+	}
+}

--- a/pkg/collector/set.go
+++ b/pkg/collector/set.go
@@ -11,6 +11,12 @@ import (
 type SetConfig struct {
 	PID    int
 	NoEBPF bool // degraded mode: skip eBPF, use /proc (or libproc on macOS) only
+
+	// TLS opts into pre-encryption payload capture via libssl uprobes (#55) —
+	// OFF by default (privacy). TLSMaxBytes caps the plaintext copied per call
+	// (0 = metadata only: direction/fd/byte count, no payload bytes).
+	TLS         bool
+	TLSMaxBytes int
 }
 
 // Sources records where each subsystem's real data came from. The value is
@@ -27,6 +33,7 @@ type Sources struct {
 	Net      string
 	Locks    string
 	Signals  string
+	TLS      string
 }
 
 // Set owns the live collectors for a single target PID, chosen by the
@@ -49,6 +56,7 @@ type Set struct {
 	NetworkEBPF  *NetworkEBPFCollector
 	FutexEBPF    *FutexEBPFCollector
 	SignalEBPF   *SignalEBPFCollector
+	TLSEBPF      *TLSEBPFCollector
 
 	Sources Sources
 }
@@ -188,6 +196,19 @@ func NewSet(cfg SetConfig) *Set {
 		} else {
 			warnEBPFFailure("signals", err)
 		}
+
+		// TLS payload capture (#55) — OFF unless explicitly opted in (--tls),
+		// because it observes plaintext. eBPF-only (libssl uprobes), no /proc
+		// fallback, never simulated.
+		if cfg.TLS {
+			c7 := NewTLSEBPFCollector(cfg.TLSMaxBytes)
+			if err := c7.Start(cfg.PID); err == nil {
+				s.TLSEBPF = c7
+				s.Sources.TLS = "eBPF"
+			} else {
+				warnEBPFFailure("tls", err)
+			}
+		}
 	}
 
 	return s
@@ -246,6 +267,9 @@ func (s *Set) Stop() {
 	if s.SignalEBPF != nil {
 		s.SignalEBPF.Stop()
 	}
+	if s.TLSEBPF != nil {
+		s.TLSEBPF.Stop()
+	}
 }
 
 // Collectors returns every started collector as a Collector. Used by consumers
@@ -277,6 +301,7 @@ func (s *Set) Collectors() []Collector {
 	add(s.NetworkEBPF, s.NetworkEBPF != nil)
 	add(s.FutexEBPF, s.FutexEBPF != nil)
 	add(s.SignalEBPF, s.SignalEBPF != nil)
+	add(s.TLSEBPF, s.TLSEBPF != nil)
 	return cs
 }
 

--- a/pkg/collector/tls_decode.go
+++ b/pkg/collector/tls_decode.go
@@ -1,0 +1,48 @@
+package collector
+
+import "time"
+
+// TLS payload directions — must match TLS_DIR_* in internal/bpf/programs/tls.bpf.c
+// and the TLSDir* constants in internal/bpf/tls.go. Duplicated here (rather than
+// imported from internal/bpf) so this decode logic compiles and is unit-tested
+// on any OS, not only the linux+ebpf lane — the same split network_error.go uses.
+const (
+	tlsDirWrite uint32 = 0
+	tlsDirRead  uint32 = 1
+)
+
+// tlsDir maps the kernel direction code to the public TLSPayload.Dir string.
+func tlsDir(dir uint32) string {
+	switch dir {
+	case tlsDirWrite:
+		return "write"
+	case tlsDirRead:
+		return "read"
+	default:
+		return "?"
+	}
+}
+
+// decodeTLS builds a TLSPayload from the raw fields of a tls_event record. ts is
+// the wall-clock capture time (stamped by the collector when the event is
+// drained — the kernel ts_ns is monotonic). It copies exactly `captured` bytes
+// of plaintext from data (defensively bounded by len(data)); Data is nil when
+// captured==0 (metadata-only mode).
+func decodeTLS(ts time.Time, dir uint32, fd, length int32, captured uint32, data []byte) TLSPayload {
+	n := int(captured)
+	if n > len(data) {
+		n = len(data)
+	}
+	var payload []byte
+	if n > 0 {
+		payload = make([]byte, n)
+		copy(payload, data[:n])
+	}
+	return TLSPayload{
+		Timestamp: ts,
+		Dir:       tlsDir(dir),
+		FD:        int(fd),
+		Len:       int(length),
+		Data:      payload,
+	}
+}

--- a/pkg/collector/tls_decode_test.go
+++ b/pkg/collector/tls_decode_test.go
@@ -1,0 +1,56 @@
+package collector
+
+import (
+	"bytes"
+	"testing"
+	"time"
+)
+
+func TestTLSDir(t *testing.T) {
+	cases := map[uint32]string{
+		tlsDirWrite: "write",
+		tlsDirRead:  "read",
+		9:           "?",
+	}
+	for code, want := range cases {
+		if got := tlsDir(code); got != want {
+			t.Errorf("tlsDir(%d) = %q, want %q", code, got, want)
+		}
+	}
+}
+
+func TestDecodeTLS(t *testing.T) {
+	ts := time.Unix(1700000000, 0)
+	data := make([]byte, 4096)
+	copy(data, "GET / HTTP/1.0\r\n")
+
+	t.Run("write copies exactly captured bytes", func(t *testing.T) {
+		p := decodeTLS(ts, tlsDirWrite, 7, 16, 16, data)
+		if p.Dir != "write" || p.FD != 7 || p.Len != 16 {
+			t.Errorf("unexpected: %+v", p)
+		}
+		if !bytes.Equal(p.Data, []byte("GET / HTTP/1.0\r\n")) {
+			t.Errorf("Data = %q", p.Data)
+		}
+		if !p.Timestamp.Equal(ts) {
+			t.Errorf("Timestamp = %v", p.Timestamp)
+		}
+	})
+
+	t.Run("metadata only → nil Data", func(t *testing.T) {
+		p := decodeTLS(ts, tlsDirRead, -1, 512, 0, data)
+		if p.Dir != "read" || p.FD != -1 || p.Len != 512 {
+			t.Errorf("unexpected: %+v", p)
+		}
+		if p.Data != nil {
+			t.Errorf("Data = %v, want nil (metadata-only)", p.Data)
+		}
+	})
+
+	t.Run("captured clamped to buffer length", func(t *testing.T) {
+		p := decodeTLS(ts, tlsDirWrite, 3, 9000, 99999, data)
+		if len(p.Data) != len(data) {
+			t.Errorf("len(Data) = %d, want %d (clamped)", len(p.Data), len(data))
+		}
+	})
+}

--- a/pkg/collector/tls_ebpf.go
+++ b/pkg/collector/tls_ebpf.go
@@ -1,0 +1,81 @@
+//go:build linux && ebpf
+
+package collector
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"time"
+
+	"github.com/trentas/ptop/internal/bpf"
+)
+
+// TLSEBPFCollector consumes the tls_events ring buffer of the eBPF TLS tracer
+// and publishes one TLSPayload per SSL_write/SSL_read of the target (#55).
+// eBPF-only, opt-in (--tls), never simulated. maxBytes bounds the plaintext
+// copied per call (0 = metadata only).
+type TLSEBPFCollector struct {
+	tracer   *bpf.TLSTracer
+	maxBytes int
+	ch       chan interface{}
+	stop     chan struct{}
+}
+
+func NewTLSEBPFCollector(maxBytes int) *TLSEBPFCollector {
+	return &TLSEBPFCollector{
+		maxBytes: maxBytes,
+		// Buffered for bursty TLS traffic; the sender drops on overflow.
+		ch:   make(chan interface{}, 64),
+		stop: make(chan struct{}),
+	}
+}
+
+func (c *TLSEBPFCollector) Start(pid int) error {
+	tracer, err := bpf.OpenTLSTracer(pid, c.maxBytes)
+	if err != nil {
+		return fmt.Errorf("tls eBPF: %w", err)
+	}
+	c.tracer = tracer
+	// Drain payload events. tracer is passed explicitly (not read from the
+	// field) so Stop()'s `c.tracer = nil` can't race this goroutine; Close()
+	// shuts the ring-buffer reader, unblocking Next with io.EOF.
+	go c.readLoop(tracer)
+	return nil
+}
+
+func (c *TLSEBPFCollector) Stop() {
+	close(c.stop)
+	if c.tracer != nil {
+		_ = c.tracer.Close()
+		c.tracer = nil
+	}
+}
+
+func (c *TLSEBPFCollector) Subscribe() <-chan interface{} {
+	return c.ch
+}
+
+// readLoop drains the ring buffer, decoding each record into a TLSPayload and
+// publishing it. It exits on io.EOF (the tracer was closed). A garbled record is
+// logged-by-skip. Sends are non-blocking: under backpressure payloads are
+// dropped, consistent with every other collector.
+func (c *TLSEBPFCollector) readLoop(tracer *bpf.TLSTracer) {
+	if tracer == nil {
+		return
+	}
+	for {
+		rec, err := tracer.Next()
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				return
+			}
+			continue // transient (short/garbled record) — keep reading
+		}
+		p := decodeTLS(time.Now(), rec.Dir, rec.FD, rec.Len, rec.Captured, rec.Data[:])
+		select {
+		case c.ch <- p:
+		default:
+		}
+	}
+}

--- a/pkg/collector/tls_ebpf_stub.go
+++ b/pkg/collector/tls_ebpf_stub.go
@@ -1,0 +1,23 @@
+//go:build !linux || !ebpf
+
+package collector
+
+import "errors"
+
+// Stub: builds without -tags=ebpf or on non-Linux hosts get this
+// TLSEBPFCollector that always fails Start. TLS payload capture is eBPF-only
+// (libssl uprobes), opt-in, and never simulated.
+
+type TLSEBPFCollector struct{}
+
+func NewTLSEBPFCollector(maxBytes int) *TLSEBPFCollector {
+	return &TLSEBPFCollector{}
+}
+
+func (*TLSEBPFCollector) Start(pid int) error {
+	return errors.New("eBPF tls collector not available in this build")
+}
+
+func (*TLSEBPFCollector) Stop() {}
+
+func (*TLSEBPFCollector) Subscribe() <-chan interface{} { return nil }

--- a/pkg/collector/types.go
+++ b/pkg/collector/types.go
@@ -45,6 +45,22 @@ type NetError struct {
 	DetailMs    float64
 }
 
+// TLSPayload is plaintext observed around a TLS call (#55), captured via libssl
+// uprobes before encryption (Dir "write") or after decryption (Dir "read") — so
+// you can inspect a process's own encrypted traffic without a MITM proxy. FD is
+// the owning socket (−1 if unknown). Len is the call's plaintext byte count;
+// Data holds up to the configured cap of those bytes and is EMPTY unless
+// --tls-bytes was set (the metadata-only default). Emitted only by the eBPF TLS
+// collector when --tls is passed; never simulated. Privacy-sensitive: Data may
+// contain credentials/PII.
+type TLSPayload struct {
+	Timestamp time.Time
+	Dir       string // "write" (pre-encryption) | "read" (post-decryption)
+	FD        int
+	Len       int    // plaintext byte count for the call
+	Data      []byte // captured plaintext (≤ cap; empty in metadata-only mode)
+}
+
 // ─── Memory ───────────────────────────────────────────────────────────────────
 
 type MemStats struct {

--- a/pkg/streampb/event.pb.go
+++ b/pkg/streampb/event.pb.go
@@ -277,6 +277,7 @@ type Event struct {
 	//	*Event_NetError
 	//	*Event_FsEvent
 	//	*Event_Signal
+	//	*Event_Tls
 	Payload       isEvent_Payload `protobuf_oneof:"payload"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
@@ -507,6 +508,15 @@ func (x *Event) GetSignal() *SignalEvent {
 	return nil
 }
 
+func (x *Event) GetTls() *TLSPayloadEvent {
+	if x != nil {
+		if x, ok := x.Payload.(*Event_Tls); ok {
+			return x.Tls
+		}
+	}
+	return nil
+}
+
 type isEvent_Payload interface {
 	isEvent_Payload()
 }
@@ -580,6 +590,10 @@ type Event_Signal struct {
 	Signal *SignalEvent `protobuf:"bytes,26,opt,name=signal,proto3,oneof"` // #58 — signal delivered to the target, with origin
 }
 
+type Event_Tls struct {
+	Tls *TLSPayloadEvent `protobuf:"bytes,27,opt,name=tls,proto3,oneof"` // #55 — pre-encryption / post-decryption plaintext
+}
+
 func (*Event_Cpu) isEvent_Payload() {}
 
 func (*Event_Syscalls) isEvent_Payload() {}
@@ -613,6 +627,8 @@ func (*Event_NetError) isEvent_Payload() {}
 func (*Event_FsEvent) isEvent_Payload() {}
 
 func (*Event_Signal) isEvent_Payload() {}
+
+func (*Event_Tls) isEvent_Payload() {}
 
 // ─── CPU ──────────────────────────────────────────────────────────────────
 type CpuSample struct {
@@ -984,6 +1000,84 @@ func (x *NetErrorEvent) GetDetailMs() float64 {
 	return 0
 }
 
+// TLSPayloadEvent is plaintext observed around a TLS call (#55), captured via
+// libssl uprobes before encryption (dir "write") or after decryption (dir
+// "read"). fd is the owning socket (−1 if unknown); len is the call's plaintext
+// byte count. data holds up to the configured cap of those bytes and is EMPTY
+// unless --tls-bytes was set (metadata-only default). Category on the envelope
+// is NETWORK; the event timestamp lives on the envelope.
+//
+// PRIVACY: data may contain credentials/PII. Capture is opt-in (--tls) and the
+// payload bytes require the additional --tls-bytes flag. Consumers of the stream
+// must treat data as sensitive.
+type TLSPayloadEvent struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Dir           string                 `protobuf:"bytes,1,opt,name=dir,proto3" json:"dir,omitempty"` // "write" | "read"
+	Fd            int32                  `protobuf:"varint,2,opt,name=fd,proto3" json:"fd,omitempty"`
+	Len           int32                  `protobuf:"varint,3,opt,name=len,proto3" json:"len,omitempty"`
+	Data          []byte                 `protobuf:"bytes,4,opt,name=data,proto3" json:"data,omitempty"` // captured plaintext (≤ cap; empty in metadata-only mode)
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *TLSPayloadEvent) Reset() {
+	*x = TLSPayloadEvent{}
+	mi := &file_event_proto_msgTypes[9]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *TLSPayloadEvent) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*TLSPayloadEvent) ProtoMessage() {}
+
+func (x *TLSPayloadEvent) ProtoReflect() protoreflect.Message {
+	mi := &file_event_proto_msgTypes[9]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use TLSPayloadEvent.ProtoReflect.Descriptor instead.
+func (*TLSPayloadEvent) Descriptor() ([]byte, []int) {
+	return file_event_proto_rawDescGZIP(), []int{9}
+}
+
+func (x *TLSPayloadEvent) GetDir() string {
+	if x != nil {
+		return x.Dir
+	}
+	return ""
+}
+
+func (x *TLSPayloadEvent) GetFd() int32 {
+	if x != nil {
+		return x.Fd
+	}
+	return 0
+}
+
+func (x *TLSPayloadEvent) GetLen() int32 {
+	if x != nil {
+		return x.Len
+	}
+	return 0
+}
+
+func (x *TLSPayloadEvent) GetData() []byte {
+	if x != nil {
+		return x.Data
+	}
+	return nil
+}
+
 // ─── Memory ─────────────────────────────────────────────────────────────────
 type MemStats struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
@@ -997,7 +1091,7 @@ type MemStats struct {
 
 func (x *MemStats) Reset() {
 	*x = MemStats{}
-	mi := &file_event_proto_msgTypes[9]
+	mi := &file_event_proto_msgTypes[10]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1009,7 +1103,7 @@ func (x *MemStats) String() string {
 func (*MemStats) ProtoMessage() {}
 
 func (x *MemStats) ProtoReflect() protoreflect.Message {
-	mi := &file_event_proto_msgTypes[9]
+	mi := &file_event_proto_msgTypes[10]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1022,7 +1116,7 @@ func (x *MemStats) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use MemStats.ProtoReflect.Descriptor instead.
 func (*MemStats) Descriptor() ([]byte, []int) {
-	return file_event_proto_rawDescGZIP(), []int{9}
+	return file_event_proto_rawDescGZIP(), []int{10}
 }
 
 func (x *MemStats) GetRssBytes() uint64 {
@@ -1071,7 +1165,7 @@ type HeapEvent struct {
 
 func (x *HeapEvent) Reset() {
 	*x = HeapEvent{}
-	mi := &file_event_proto_msgTypes[10]
+	mi := &file_event_proto_msgTypes[11]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1083,7 +1177,7 @@ func (x *HeapEvent) String() string {
 func (*HeapEvent) ProtoMessage() {}
 
 func (x *HeapEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_event_proto_msgTypes[10]
+	mi := &file_event_proto_msgTypes[11]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1096,7 +1190,7 @@ func (x *HeapEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use HeapEvent.ProtoReflect.Descriptor instead.
 func (*HeapEvent) Descriptor() ([]byte, []int) {
-	return file_event_proto_rawDescGZIP(), []int{10}
+	return file_event_proto_rawDescGZIP(), []int{11}
 }
 
 func (x *HeapEvent) GetOp() string {
@@ -1172,7 +1266,7 @@ type HeapCallSite struct {
 
 func (x *HeapCallSite) Reset() {
 	*x = HeapCallSite{}
-	mi := &file_event_proto_msgTypes[11]
+	mi := &file_event_proto_msgTypes[12]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1184,7 +1278,7 @@ func (x *HeapCallSite) String() string {
 func (*HeapCallSite) ProtoMessage() {}
 
 func (x *HeapCallSite) ProtoReflect() protoreflect.Message {
-	mi := &file_event_proto_msgTypes[11]
+	mi := &file_event_proto_msgTypes[12]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1197,7 +1291,7 @@ func (x *HeapCallSite) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use HeapCallSite.ProtoReflect.Descriptor instead.
 func (*HeapCallSite) Descriptor() ([]byte, []int) {
-	return file_event_proto_rawDescGZIP(), []int{11}
+	return file_event_proto_rawDescGZIP(), []int{12}
 }
 
 func (x *HeapCallSite) GetCallSite() uint64 {
@@ -1300,7 +1394,7 @@ type HeapSnapshot struct {
 
 func (x *HeapSnapshot) Reset() {
 	*x = HeapSnapshot{}
-	mi := &file_event_proto_msgTypes[12]
+	mi := &file_event_proto_msgTypes[13]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1312,7 +1406,7 @@ func (x *HeapSnapshot) String() string {
 func (*HeapSnapshot) ProtoMessage() {}
 
 func (x *HeapSnapshot) ProtoReflect() protoreflect.Message {
-	mi := &file_event_proto_msgTypes[12]
+	mi := &file_event_proto_msgTypes[13]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1325,7 +1419,7 @@ func (x *HeapSnapshot) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use HeapSnapshot.ProtoReflect.Descriptor instead.
 func (*HeapSnapshot) Descriptor() ([]byte, []int) {
-	return file_event_proto_rawDescGZIP(), []int{12}
+	return file_event_proto_rawDescGZIP(), []int{13}
 }
 
 func (x *HeapSnapshot) GetLiveHeapBytes() uint64 {
@@ -1371,7 +1465,7 @@ type ThreadInfo struct {
 
 func (x *ThreadInfo) Reset() {
 	*x = ThreadInfo{}
-	mi := &file_event_proto_msgTypes[13]
+	mi := &file_event_proto_msgTypes[14]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1383,7 +1477,7 @@ func (x *ThreadInfo) String() string {
 func (*ThreadInfo) ProtoMessage() {}
 
 func (x *ThreadInfo) ProtoReflect() protoreflect.Message {
-	mi := &file_event_proto_msgTypes[13]
+	mi := &file_event_proto_msgTypes[14]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1396,7 +1490,7 @@ func (x *ThreadInfo) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ThreadInfo.ProtoReflect.Descriptor instead.
 func (*ThreadInfo) Descriptor() ([]byte, []int) {
-	return file_event_proto_rawDescGZIP(), []int{13}
+	return file_event_proto_rawDescGZIP(), []int{14}
 }
 
 func (x *ThreadInfo) GetTid() int32 {
@@ -1450,7 +1544,7 @@ type ThreadSnapshot struct {
 
 func (x *ThreadSnapshot) Reset() {
 	*x = ThreadSnapshot{}
-	mi := &file_event_proto_msgTypes[14]
+	mi := &file_event_proto_msgTypes[15]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1462,7 +1556,7 @@ func (x *ThreadSnapshot) String() string {
 func (*ThreadSnapshot) ProtoMessage() {}
 
 func (x *ThreadSnapshot) ProtoReflect() protoreflect.Message {
-	mi := &file_event_proto_msgTypes[14]
+	mi := &file_event_proto_msgTypes[15]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1475,7 +1569,7 @@ func (x *ThreadSnapshot) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ThreadSnapshot.ProtoReflect.Descriptor instead.
 func (*ThreadSnapshot) Descriptor() ([]byte, []int) {
-	return file_event_proto_rawDescGZIP(), []int{14}
+	return file_event_proto_rawDescGZIP(), []int{15}
 }
 
 func (x *ThreadSnapshot) GetThreads() []*ThreadInfo {
@@ -1495,7 +1589,7 @@ type IoWaitSample struct {
 
 func (x *IoWaitSample) Reset() {
 	*x = IoWaitSample{}
-	mi := &file_event_proto_msgTypes[15]
+	mi := &file_event_proto_msgTypes[16]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1507,7 +1601,7 @@ func (x *IoWaitSample) String() string {
 func (*IoWaitSample) ProtoMessage() {}
 
 func (x *IoWaitSample) ProtoReflect() protoreflect.Message {
-	mi := &file_event_proto_msgTypes[15]
+	mi := &file_event_proto_msgTypes[16]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1520,7 +1614,7 @@ func (x *IoWaitSample) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use IoWaitSample.ProtoReflect.Descriptor instead.
 func (*IoWaitSample) Descriptor() ([]byte, []int) {
-	return file_event_proto_rawDescGZIP(), []int{15}
+	return file_event_proto_rawDescGZIP(), []int{16}
 }
 
 func (x *IoWaitSample) GetPct() float64 {
@@ -1542,7 +1636,7 @@ type IoThroughputSample struct {
 
 func (x *IoThroughputSample) Reset() {
 	*x = IoThroughputSample{}
-	mi := &file_event_proto_msgTypes[16]
+	mi := &file_event_proto_msgTypes[17]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1554,7 +1648,7 @@ func (x *IoThroughputSample) String() string {
 func (*IoThroughputSample) ProtoMessage() {}
 
 func (x *IoThroughputSample) ProtoReflect() protoreflect.Message {
-	mi := &file_event_proto_msgTypes[16]
+	mi := &file_event_proto_msgTypes[17]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1567,7 +1661,7 @@ func (x *IoThroughputSample) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use IoThroughputSample.ProtoReflect.Descriptor instead.
 func (*IoThroughputSample) Descriptor() ([]byte, []int) {
-	return file_event_proto_rawDescGZIP(), []int{16}
+	return file_event_proto_rawDescGZIP(), []int{17}
 }
 
 func (x *IoThroughputSample) GetReadBytesPerS() float64 {
@@ -1613,7 +1707,7 @@ type IoFileStats struct {
 
 func (x *IoFileStats) Reset() {
 	*x = IoFileStats{}
-	mi := &file_event_proto_msgTypes[17]
+	mi := &file_event_proto_msgTypes[18]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1625,7 +1719,7 @@ func (x *IoFileStats) String() string {
 func (*IoFileStats) ProtoMessage() {}
 
 func (x *IoFileStats) ProtoReflect() protoreflect.Message {
-	mi := &file_event_proto_msgTypes[17]
+	mi := &file_event_proto_msgTypes[18]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1638,7 +1732,7 @@ func (x *IoFileStats) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use IoFileStats.ProtoReflect.Descriptor instead.
 func (*IoFileStats) Descriptor() ([]byte, []int) {
-	return file_event_proto_rawDescGZIP(), []int{17}
+	return file_event_proto_rawDescGZIP(), []int{18}
 }
 
 func (x *IoFileStats) GetPath() string {
@@ -1701,7 +1795,7 @@ type LatencyBucket struct {
 
 func (x *LatencyBucket) Reset() {
 	*x = LatencyBucket{}
-	mi := &file_event_proto_msgTypes[18]
+	mi := &file_event_proto_msgTypes[19]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1713,7 +1807,7 @@ func (x *LatencyBucket) String() string {
 func (*LatencyBucket) ProtoMessage() {}
 
 func (x *LatencyBucket) ProtoReflect() protoreflect.Message {
-	mi := &file_event_proto_msgTypes[18]
+	mi := &file_event_proto_msgTypes[19]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1726,7 +1820,7 @@ func (x *LatencyBucket) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LatencyBucket.ProtoReflect.Descriptor instead.
 func (*LatencyBucket) Descriptor() ([]byte, []int) {
-	return file_event_proto_rawDescGZIP(), []int{18}
+	return file_event_proto_rawDescGZIP(), []int{19}
 }
 
 func (x *LatencyBucket) GetLabel() string {
@@ -1767,7 +1861,7 @@ type IoSnapshot struct {
 
 func (x *IoSnapshot) Reset() {
 	*x = IoSnapshot{}
-	mi := &file_event_proto_msgTypes[19]
+	mi := &file_event_proto_msgTypes[20]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1779,7 +1873,7 @@ func (x *IoSnapshot) String() string {
 func (*IoSnapshot) ProtoMessage() {}
 
 func (x *IoSnapshot) ProtoReflect() protoreflect.Message {
-	mi := &file_event_proto_msgTypes[19]
+	mi := &file_event_proto_msgTypes[20]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1792,7 +1886,7 @@ func (x *IoSnapshot) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use IoSnapshot.ProtoReflect.Descriptor instead.
 func (*IoSnapshot) Descriptor() ([]byte, []int) {
-	return file_event_proto_rawDescGZIP(), []int{19}
+	return file_event_proto_rawDescGZIP(), []int{20}
 }
 
 func (x *IoSnapshot) GetReadBytesPerS() float64 {
@@ -1878,7 +1972,7 @@ type FSEvent struct {
 
 func (x *FSEvent) Reset() {
 	*x = FSEvent{}
-	mi := &file_event_proto_msgTypes[20]
+	mi := &file_event_proto_msgTypes[21]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1890,7 +1984,7 @@ func (x *FSEvent) String() string {
 func (*FSEvent) ProtoMessage() {}
 
 func (x *FSEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_event_proto_msgTypes[20]
+	mi := &file_event_proto_msgTypes[21]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1903,7 +1997,7 @@ func (x *FSEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use FSEvent.ProtoReflect.Descriptor instead.
 func (*FSEvent) Descriptor() ([]byte, []int) {
-	return file_event_proto_rawDescGZIP(), []int{20}
+	return file_event_proto_rawDescGZIP(), []int{21}
 }
 
 func (x *FSEvent) GetOp() string {
@@ -1964,7 +2058,7 @@ type SignalEvent struct {
 
 func (x *SignalEvent) Reset() {
 	*x = SignalEvent{}
-	mi := &file_event_proto_msgTypes[21]
+	mi := &file_event_proto_msgTypes[22]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1976,7 +2070,7 @@ func (x *SignalEvent) String() string {
 func (*SignalEvent) ProtoMessage() {}
 
 func (x *SignalEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_event_proto_msgTypes[21]
+	mi := &file_event_proto_msgTypes[22]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1989,7 +2083,7 @@ func (x *SignalEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SignalEvent.ProtoReflect.Descriptor instead.
 func (*SignalEvent) Descriptor() ([]byte, []int) {
-	return file_event_proto_rawDescGZIP(), []int{21}
+	return file_event_proto_rawDescGZIP(), []int{22}
 }
 
 func (x *SignalEvent) GetSignal() string {
@@ -2057,7 +2151,7 @@ type FdEntry struct {
 
 func (x *FdEntry) Reset() {
 	*x = FdEntry{}
-	mi := &file_event_proto_msgTypes[22]
+	mi := &file_event_proto_msgTypes[23]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2069,7 +2163,7 @@ func (x *FdEntry) String() string {
 func (*FdEntry) ProtoMessage() {}
 
 func (x *FdEntry) ProtoReflect() protoreflect.Message {
-	mi := &file_event_proto_msgTypes[22]
+	mi := &file_event_proto_msgTypes[23]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2082,7 +2176,7 @@ func (x *FdEntry) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use FdEntry.ProtoReflect.Descriptor instead.
 func (*FdEntry) Descriptor() ([]byte, []int) {
-	return file_event_proto_rawDescGZIP(), []int{22}
+	return file_event_proto_rawDescGZIP(), []int{23}
 }
 
 func (x *FdEntry) GetFd() int32 {
@@ -2143,7 +2237,7 @@ type FdSnapshot struct {
 
 func (x *FdSnapshot) Reset() {
 	*x = FdSnapshot{}
-	mi := &file_event_proto_msgTypes[23]
+	mi := &file_event_proto_msgTypes[24]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2155,7 +2249,7 @@ func (x *FdSnapshot) String() string {
 func (*FdSnapshot) ProtoMessage() {}
 
 func (x *FdSnapshot) ProtoReflect() protoreflect.Message {
-	mi := &file_event_proto_msgTypes[23]
+	mi := &file_event_proto_msgTypes[24]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2168,7 +2262,7 @@ func (x *FdSnapshot) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use FdSnapshot.ProtoReflect.Descriptor instead.
 func (*FdSnapshot) Descriptor() ([]byte, []int) {
-	return file_event_proto_rawDescGZIP(), []int{23}
+	return file_event_proto_rawDescGZIP(), []int{24}
 }
 
 func (x *FdSnapshot) GetFds() []*FdEntry {
@@ -2189,7 +2283,7 @@ type FdEvent struct {
 
 func (x *FdEvent) Reset() {
 	*x = FdEvent{}
-	mi := &file_event_proto_msgTypes[24]
+	mi := &file_event_proto_msgTypes[25]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2201,7 +2295,7 @@ func (x *FdEvent) String() string {
 func (*FdEvent) ProtoMessage() {}
 
 func (x *FdEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_event_proto_msgTypes[24]
+	mi := &file_event_proto_msgTypes[25]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2214,7 +2308,7 @@ func (x *FdEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use FdEvent.ProtoReflect.Descriptor instead.
 func (*FdEvent) Descriptor() ([]byte, []int) {
-	return file_event_proto_rawDescGZIP(), []int{24}
+	return file_event_proto_rawDescGZIP(), []int{25}
 }
 
 func (x *FdEvent) GetMessage() string {
@@ -2240,7 +2334,7 @@ type LockEntry struct {
 
 func (x *LockEntry) Reset() {
 	*x = LockEntry{}
-	mi := &file_event_proto_msgTypes[25]
+	mi := &file_event_proto_msgTypes[26]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2252,7 +2346,7 @@ func (x *LockEntry) String() string {
 func (*LockEntry) ProtoMessage() {}
 
 func (x *LockEntry) ProtoReflect() protoreflect.Message {
-	mi := &file_event_proto_msgTypes[25]
+	mi := &file_event_proto_msgTypes[26]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2265,7 +2359,7 @@ func (x *LockEntry) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LockEntry.ProtoReflect.Descriptor instead.
 func (*LockEntry) Descriptor() ([]byte, []int) {
-	return file_event_proto_rawDescGZIP(), []int{25}
+	return file_event_proto_rawDescGZIP(), []int{26}
 }
 
 func (x *LockEntry) GetUaddr() uint64 {
@@ -2326,7 +2420,7 @@ type LockSnapshot struct {
 
 func (x *LockSnapshot) Reset() {
 	*x = LockSnapshot{}
-	mi := &file_event_proto_msgTypes[26]
+	mi := &file_event_proto_msgTypes[27]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2338,7 +2432,7 @@ func (x *LockSnapshot) String() string {
 func (*LockSnapshot) ProtoMessage() {}
 
 func (x *LockSnapshot) ProtoReflect() protoreflect.Message {
-	mi := &file_event_proto_msgTypes[26]
+	mi := &file_event_proto_msgTypes[27]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2351,7 +2445,7 @@ func (x *LockSnapshot) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LockSnapshot.ProtoReflect.Descriptor instead.
 func (*LockSnapshot) Descriptor() ([]byte, []int) {
-	return file_event_proto_rawDescGZIP(), []int{26}
+	return file_event_proto_rawDescGZIP(), []int{27}
 }
 
 func (x *LockSnapshot) GetLocks() []*LockEntry {
@@ -2372,7 +2466,7 @@ type TimelineEvent struct {
 
 func (x *TimelineEvent) Reset() {
 	*x = TimelineEvent{}
-	mi := &file_event_proto_msgTypes[27]
+	mi := &file_event_proto_msgTypes[28]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2384,7 +2478,7 @@ func (x *TimelineEvent) String() string {
 func (*TimelineEvent) ProtoMessage() {}
 
 func (x *TimelineEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_event_proto_msgTypes[27]
+	mi := &file_event_proto_msgTypes[28]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2397,7 +2491,7 @@ func (x *TimelineEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TimelineEvent.ProtoReflect.Descriptor instead.
 func (*TimelineEvent) Descriptor() ([]byte, []int) {
-	return file_event_proto_rawDescGZIP(), []int{27}
+	return file_event_proto_rawDescGZIP(), []int{28}
 }
 
 func (x *TimelineEvent) GetMessage() string {
@@ -2422,7 +2516,7 @@ const file_event_proto_rawDesc = "" +
 	"\x04line\x18\x03 \x01(\x05R\x04line\x12\x16\n" +
 	"\x06module\x18\x04 \x01(\tR\x06module\x12\x16\n" +
 	"\x06offset\x18\x05 \x01(\x04R\x06offset\x12\x19\n" +
-	"\bbuild_id\x18\x06 \x01(\tR\abuildId\"\xfa\a\n" +
+	"\bbuild_id\x18\x06 \x01(\tR\abuildId\"\xa8\b\n" +
 	"\x05Event\x12 \n" +
 	"\fts_unix_nano\x18\x01 \x01(\x03R\n" +
 	"tsUnixNano\x12\x10\n" +
@@ -2448,7 +2542,8 @@ const file_event_proto_rawDesc = "" +
 	"heap_event\x18\x17 \x01(\v2\x12.ptop.v1.HeapEventH\x00R\theapEvent\x125\n" +
 	"\tnet_error\x18\x18 \x01(\v2\x16.ptop.v1.NetErrorEventH\x00R\bnetError\x12-\n" +
 	"\bfs_event\x18\x19 \x01(\v2\x10.ptop.v1.FSEventH\x00R\afsEvent\x12.\n" +
-	"\x06signal\x18\x1a \x01(\v2\x14.ptop.v1.SignalEventH\x00R\x06signalB\t\n" +
+	"\x06signal\x18\x1a \x01(\v2\x14.ptop.v1.SignalEventH\x00R\x06signal\x12,\n" +
+	"\x03tls\x18\x1b \x01(\v2\x18.ptop.v1.TLSPayloadEventH\x00R\x03tlsB\t\n" +
 	"\apayload\"(\n" +
 	"\tCpuSample\x12\x1b\n" +
 	"\tusage_pct\x18\x01 \x01(\x01R\busagePct\"V\n" +
@@ -2475,7 +2570,12 @@ const file_event_proto_rawDesc = "" +
 	"\x04kind\x18\x01 \x01(\tR\x04kind\x12\x16\n" +
 	"\x06remote\x18\x02 \x01(\tR\x06remote\x12 \n" +
 	"\vretransmits\x18\x03 \x01(\rR\vretransmits\x12\x1b\n" +
-	"\tdetail_ms\x18\x04 \x01(\x01R\bdetailMs\"\x89\x01\n" +
+	"\tdetail_ms\x18\x04 \x01(\x01R\bdetailMs\"Y\n" +
+	"\x0fTLSPayloadEvent\x12\x10\n" +
+	"\x03dir\x18\x01 \x01(\tR\x03dir\x12\x0e\n" +
+	"\x02fd\x18\x02 \x01(\x05R\x02fd\x12\x10\n" +
+	"\x03len\x18\x03 \x01(\x05R\x03len\x12\x12\n" +
+	"\x04data\x18\x04 \x01(\fR\x04data\"\x89\x01\n" +
 	"\bMemStats\x12\x1b\n" +
 	"\trss_bytes\x18\x01 \x01(\x04R\brssBytes\x12\x1d\n" +
 	"\n" +
@@ -2628,7 +2728,7 @@ func file_event_proto_rawDescGZIP() []byte {
 }
 
 var file_event_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
-var file_event_proto_msgTypes = make([]protoimpl.MessageInfo, 28)
+var file_event_proto_msgTypes = make([]protoimpl.MessageInfo, 29)
 var file_event_proto_goTypes = []any{
 	(Category)(0),              // 0: ptop.v1.Category
 	(*StackRef)(nil),           // 1: ptop.v1.StackRef
@@ -2640,25 +2740,26 @@ var file_event_proto_goTypes = []any{
 	(*NetConn)(nil),            // 7: ptop.v1.NetConn
 	(*NetworkSnapshot)(nil),    // 8: ptop.v1.NetworkSnapshot
 	(*NetErrorEvent)(nil),      // 9: ptop.v1.NetErrorEvent
-	(*MemStats)(nil),           // 10: ptop.v1.MemStats
-	(*HeapEvent)(nil),          // 11: ptop.v1.HeapEvent
-	(*HeapCallSite)(nil),       // 12: ptop.v1.HeapCallSite
-	(*HeapSnapshot)(nil),       // 13: ptop.v1.HeapSnapshot
-	(*ThreadInfo)(nil),         // 14: ptop.v1.ThreadInfo
-	(*ThreadSnapshot)(nil),     // 15: ptop.v1.ThreadSnapshot
-	(*IoWaitSample)(nil),       // 16: ptop.v1.IoWaitSample
-	(*IoThroughputSample)(nil), // 17: ptop.v1.IoThroughputSample
-	(*IoFileStats)(nil),        // 18: ptop.v1.IoFileStats
-	(*LatencyBucket)(nil),      // 19: ptop.v1.LatencyBucket
-	(*IoSnapshot)(nil),         // 20: ptop.v1.IoSnapshot
-	(*FSEvent)(nil),            // 21: ptop.v1.FSEvent
-	(*SignalEvent)(nil),        // 22: ptop.v1.SignalEvent
-	(*FdEntry)(nil),            // 23: ptop.v1.FdEntry
-	(*FdSnapshot)(nil),         // 24: ptop.v1.FdSnapshot
-	(*FdEvent)(nil),            // 25: ptop.v1.FdEvent
-	(*LockEntry)(nil),          // 26: ptop.v1.LockEntry
-	(*LockSnapshot)(nil),       // 27: ptop.v1.LockSnapshot
-	(*TimelineEvent)(nil),      // 28: ptop.v1.TimelineEvent
+	(*TLSPayloadEvent)(nil),    // 10: ptop.v1.TLSPayloadEvent
+	(*MemStats)(nil),           // 11: ptop.v1.MemStats
+	(*HeapEvent)(nil),          // 12: ptop.v1.HeapEvent
+	(*HeapCallSite)(nil),       // 13: ptop.v1.HeapCallSite
+	(*HeapSnapshot)(nil),       // 14: ptop.v1.HeapSnapshot
+	(*ThreadInfo)(nil),         // 15: ptop.v1.ThreadInfo
+	(*ThreadSnapshot)(nil),     // 16: ptop.v1.ThreadSnapshot
+	(*IoWaitSample)(nil),       // 17: ptop.v1.IoWaitSample
+	(*IoThroughputSample)(nil), // 18: ptop.v1.IoThroughputSample
+	(*IoFileStats)(nil),        // 19: ptop.v1.IoFileStats
+	(*LatencyBucket)(nil),      // 20: ptop.v1.LatencyBucket
+	(*IoSnapshot)(nil),         // 21: ptop.v1.IoSnapshot
+	(*FSEvent)(nil),            // 22: ptop.v1.FSEvent
+	(*SignalEvent)(nil),        // 23: ptop.v1.SignalEvent
+	(*FdEntry)(nil),            // 24: ptop.v1.FdEntry
+	(*FdSnapshot)(nil),         // 25: ptop.v1.FdSnapshot
+	(*FdEvent)(nil),            // 26: ptop.v1.FdEvent
+	(*LockEntry)(nil),          // 27: ptop.v1.LockEntry
+	(*LockSnapshot)(nil),       // 28: ptop.v1.LockSnapshot
+	(*TimelineEvent)(nil),      // 29: ptop.v1.TimelineEvent
 }
 var file_event_proto_depIdxs = []int32{
 	0,  // 0: ptop.v1.Event.category:type_name -> ptop.v1.Category
@@ -2666,33 +2767,34 @@ var file_event_proto_depIdxs = []int32{
 	4,  // 2: ptop.v1.Event.cpu:type_name -> ptop.v1.CpuSample
 	6,  // 3: ptop.v1.Event.syscalls:type_name -> ptop.v1.SyscallSnapshot
 	8,  // 4: ptop.v1.Event.network:type_name -> ptop.v1.NetworkSnapshot
-	10, // 5: ptop.v1.Event.memory:type_name -> ptop.v1.MemStats
-	15, // 6: ptop.v1.Event.threads:type_name -> ptop.v1.ThreadSnapshot
-	16, // 7: ptop.v1.Event.io_wait:type_name -> ptop.v1.IoWaitSample
-	17, // 8: ptop.v1.Event.io_throughput:type_name -> ptop.v1.IoThroughputSample
-	20, // 9: ptop.v1.Event.io:type_name -> ptop.v1.IoSnapshot
-	24, // 10: ptop.v1.Event.fds:type_name -> ptop.v1.FdSnapshot
-	25, // 11: ptop.v1.Event.fd_event:type_name -> ptop.v1.FdEvent
-	27, // 12: ptop.v1.Event.locks:type_name -> ptop.v1.LockSnapshot
-	28, // 13: ptop.v1.Event.timeline:type_name -> ptop.v1.TimelineEvent
-	13, // 14: ptop.v1.Event.heap:type_name -> ptop.v1.HeapSnapshot
-	11, // 15: ptop.v1.Event.heap_event:type_name -> ptop.v1.HeapEvent
+	11, // 5: ptop.v1.Event.memory:type_name -> ptop.v1.MemStats
+	16, // 6: ptop.v1.Event.threads:type_name -> ptop.v1.ThreadSnapshot
+	17, // 7: ptop.v1.Event.io_wait:type_name -> ptop.v1.IoWaitSample
+	18, // 8: ptop.v1.Event.io_throughput:type_name -> ptop.v1.IoThroughputSample
+	21, // 9: ptop.v1.Event.io:type_name -> ptop.v1.IoSnapshot
+	25, // 10: ptop.v1.Event.fds:type_name -> ptop.v1.FdSnapshot
+	26, // 11: ptop.v1.Event.fd_event:type_name -> ptop.v1.FdEvent
+	28, // 12: ptop.v1.Event.locks:type_name -> ptop.v1.LockSnapshot
+	29, // 13: ptop.v1.Event.timeline:type_name -> ptop.v1.TimelineEvent
+	14, // 14: ptop.v1.Event.heap:type_name -> ptop.v1.HeapSnapshot
+	12, // 15: ptop.v1.Event.heap_event:type_name -> ptop.v1.HeapEvent
 	9,  // 16: ptop.v1.Event.net_error:type_name -> ptop.v1.NetErrorEvent
-	21, // 17: ptop.v1.Event.fs_event:type_name -> ptop.v1.FSEvent
-	22, // 18: ptop.v1.Event.signal:type_name -> ptop.v1.SignalEvent
-	5,  // 19: ptop.v1.SyscallSnapshot.stats:type_name -> ptop.v1.SyscallStat
-	7,  // 20: ptop.v1.NetworkSnapshot.conns:type_name -> ptop.v1.NetConn
-	12, // 21: ptop.v1.HeapSnapshot.top_call_sites:type_name -> ptop.v1.HeapCallSite
-	14, // 22: ptop.v1.ThreadSnapshot.threads:type_name -> ptop.v1.ThreadInfo
-	18, // 23: ptop.v1.IoSnapshot.top_files:type_name -> ptop.v1.IoFileStats
-	19, // 24: ptop.v1.IoSnapshot.latency_buckets:type_name -> ptop.v1.LatencyBucket
-	23, // 25: ptop.v1.FdSnapshot.fds:type_name -> ptop.v1.FdEntry
-	26, // 26: ptop.v1.LockSnapshot.locks:type_name -> ptop.v1.LockEntry
-	27, // [27:27] is the sub-list for method output_type
-	27, // [27:27] is the sub-list for method input_type
-	27, // [27:27] is the sub-list for extension type_name
-	27, // [27:27] is the sub-list for extension extendee
-	0,  // [0:27] is the sub-list for field type_name
+	22, // 17: ptop.v1.Event.fs_event:type_name -> ptop.v1.FSEvent
+	23, // 18: ptop.v1.Event.signal:type_name -> ptop.v1.SignalEvent
+	10, // 19: ptop.v1.Event.tls:type_name -> ptop.v1.TLSPayloadEvent
+	5,  // 20: ptop.v1.SyscallSnapshot.stats:type_name -> ptop.v1.SyscallStat
+	7,  // 21: ptop.v1.NetworkSnapshot.conns:type_name -> ptop.v1.NetConn
+	13, // 22: ptop.v1.HeapSnapshot.top_call_sites:type_name -> ptop.v1.HeapCallSite
+	15, // 23: ptop.v1.ThreadSnapshot.threads:type_name -> ptop.v1.ThreadInfo
+	19, // 24: ptop.v1.IoSnapshot.top_files:type_name -> ptop.v1.IoFileStats
+	20, // 25: ptop.v1.IoSnapshot.latency_buckets:type_name -> ptop.v1.LatencyBucket
+	24, // 26: ptop.v1.FdSnapshot.fds:type_name -> ptop.v1.FdEntry
+	27, // 27: ptop.v1.LockSnapshot.locks:type_name -> ptop.v1.LockEntry
+	28, // [28:28] is the sub-list for method output_type
+	28, // [28:28] is the sub-list for method input_type
+	28, // [28:28] is the sub-list for extension type_name
+	28, // [28:28] is the sub-list for extension extendee
+	0,  // [0:28] is the sub-list for field type_name
 }
 
 func init() { file_event_proto_init() }
@@ -2718,6 +2820,7 @@ func file_event_proto_init() {
 		(*Event_NetError)(nil),
 		(*Event_FsEvent)(nil),
 		(*Event_Signal)(nil),
+		(*Event_Tls)(nil),
 	}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
@@ -2725,7 +2828,7 @@ func file_event_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_event_proto_rawDesc), len(file_event_proto_rawDesc)),
 			NumEnums:      1,
-			NumMessages:   28,
+			NumMessages:   29,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/proto/event.proto
+++ b/proto/event.proto
@@ -79,8 +79,9 @@ message Event {
     NetErrorEvent net_error = 24; // #56 — detailed network error
     FSEvent fs_event = 25; // #57 — filesystem semantics (denial/delete/rename)
     SignalEvent signal = 26; // #58 — signal delivered to the target, with origin
-    // 27+ reserved for the remaining #52 capabilities (pre-encryption payload,
-    // security/LSM, exec-context enrichment).
+    TLSPayloadEvent tls = 27; // #55 — pre-encryption / post-decryption plaintext
+    // 28+ reserved for the remaining #52 capabilities (security/LSM,
+    // exec-context enrichment).
   }
 }
 
@@ -126,6 +127,23 @@ message NetErrorEvent {
   string remote = 2; // peer host:port
   uint32 retransmits = 3;
   double detail_ms = 4;
+}
+
+// TLSPayloadEvent is plaintext observed around a TLS call (#55), captured via
+// libssl uprobes before encryption (dir "write") or after decryption (dir
+// "read"). fd is the owning socket (−1 if unknown); len is the call's plaintext
+// byte count. data holds up to the configured cap of those bytes and is EMPTY
+// unless --tls-bytes was set (metadata-only default). Category on the envelope
+// is NETWORK; the event timestamp lives on the envelope.
+//
+// PRIVACY: data may contain credentials/PII. Capture is opt-in (--tls) and the
+// payload bytes require the additional --tls-bytes flag. Consumers of the stream
+// must treat data as sensitive.
+message TLSPayloadEvent {
+  string dir = 1; // "write" | "read"
+  int32 fd = 2;
+  int32 len = 3;
+  bytes data = 4; // captured plaintext (≤ cap; empty in metadata-only mode)
 }
 
 // ─── Memory ─────────────────────────────────────────────────────────────────


### PR DESCRIPTION
Closes #55 — part of the #52 epic (expand collector capture surface).

## What

Capture **plaintext around TLS** — written before encryption (`SSL_write`) and
read after decryption (`SSL_read`) — by uprobing the target's libssl, so you can
debug a process's own encrypted traffic without a MITM proxy or SSLKEYLOGFILE.
**Stream/export-only** (no live TUI panel — live plaintext is a privacy footgun).

`TLSPayloadEvent{dir, fd, len, data}` on the gRPC/JSONL stream (oneof 27,
`CATEGORY_NETWORK`).

## Privacy model (opt-in, two levels)

- **OFF by default** — no SSL uprobes attach unless `--tls` is passed.
- `--tls` → **metadata only** (direction, fd, byte count). No payload bytes.
- `--tls-bytes N` (implies `--tls`) → also capture ≤ N **plaintext** bytes/call
  (credentials/PII), clamped to 4096, with a loud stderr warning.
- The `--serve` privilege boundary (unix `0600` / TCP loopback-only) guards the
  captured plaintext. Resolve **by symbol** (version-drift safe).

## Design — mirrors the heap libc uprobes (#53)

`resolveLibSSL` finds `libssl.so` in `/proc/<pid>/maps`; `link.OpenExecutable.
Uprobe` attaches `SSL_write` (plaintext in buf at entry), `SSL_read`
(entry-stash + uretprobe — buf is filled at return), and `SSL_set_fd` →
`ssl→fd` map for connection correlation (no SSL-struct offset reads). The
payload copy is bounded by a verifier-friendly `& (TLS_MAX_DATA-1)` mask kept as
the **sole** bound (a pre-clamp gets optimized away, leaving the verifier with
an unbounded length — `R2 min value is negative`).

## Validation

- `go vet` + `go test -race` (default + `-tags=ebpf` stub); `buf
  lint/format/generate/breaking`; `GOOS=linux go vet`.
- **Real eBPF in privileged Docker** (local TLS server + a C OpenSSL client that
  explicitly calls `SSL_set_fd`/`SSL_write`/`SSL_read`): `--tls-bytes 256`
  captured the cleartext request (incl. a secret header) + decrypted response
  with `fd` correlated; `--tls` alone emitted metadata with empty `data`;
  without `--tls`, zero TLS events.

## Deferred (documented)
`libgnutls`/NSS; OpenSSL 3.x `SSL_write_ex`/`SSL_read_ex`; call-site/stack ref;
redaction hooks; SSL→fd when `SSL_set_fd` wasn't used. Go/static targets have no
libssl → capture unavailable (graceful).

🤖 Generated with [Claude Code](https://claude.com/claude-code)