### PR TITLE
context: capture namespace/cgroup + uid/gid execution context (#60)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -146,6 +146,8 @@ ptop/
 │       ├── network_ebpf.go        connections + RTT + bytes
 │       ├── syscalls_ebpf.go       per-syscall counts + latency
 │       ├── futex_ebpf.go          lock graph from futex tracking
+│       ├── proccontext_linux.go   /proc ns + cgroup + uid/gid context (#60)
+│       ├── proccontext.go         container-id / cgroup / ns-inode parsers (build-tag-free)
 │       ├── fds.go                 /proc/<pid>/fd + fdinfo + events
 │       ├── sockets.go             inode → host:port via /proc/net/*
 │       ├── syscall_names.go       syscall id → name table

--- a/README.md
+++ b/README.md
@@ -163,6 +163,11 @@ overlay shows which one is active per tab.
 - `iowait_proc.go` — `/proc/<pid>/stat` field 42 (delayacct_blkio_ticks)
 - `io_proc.go` — `/proc/<pid>/io`
 - `fds.go` + `sockets.go` — `/proc/<pid>/fd`, `/proc/net/{tcp,tcp6,udp,udp6,unix}`
+- `proccontext_linux.go` — `/proc/<pid>/{status,cgroup,ns/*}` → namespace +
+  cgroup + uid/gid (the execution/container context, #60). When the target runs
+  in a container the derived id (`docker:…`, `containerd:…`, `kubepods:…`, …)
+  shows in the header; the full context rides the `--serve`/`--export` stream
+  (a periodic `ProcContext`, plus uid/gid/cgroup_id stamped on every event).
 
 eBPF programs in `internal/bpf/programs/`:
 

--- a/internal/serve/hub.go
+++ b/internal/serve/hub.go
@@ -17,6 +17,13 @@ type Hub struct {
 	buildID string // target exec build-id, stamped onto every StackRef (#54)
 	mu      sync.Mutex
 	sinks   map[Sink]struct{}
+
+	// Execution-context identity (#60) stamped onto every outgoing envelope.
+	// Updated whenever a ProcContext snapshot flows through; zero until the
+	// first one is observed (and on platforms without /proc).
+	identMu  sync.Mutex
+	uid, gid uint32
+	cgroupID uint64
 }
 
 func NewHub(pid int, buildID string) *Hub {
@@ -45,11 +52,34 @@ func (h *Hub) drain(ctx context.Context, ch <-chan interface{}) {
 			if !ok {
 				return
 			}
+			// A ProcContext refreshes the cached identity before it (and every
+			// subsequent event) is stamped — so the snapshot event itself
+			// carries its own up-to-date uid/gid/cgroup_id.
+			if pc, ok := v.(collector.ProcContext); ok {
+				h.setIdent(pc)
+			}
 			if ev := toEvent(h.pid, h.buildID, v); ev != nil {
+				h.stampIdent(ev)
 				h.broadcast(ev)
 			}
 		}
 	}
+}
+
+// setIdent updates the cached execution-context identity from a ProcContext
+// snapshot (#60).
+func (h *Hub) setIdent(pc collector.ProcContext) {
+	h.identMu.Lock()
+	h.uid, h.gid, h.cgroupID = pc.UID, pc.GID, pc.CgroupID
+	h.identMu.Unlock()
+}
+
+// stampIdent writes the cached identity onto an event envelope. Values are 0
+// until the first ProcContext arrives (and where /proc is unavailable).
+func (h *Hub) stampIdent(ev *pb.Event) {
+	h.identMu.Lock()
+	ev.Uid, ev.Gid, ev.CgroupId = h.uid, h.gid, h.cgroupID
+	h.identMu.Unlock()
 }
 
 // broadcast hands the event to every sink. Emit must not block (sinks own their

--- a/internal/serve/mapper.go
+++ b/internal/serve/mapper.go
@@ -170,6 +170,16 @@ func toEvent(pid int, buildID string, v interface{}) *pb.Event {
 			Code: x.Code, Result: x.Result,
 		}}
 
+	case collector.ProcContext:
+		ev.TsUnixNano = tsNano(x.Timestamp)
+		ev.Category = pb.Category_CATEGORY_PROCESS
+		ev.Payload = &pb.Event_ProcContext{ProcContext: &pb.ProcContext{
+			Uid: x.UID, Gid: x.GID,
+			PidNs: x.PIDNS, NetNs: x.NetNS, MntNs: x.MntNS, UserNs: x.UserNS,
+			CgroupNs: x.CgroupNS, IpcNs: x.IPCNS, UtsNs: x.UTSNS,
+			CgroupId: x.CgroupID, Cgroup: x.Cgroup, Container: x.Container,
+		}}
+
 	case collector.TimelineEvent:
 		ev.TsUnixNano = tsNano(x.Timestamp)
 		ev.Category = timelineCategory(x.Category)

--- a/internal/tui/header.go
+++ b/internal/tui/header.go
@@ -60,6 +60,12 @@ func renderHeader(m Model) string {
 	if m.Runtime != "" {
 		leftSegs = append(leftSegs, seg{Badge(m.Runtime, ColorCyan), 2})
 	}
+	// Container/execution context (#60): show the derived container id when the
+	// target runs inside one. Lowest priority (prio 2) — drops first on narrow
+	// terminals, like the runtime badge.
+	if m.ProcCtx.Container != "" {
+		leftSegs = append(leftSegs, seg{Badge(m.ProcCtx.Container, ColorPurple), 2})
+	}
 	leftSegs = append(leftSegs,
 		seg{stateBadge, 1},
 		seg{fdBadge, 1},

--- a/internal/tui/help.go
+++ b/internal/tui/help.go
@@ -145,6 +145,15 @@ func renderHelpOverlayWithStatus(m Model, w, h int) string {
 		statusRow("io-wait", m.usingMockIOWait, sourceProcOrEmpty(!m.usingMockIOWait)),
 		statusRow("io-throughput", m.usingMockIOThrough, sourceProcOrEmpty(!m.usingMockIOThrough)),
 		statusRow("fds", m.usingMockFDs, sourceProcOrEmpty(!m.usingMockFDs)),
+		// Execution context (#60) is /proc-based and never simulated: "real via
+		// /proc" when the namespace/cgroup collector started, else structurally
+		// unavailable (macOS has no namespaces/cgroups).
+		func() string {
+			if m.contextSource != "" {
+				return statusRow("context", false, m.contextSource)
+			}
+			return statusRowNA("context", "namespace/cgroup is Linux-only")
+		}(),
 	}
 
 	// Scroll: card has border (2 lines) + padding (2 lines) = 4 overhead;

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -91,6 +91,7 @@ type NetMsg []collector.NetConn
 type NetErrorMsg collector.NetError
 type SignalMsg collector.SignalEvent
 type TLSPayloadMsg collector.TLSPayload
+type ProcContextMsg collector.ProcContext
 type LockGraphMsg []collector.LockEntry
 type LockTimelineMsg collector.TimelineEvent
 
@@ -130,6 +131,7 @@ type Model struct {
 	Timeline       []collector.TimelineEvent
 	Signals        []collector.SignalEvent // eBPF signals delivered to the target (#58), newest-first
 	TLSPayloads    []collector.TLSPayload  // eBPF TLS payloads (#55), newest-first; stream/export-only, no live panel
+	ProcCtx        collector.ProcContext   // /proc namespace/cgroup/identity context (#60); zero value until first sample (or on macOS)
 	LockGraph      []collector.LockEntry
 
 	// UI state
@@ -191,6 +193,7 @@ type Model struct {
 	locksSource    string
 	signalsSource  string
 	tlsSource      string
+	contextSource  string
 
 	// Stable caches to avoid visual reordering between ticks.
 	// topSyscallNames is recomputed every `topRefreshInterval`; between refreshes
@@ -245,6 +248,7 @@ func NewModel(cfg Config) Model {
 	m.locksSource = m.collectors.Sources.Locks
 	m.signalsSource = m.collectors.Sources.Signals
 	m.tlsSource = m.collectors.Sources.TLS
+	m.contextSource = m.collectors.Sources.Context
 
 	m.usingMockFDs = m.collectors.MockFDs()
 	m.usingMockCPU = m.collectors.MockCPU()
@@ -321,6 +325,9 @@ func (m Model) Init() tea.Cmd {
 	}
 	if m.collectors.TLSEBPF != nil {
 		cmds = append(cmds, waitForTLSEBPF(m.collectors.TLSEBPF))
+	}
+	if m.collectors.ProcContext != nil {
+		cmds = append(cmds, waitForProcContext(m.collectors.ProcContext))
 	}
 	if m.exportFile != nil {
 		cmds = append(cmds, exportTick())
@@ -494,6 +501,13 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.TLSPayloads = m.TLSPayloads[:40]
 		}
 		return m, waitForTLSEBPF(m.collectors.TLSEBPF)
+
+	case ProcContextMsg:
+		// Execution/container context refresh (#60). We keep only the latest
+		// snapshot — the header shows the container badge; the full context is
+		// in the export and the stream. Never simulated.
+		m.ProcCtx = collector.ProcContext(v)
+		return m, waitForProcContext(m.collectors.ProcContext)
 
 	case LockGraphMsg:
 		m.LockGraph = []collector.LockEntry(v)
@@ -1228,6 +1242,22 @@ func waitForSignalEBPF(c *collector.SignalEBPFCollector) tea.Cmd {
 		}
 		if s, ok := (<-ch).(collector.SignalEvent); ok {
 			return SignalMsg(s)
+		}
+		return TickMsg(time.Now())
+	}
+}
+
+func waitForProcContext(c *collector.ProcContextCollector) tea.Cmd {
+	if c == nil {
+		return nil
+	}
+	return func() tea.Msg {
+		ch := c.Subscribe()
+		if ch == nil {
+			return TickMsg(time.Now())
+		}
+		if s, ok := (<-ch).(collector.ProcContext); ok {
+			return ProcContextMsg(s)
 		}
 		return TickMsg(time.Now())
 	}

--- a/internal/tui/snapshot.go
+++ b/internal/tui/snapshot.go
@@ -44,6 +44,7 @@ type SnapshotData struct {
 	Timeline       []collector.TimelineEvent `json:"timeline"`
 	Signals        []collector.SignalEvent   `json:"signals"`
 	TLSPayloads    []collector.TLSPayload    `json:"tls_payloads,omitempty"`
+	ProcContext    collector.ProcContext     `json:"proc_context"`
 }
 
 // buildSnapshot extracts a Snapshot from the current model state.
@@ -72,6 +73,7 @@ func buildSnapshot(m Model) Snapshot {
 			Timeline:       append([]collector.TimelineEvent(nil), m.Timeline...),
 			Signals:        append([]collector.SignalEvent(nil), m.Signals...),
 			TLSPayloads:    append([]collector.TLSPayload(nil), m.TLSPayloads...),
+			ProcContext:    m.ProcCtx,
 		},
 	}
 }

--- a/pkg/collector/proccontext.go
+++ b/pkg/collector/proccontext.go
@@ -1,0 +1,217 @@
+package collector
+
+import (
+	"strconv"
+	"strings"
+)
+
+// Parsers for the execution-context collector (#60). Kept build-tag-free (no
+// linux/ebpf gate) so they compile and are unit-tested on any OS — the same
+// split fs_decode.go / signal_decode.go use. The OS-specific /proc reading
+// lives in proccontext_linux.go.
+
+// parseNSInode extracts the inode from a namespace symlink target of the form
+// "pid:[4026531836]" (what readlink(/proc/<pid>/ns/<kind>) returns). Returns 0
+// when the form isn't recognized.
+func parseNSInode(link string) uint64 {
+	open := strings.IndexByte(link, '[')
+	close := strings.IndexByte(link, ']')
+	if open < 0 || close < 0 || close <= open+1 {
+		return 0
+	}
+	n, err := strconv.ParseUint(link[open+1:close], 10, 64)
+	if err != nil {
+		return 0
+	}
+	return n
+}
+
+// parseCgroup picks the target's cgroup path from the contents of
+// /proc/<pid>/cgroup. Each line is "hierarchy-ID:controller-list:path". The
+// cgroup-v2 unified line has an empty controller list ("0::/path") and is
+// preferred; otherwise the first line's path is returned. Returns "" when the
+// data has no usable line.
+func parseCgroup(data string) string {
+	var fallback string
+	for _, line := range strings.Split(data, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		// SplitN with 3 so a ':' inside the path (rare) stays intact.
+		parts := strings.SplitN(line, ":", 3)
+		if len(parts) != 3 {
+			continue
+		}
+		controllers, path := parts[1], parts[2]
+		if controllers == "" { // cgroup v2 unified hierarchy
+			return path
+		}
+		if fallback == "" {
+			fallback = path
+		}
+	}
+	return fallback
+}
+
+// deriveContainer turns a cgroup path into a best-effort container id like
+// "docker:ab12cd34ef56", classifying the runtime by keyword and using the
+// 64-hex container id (truncated to 12) found in the path. LXC payloads carry a
+// name rather than a hex id, so the trailing path segment is used. Returns ""
+// when the path isn't from a recognized container runtime.
+func deriveContainer(cgroupPath string) string {
+	if cgroupPath == "" {
+		return ""
+	}
+	lower := strings.ToLower(cgroupPath)
+	id := shortHex(longestHexRun(lower, 32))
+
+	switch {
+	case strings.Contains(lower, "lxc"):
+		// "/lxc/<name>" or "lxc.payload.<name>" — the name isn't hex.
+		if name := lxcName(cgroupPath); name != "" {
+			return "lxc:" + name
+		}
+		return "lxc"
+	case strings.Contains(lower, "libpod"):
+		return withID("libpod", id)
+	case strings.Contains(lower, "cri-containerd") || strings.Contains(lower, "containerd"):
+		return withID("containerd", id)
+	case strings.Contains(lower, "crio") || strings.Contains(lower, "cri-o"):
+		return withID("crio", id)
+	case strings.Contains(lower, "docker"):
+		return withID("docker", id)
+	case strings.Contains(lower, "kubepods"):
+		// Generic Kubernetes pod with no embedded runtime keyword.
+		return withID("kubepods", id)
+	default:
+		// No runtime keyword, but a bare 64-hex leaf is still very likely a
+		// container (some setups mount the container cgroup directly).
+		if id != "" && looksLikeContainerLeaf(lower) {
+			return "container:" + id
+		}
+		return ""
+	}
+}
+
+// withID joins a runtime label with its container id, dropping the id when none
+// was found (e.g. the path named the runtime but carried no hex id).
+func withID(label, id string) string {
+	if id == "" {
+		return label
+	}
+	return label + ":" + id
+}
+
+// shortHex truncates a container id to its first 12 chars (the conventional
+// "docker ps" short id). Returns "" unchanged.
+func shortHex(hex string) string {
+	if len(hex) > 12 {
+		return hex[:12]
+	}
+	return hex
+}
+
+// longestHexRun returns the longest run of lowercase-hex digits in s with
+// length >= min, or "" if none qualifies. Container ids are 64-hex, so this
+// reliably skips the hyphenated pod UUIDs and short hierarchy numbers.
+func longestHexRun(s string, min int) string {
+	best, bestLen := "", 0
+	i := 0
+	for i < len(s) {
+		if isHex(s[i]) {
+			j := i
+			for j < len(s) && isHex(s[j]) {
+				j++
+			}
+			if j-i > bestLen {
+				best, bestLen = s[i:j], j-i
+			}
+			i = j
+		} else {
+			i++
+		}
+	}
+	if bestLen >= min {
+		return best
+	}
+	return ""
+}
+
+func isHex(c byte) bool {
+	return (c >= '0' && c <= '9') || (c >= 'a' && c <= 'f')
+}
+
+// looksLikeContainerLeaf reports whether the path's final segment is a long hex
+// blob (>=32 chars, optionally with a .scope/.slice systemd suffix), the shape
+// of a directly-mounted container cgroup.
+func looksLikeContainerLeaf(lower string) bool {
+	seg := lower
+	if i := strings.LastIndexByte(seg, '/'); i >= 0 {
+		seg = seg[i+1:]
+	}
+	seg = strings.TrimSuffix(seg, ".scope")
+	seg = strings.TrimSuffix(seg, ".slice")
+	// Strip a leading "<runtime>-" prefix (systemd cgroup driver form).
+	if i := strings.LastIndexByte(seg, '-'); i >= 0 && i+1 < len(seg) {
+		seg = seg[i+1:]
+	}
+	return len(seg) >= 32 && longestHexRun(seg, 32) == seg
+}
+
+// lxcName extracts the LXC container name from "/lxc/<name>/..." or
+// "lxc.payload.<name>" forms. Returns "" when no name segment follows.
+func lxcName(cgroupPath string) string {
+	for _, seg := range strings.Split(cgroupPath, "/") {
+		seg = strings.TrimSpace(seg)
+		if seg == "" {
+			continue
+		}
+		if rest, ok := strings.CutPrefix(seg, "lxc.payload."); ok {
+			return rest
+		}
+		if seg == "lxc" {
+			continue
+		}
+		// First non-"lxc" segment after we've seen the lxc keyword.
+		if strings.Contains(cgroupPath, "/lxc/") {
+			if i := strings.Index(cgroupPath, "/lxc/"); i >= 0 {
+				rest := cgroupPath[i+len("/lxc/"):]
+				if j := strings.IndexByte(rest, '/'); j >= 0 {
+					return rest[:j]
+				}
+				return rest
+			}
+		}
+	}
+	return ""
+}
+
+// parseStatusUIDGID reads the real UID and GID from the contents of
+// /proc/<pid>/status. The "Uid:"/"Gid:" lines list real, effective, saved, and
+// fs ids; the first (real) is the conventional process owner. Returns (0, 0)
+// when the lines are absent.
+func parseStatusUIDGID(status string) (uid, gid uint32) {
+	for _, line := range strings.Split(status, "\n") {
+		if rest, ok := strings.CutPrefix(line, "Uid:"); ok {
+			uid = firstUint32(rest)
+		} else if rest, ok := strings.CutPrefix(line, "Gid:"); ok {
+			gid = firstUint32(rest)
+		}
+	}
+	return uid, gid
+}
+
+// firstUint32 parses the first whitespace-separated field of s as a uint32,
+// returning 0 on failure.
+func firstUint32(s string) uint32 {
+	fields := strings.Fields(s)
+	if len(fields) == 0 {
+		return 0
+	}
+	n, err := strconv.ParseUint(fields[0], 10, 32)
+	if err != nil {
+		return 0
+	}
+	return uint32(n)
+}

--- a/pkg/collector/proccontext_linux.go
+++ b/pkg/collector/proccontext_linux.go
@@ -1,0 +1,133 @@
+//go:build linux
+
+package collector
+
+import (
+	"fmt"
+	"os"
+	"sync"
+	"syscall"
+	"time"
+)
+
+// ProcContextCollector reads the target's execution/container context from
+// /proc — uid/gid (status), namespace inodes (ns/*), and the cgroup path — and
+// publishes a ProcContext snapshot once at start and then periodically. It is a
+// pure /proc collector (no eBPF, no caps), so it runs in --no-ebpf mode too. The
+// context of a single target is essentially fixed, so the period is relaxed; a
+// refresh still catches setuid/setns/cgroup-move during the process's life.
+type ProcContextCollector struct {
+	pid  int
+	ch   chan interface{}
+	stop chan struct{}
+	once sync.Once
+}
+
+// procContextInterval is the refresh period. The target's ns/cgroup/uid rarely
+// change, so this is deliberately slow — it exists to catch the occasional
+// setuid/setns, not to poll hot.
+const procContextInterval = 3 * time.Second
+
+// cgroupRoot is the cgroup-v2 unified mount point. Used to resolve a cgroup
+// path to its directory inode (the cgroup id).
+const cgroupRoot = "/sys/fs/cgroup"
+
+func NewProcContextCollector() *ProcContextCollector {
+	return &ProcContextCollector{
+		ch:   make(chan interface{}, 4),
+		stop: make(chan struct{}),
+	}
+}
+
+func (c *ProcContextCollector) Start(pid int) error {
+	c.pid = pid
+	// status is the cheapest existence check that also proves we can read the
+	// target's /proc entries at all.
+	if _, err := os.ReadFile(fmt.Sprintf("/proc/%d/status", pid)); err != nil {
+		return fmt.Errorf("process %d /proc unreadable: %w", pid, err)
+	}
+	go c.loop()
+	return nil
+}
+
+func (c *ProcContextCollector) Stop() {
+	c.once.Do(func() { close(c.stop) })
+}
+
+func (c *ProcContextCollector) Subscribe() <-chan interface{} { return c.ch }
+
+func (c *ProcContextCollector) loop() {
+	c.publish() // immediate first snapshot — the header/badge fills in at once
+	t := time.NewTicker(procContextInterval)
+	defer t.Stop()
+	for {
+		select {
+		case <-c.stop:
+			return
+		case <-t.C:
+			c.publish()
+		}
+	}
+}
+
+// publish samples the current context and sends it non-blocking. A read error
+// for a single field degrades that field to its zero value rather than dropping
+// the whole snapshot — a process may briefly hide a /proc entry without meaning
+// the rest is unavailable.
+func (c *ProcContextCollector) publish() {
+	pc := c.sample()
+	select {
+	case c.ch <- pc:
+	default:
+	}
+}
+
+func (c *ProcContextCollector) sample() ProcContext {
+	pc := ProcContext{Timestamp: time.Now()}
+
+	if data, err := os.ReadFile(fmt.Sprintf("/proc/%d/status", c.pid)); err == nil {
+		pc.UID, pc.GID = parseStatusUIDGID(string(data))
+	}
+
+	if data, err := os.ReadFile(fmt.Sprintf("/proc/%d/cgroup", c.pid)); err == nil {
+		pc.Cgroup = parseCgroup(string(data))
+		pc.Container = deriveContainer(pc.Cgroup)
+		pc.CgroupID = cgroupInode(pc.Cgroup)
+	}
+
+	pc.PIDNS = c.nsInode("pid")
+	pc.NetNS = c.nsInode("net")
+	pc.MntNS = c.nsInode("mnt")
+	pc.UserNS = c.nsInode("user")
+	pc.CgroupNS = c.nsInode("cgroup")
+	pc.IPCNS = c.nsInode("ipc")
+	pc.UTSNS = c.nsInode("uts")
+
+	return pc
+}
+
+// nsInode resolves the inode of /proc/<pid>/ns/<kind> from its symlink target
+// ("kind:[<inode>]"). Returns 0 when the namespace isn't accessible (e.g. the
+// kind is unsupported, or we lack permission).
+func (c *ProcContextCollector) nsInode(kind string) uint64 {
+	link, err := os.Readlink(fmt.Sprintf("/proc/%d/ns/%s", c.pid, kind))
+	if err != nil {
+		return 0
+	}
+	return parseNSInode(link)
+}
+
+// cgroupInode returns the directory inode of a cgroup-v2 path under the unified
+// mount — the same value bpf_get_current_cgroup_id() reports, so it correlates
+// with eBPF-side ids. Returns 0 for the empty path or when the directory can't
+// be stat'd (cgroup v1's per-controller layout, or no unified mount).
+func cgroupInode(path string) uint64 {
+	if path == "" {
+		return 0
+	}
+	var st syscall.Stat_t
+	if err := syscall.Stat(cgroupRoot+path, &st); err != nil {
+		return 0
+	}
+	return st.Ino
+}

--- a/pkg/collector/proccontext_linux_test.go
+++ b/pkg/collector/proccontext_linux_test.go
@@ -1,0 +1,45 @@
+//go:build linux
+
+package collector
+
+import (
+	"os"
+	"testing"
+	"time"
+)
+
+// TestProcContextCollectorLive exercises the real /proc reading path against
+// the test process itself (CI-only — the file is linux-tagged). The parsers are
+// unit-tested separately in proccontext_test.go; this proves the glue and the
+// namespace readlinks actually work on a live pid.
+func TestProcContextCollectorLive(t *testing.T) {
+	c := NewProcContextCollector()
+	if err := c.Start(os.Getpid()); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer c.Stop()
+
+	select {
+	case v := <-c.Subscribe():
+		pc, ok := v.(ProcContext)
+		if !ok {
+			t.Fatalf("got %T, want ProcContext", v)
+		}
+		if pc.UID != uint32(os.Getuid()) {
+			t.Errorf("UID = %d, want %d", pc.UID, os.Getuid())
+		}
+		if pc.GID != uint32(os.Getgid()) {
+			t.Errorf("GID = %d, want %d", pc.GID, os.Getgid())
+		}
+		// /proc/self/ns/pid is always readable for the caller, so its inode
+		// must resolve to a non-zero value.
+		if pc.PIDNS == 0 {
+			t.Errorf("PIDNS = 0, want a namespace inode")
+		}
+		if pc.Timestamp.IsZero() {
+			t.Errorf("Timestamp is zero")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("no ProcContext published within 2s")
+	}
+}

--- a/pkg/collector/proccontext_other.go
+++ b/pkg/collector/proccontext_other.go
@@ -1,0 +1,21 @@
+//go:build !linux
+
+package collector
+
+import "errors"
+
+// Stub: namespaces and cgroups are Linux kernel concepts with no macOS (or other
+// OS) equivalent, so the execution-context collector simply doesn't start there.
+// The consumer then has no ProcContext — the help overlay reports it unavailable.
+
+type ProcContextCollector struct{}
+
+func NewProcContextCollector() *ProcContextCollector { return &ProcContextCollector{} }
+
+func (*ProcContextCollector) Start(pid int) error {
+	return errors.New("execution context (namespace/cgroup) is Linux-only")
+}
+
+func (*ProcContextCollector) Stop() {}
+
+func (*ProcContextCollector) Subscribe() <-chan interface{} { return nil }

--- a/pkg/collector/proccontext_test.go
+++ b/pkg/collector/proccontext_test.go
@@ -1,0 +1,168 @@
+package collector
+
+import "testing"
+
+func TestParseNSInode(t *testing.T) {
+	cases := []struct {
+		in   string
+		want uint64
+	}{
+		{"pid:[4026531836]", 4026531836},
+		{"net:[4026532008]", 4026532008},
+		{"mnt:[4026531840]", 4026531840},
+		{"", 0},
+		{"pid:[]", 0},
+		{"pid:4026531836", 0}, // no brackets
+		{"pid:[notanumber]", 0},
+		{"cgroup:[4026531835]", 4026531835},
+	}
+	for _, c := range cases {
+		if got := parseNSInode(c.in); got != c.want {
+			t.Errorf("parseNSInode(%q) = %d, want %d", c.in, got, c.want)
+		}
+	}
+}
+
+func TestParseCgroup(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "v2 unified",
+			in:   "0::/system.slice/docker-abc.scope\n",
+			want: "/system.slice/docker-abc.scope",
+		},
+		{
+			name: "v1 multiple, prefer unified",
+			in: "12:pids:/docker/abc\n" +
+				"11:hugetlb:/docker/abc\n" +
+				"0::/docker/abc\n",
+			want: "/docker/abc",
+		},
+		{
+			name: "v1 only, first line fallback",
+			in:   "12:pids:/docker/abc\n11:memory:/docker/abc\n",
+			want: "/docker/abc",
+		},
+		{
+			name: "root cgroup",
+			in:   "0::/\n",
+			want: "/",
+		},
+		{
+			name: "path with colon",
+			in:   "0::/weird:path/here\n",
+			want: "/weird:path/here",
+		},
+		{name: "empty", in: "", want: ""},
+		{name: "garbage", in: "not-a-cgroup-line\n", want: ""},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := parseCgroup(c.in); got != c.want {
+				t.Errorf("parseCgroup() = %q, want %q", got, c.want)
+			}
+		})
+	}
+}
+
+func TestDeriveContainer(t *testing.T) {
+	const cid = "ab12cd34ef5678901234567890123456789012345678901234567890abcdef00"
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "docker cgroupfs driver",
+			in:   "/docker/" + cid,
+			want: "docker:ab12cd34ef56",
+		},
+		{
+			name: "docker systemd driver",
+			in:   "/system.slice/docker-" + cid + ".scope",
+			want: "docker:ab12cd34ef56",
+		},
+		{
+			name: "kubepods cri-containerd",
+			in:   "/kubepods/besteffort/pod1234abcd-5678-90ef/cri-containerd-" + cid + ".scope",
+			want: "containerd:ab12cd34ef56",
+		},
+		{
+			name: "kubepods generic",
+			in:   "/kubepods/burstable/podaaaa-bbbb/" + cid,
+			want: "kubepods:ab12cd34ef56",
+		},
+		{
+			name: "libpod / podman",
+			in:   "/machine.slice/libpod-" + cid + ".scope",
+			want: "libpod:ab12cd34ef56",
+		},
+		{
+			name: "crio",
+			in:   "/kubepods/pod-x/crio-" + cid + ".scope",
+			want: "crio:ab12cd34ef56",
+		},
+		{
+			name: "lxc path form",
+			in:   "/lxc/mycontainer/init.scope",
+			want: "lxc:mycontainer",
+		},
+		{
+			name: "lxc payload form",
+			in:   "/lxc.payload.web01/system.slice",
+			want: "lxc:web01",
+		},
+		{
+			name: "bare hex leaf",
+			in:   "/" + cid,
+			want: "container:ab12cd34ef56",
+		},
+		{
+			name: "host root — no container",
+			in:   "/",
+			want: "",
+		},
+		{
+			name: "host systemd unit — no container",
+			in:   "/system.slice/sshd.service",
+			want: "",
+		},
+		{name: "empty", in: "", want: ""},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := deriveContainer(c.in); got != c.want {
+				t.Errorf("deriveContainer(%q) = %q, want %q", c.in, got, c.want)
+			}
+		})
+	}
+}
+
+func TestParseStatusUIDGID(t *testing.T) {
+	status := "Name:\tbash\n" +
+		"Umask:\t0022\n" +
+		"State:\tS (sleeping)\n" +
+		"Uid:\t1000\t1000\t1000\t1000\n" +
+		"Gid:\t1001\t1001\t1001\t1001\n" +
+		"FDSize:\t256\n"
+	uid, gid := parseStatusUIDGID(status)
+	if uid != 1000 {
+		t.Errorf("uid = %d, want 1000", uid)
+	}
+	if gid != 1001 {
+		t.Errorf("gid = %d, want 1001", gid)
+	}
+
+	// Root and absent lines.
+	uid, gid = parseStatusUIDGID("Uid:\t0\t0\t0\t0\nGid:\t0\t0\t0\t0\n")
+	if uid != 0 || gid != 0 {
+		t.Errorf("root uid/gid = %d/%d, want 0/0", uid, gid)
+	}
+	uid, gid = parseStatusUIDGID("Name:\tx\n")
+	if uid != 0 || gid != 0 {
+		t.Errorf("missing uid/gid = %d/%d, want 0/0", uid, gid)
+	}
+}

--- a/pkg/collector/set.go
+++ b/pkg/collector/set.go
@@ -34,6 +34,7 @@ type Sources struct {
 	Locks    string
 	Signals  string
 	TLS      string
+	Context  string
 }
 
 // Set owns the live collectors for a single target PID, chosen by the
@@ -57,6 +58,7 @@ type Set struct {
 	FutexEBPF    *FutexEBPFCollector
 	SignalEBPF   *SignalEBPFCollector
 	TLSEBPF      *TLSEBPFCollector
+	ProcContext  *ProcContextCollector
 
 	Sources Sources
 }
@@ -138,6 +140,14 @@ func NewSet(cfg SetConfig) *Set {
 	}
 	if c := NewIOThroughputCollector(); c.Start(cfg.PID) == nil {
 		s.IOThroughput = c
+	}
+
+	// Execution/container context (#60): namespace + cgroup + uid/gid from
+	// /proc. Pure /proc (no eBPF, no caps), so it starts even in --no-ebpf mode;
+	// the !linux stub fails Start (ns/cgroup are Linux-only), leaving it nil.
+	if c := NewProcContextCollector(); c.Start(cfg.PID) == nil {
+		s.ProcContext = c
+		s.Sources.Context = SourceProc
 	}
 
 	// eBPF-only subsystems: only with -tags=ebpf, kernel >= 5.8 and
@@ -270,6 +280,9 @@ func (s *Set) Stop() {
 	if s.TLSEBPF != nil {
 		s.TLSEBPF.Stop()
 	}
+	if s.ProcContext != nil {
+		s.ProcContext.Stop()
+	}
 }
 
 // Collectors returns every started collector as a Collector. Used by consumers
@@ -302,6 +315,7 @@ func (s *Set) Collectors() []Collector {
 	add(s.FutexEBPF, s.FutexEBPF != nil)
 	add(s.SignalEBPF, s.SignalEBPF != nil)
 	add(s.TLSEBPF, s.TLSEBPF != nil)
+	add(s.ProcContext, s.ProcContext != nil)
 	return cs
 }
 
@@ -318,6 +332,7 @@ func (s *Set) MockIOThroughput() bool { return s.IOThroughput == nil }
 func (s *Set) MockSyscalls() bool     { return s.SyscallsEBPF == nil }
 func (s *Set) MockIOFiles() bool      { return s.IOEBPF == nil }
 func (s *Set) MockNet() bool          { return s.NetworkEBPF == nil }
+func (s *Set) MockContext() bool      { return s.ProcContext == nil }
 
 // warnEBPFFailure reports an eBPF collector start failure to stderr, but only
 // when this binary actually embeds eBPF (-tags=ebpf). Without it, the failure

--- a/pkg/collector/types.go
+++ b/pkg/collector/types.go
@@ -271,6 +271,34 @@ type SignalEvent struct {
 	Result     int32 // TRACE_SIGNAL_* disposition
 }
 
+// ─── Execution context (#60) ─────────────────────────────────────────────────
+
+// ProcContext is the target's container/execution context, read from /proc and
+// published periodically (and once at start). UID/GID are the real user/group.
+// The *NS fields are namespace inode numbers (from /proc/<pid>/ns/*) — equal
+// across processes sharing a namespace, so they identify container/sandbox
+// membership. CgroupID is the inode of the cgroup directory (matches
+// bpf_get_current_cgroup_id() on cgroup v2); Cgroup is its path. Container is a
+// best-effort id derived from the cgroup path ("docker:<12hex>",
+// "containerd:…", "kubepods:…", "libpod:…", "lxc:…"), or "" when the target is
+// not in a recognized container. Linux-only (namespaces/cgroups don't exist on
+// macOS — the collector simply doesn't start there).
+type ProcContext struct {
+	Timestamp time.Time
+	UID       uint32
+	GID       uint32
+	PIDNS     uint64
+	NetNS     uint64
+	MntNS     uint64
+	UserNS    uint64
+	CgroupNS  uint64
+	IPCNS     uint64
+	UTSNS     uint64
+	CgroupID  uint64
+	Cgroup    string // cgroup path
+	Container string // derived container id; "" if none
+}
+
 // ─── Timeline ────────────────────────────────────────────────────────────────
 
 type TimelineEvent struct {

--- a/pkg/streampb/event.pb.go
+++ b/pkg/streampb/event.pb.go
@@ -37,6 +37,7 @@ const (
 	Category_CATEGORY_LOCK        Category = 8
 	Category_CATEGORY_TIMELINE    Category = 9
 	Category_CATEGORY_SIGNAL      Category = 10 // #58 — signals delivered to the target
+	Category_CATEGORY_PROCESS     Category = 11 // #60 — execution context + exec lineage
 )
 
 // Enum value maps for Category.
@@ -53,6 +54,7 @@ var (
 		8:  "CATEGORY_LOCK",
 		9:  "CATEGORY_TIMELINE",
 		10: "CATEGORY_SIGNAL",
+		11: "CATEGORY_PROCESS",
 	}
 	Category_value = map[string]int32{
 		"CATEGORY_UNSPECIFIED": 0,
@@ -66,6 +68,7 @@ var (
 		"CATEGORY_LOCK":        8,
 		"CATEGORY_TIMELINE":    9,
 		"CATEGORY_SIGNAL":      10,
+		"CATEGORY_PROCESS":     11,
 	}
 )
 
@@ -258,6 +261,15 @@ type Event struct {
 	Category Category `protobuf:"varint,4,opt,name=category,proto3,enum=ptop.v1.Category" json:"category,omitempty"`
 	// Optional; unset until #54.
 	Stack *StackRef `protobuf:"bytes,5,opt,name=stack,proto3" json:"stack,omitempty"`
+	// Execution-context identity stamped on EVERY event (#60). uid/gid are the
+	// target's real user/group; cgroup_id is the inode of its cgroup directory
+	// (== bpf_get_current_cgroup_id() on cgroup v2). All three are 0 until the
+	// first ProcContext snapshot has been observed, and on platforms without
+	// /proc (macOS). The rich strings (cgroup path, container id, namespace
+	// inodes) live in the periodic ProcContext payload, not on every envelope.
+	Uid      uint32 `protobuf:"varint,6,opt,name=uid,proto3" json:"uid,omitempty"`
+	Gid      uint32 `protobuf:"varint,7,opt,name=gid,proto3" json:"gid,omitempty"`
+	CgroupId uint64 `protobuf:"varint,8,opt,name=cgroup_id,json=cgroupId,proto3" json:"cgroup_id,omitempty"`
 	// Types that are valid to be assigned to Payload:
 	//
 	//	*Event_Cpu
@@ -278,6 +290,7 @@ type Event struct {
 	//	*Event_FsEvent
 	//	*Event_Signal
 	//	*Event_Tls
+	//	*Event_ProcContext
 	Payload       isEvent_Payload `protobuf_oneof:"payload"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
@@ -346,6 +359,27 @@ func (x *Event) GetStack() *StackRef {
 		return x.Stack
 	}
 	return nil
+}
+
+func (x *Event) GetUid() uint32 {
+	if x != nil {
+		return x.Uid
+	}
+	return 0
+}
+
+func (x *Event) GetGid() uint32 {
+	if x != nil {
+		return x.Gid
+	}
+	return 0
+}
+
+func (x *Event) GetCgroupId() uint64 {
+	if x != nil {
+		return x.CgroupId
+	}
+	return 0
 }
 
 func (x *Event) GetPayload() isEvent_Payload {
@@ -517,6 +551,15 @@ func (x *Event) GetTls() *TLSPayloadEvent {
 	return nil
 }
 
+func (x *Event) GetProcContext() *ProcContext {
+	if x != nil {
+		if x, ok := x.Payload.(*Event_ProcContext); ok {
+			return x.ProcContext
+		}
+	}
+	return nil
+}
+
 type isEvent_Payload interface {
 	isEvent_Payload()
 }
@@ -594,6 +637,10 @@ type Event_Tls struct {
 	Tls *TLSPayloadEvent `protobuf:"bytes,27,opt,name=tls,proto3,oneof"` // #55 — pre-encryption / post-decryption plaintext
 }
 
+type Event_ProcContext struct {
+	ProcContext *ProcContext `protobuf:"bytes,28,opt,name=proc_context,json=procContext,proto3,oneof"` // #60 — periodic namespace/cgroup/identity snapshot
+}
+
 func (*Event_Cpu) isEvent_Payload() {}
 
 func (*Event_Syscalls) isEvent_Payload() {}
@@ -629,6 +676,8 @@ func (*Event_FsEvent) isEvent_Payload() {}
 func (*Event_Signal) isEvent_Payload() {}
 
 func (*Event_Tls) isEvent_Payload() {}
+
+func (*Event_ProcContext) isEvent_Payload() {}
 
 // ─── CPU ──────────────────────────────────────────────────────────────────
 type CpuSample struct {
@@ -2135,6 +2184,150 @@ func (x *SignalEvent) GetResult() int32 {
 	return 0
 }
 
+// ─── Execution context (#60) ────────────────────────────────────────────────
+// ProcContext is the target's container/execution context, read from /proc and
+// emitted periodically (and once at start). uid/gid are the real user/group;
+// the *_ns fields are the inode numbers of the target's namespaces (from
+// /proc/<pid>/ns/*) — equal across processes in the same namespace, so they
+// identify container/sandbox membership. cgroup_id is the inode of the cgroup
+// directory (matches bpf_get_current_cgroup_id() on cgroup v2); cgroup is its
+// path. container is a best-effort id derived from the cgroup path
+// ("docker:<12hex>", "containerd:…", "kubepods:…", "libpod:…", "lxc:…"), or ""
+// when the target isn't in a recognized container. Category on the envelope is
+// PROCESS; the snapshot time lives on the envelope. This payload is Linux-only
+// (namespaces/cgroups don't exist on macOS).
+type ProcContext struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Uid           uint32                 `protobuf:"varint,1,opt,name=uid,proto3" json:"uid,omitempty"`
+	Gid           uint32                 `protobuf:"varint,2,opt,name=gid,proto3" json:"gid,omitempty"`
+	PidNs         uint64                 `protobuf:"varint,3,opt,name=pid_ns,json=pidNs,proto3" json:"pid_ns,omitempty"`
+	NetNs         uint64                 `protobuf:"varint,4,opt,name=net_ns,json=netNs,proto3" json:"net_ns,omitempty"`
+	MntNs         uint64                 `protobuf:"varint,5,opt,name=mnt_ns,json=mntNs,proto3" json:"mnt_ns,omitempty"`
+	UserNs        uint64                 `protobuf:"varint,6,opt,name=user_ns,json=userNs,proto3" json:"user_ns,omitempty"`
+	CgroupNs      uint64                 `protobuf:"varint,7,opt,name=cgroup_ns,json=cgroupNs,proto3" json:"cgroup_ns,omitempty"`
+	IpcNs         uint64                 `protobuf:"varint,8,opt,name=ipc_ns,json=ipcNs,proto3" json:"ipc_ns,omitempty"`
+	UtsNs         uint64                 `protobuf:"varint,9,opt,name=uts_ns,json=utsNs,proto3" json:"uts_ns,omitempty"`
+	CgroupId      uint64                 `protobuf:"varint,10,opt,name=cgroup_id,json=cgroupId,proto3" json:"cgroup_id,omitempty"`
+	Cgroup        string                 `protobuf:"bytes,11,opt,name=cgroup,proto3" json:"cgroup,omitempty"`       // cgroup path (v2 "0::/p" → "/p")
+	Container     string                 `protobuf:"bytes,12,opt,name=container,proto3" json:"container,omitempty"` // derived container id; "" if none
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ProcContext) Reset() {
+	*x = ProcContext{}
+	mi := &file_event_proto_msgTypes[23]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ProcContext) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ProcContext) ProtoMessage() {}
+
+func (x *ProcContext) ProtoReflect() protoreflect.Message {
+	mi := &file_event_proto_msgTypes[23]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ProcContext.ProtoReflect.Descriptor instead.
+func (*ProcContext) Descriptor() ([]byte, []int) {
+	return file_event_proto_rawDescGZIP(), []int{23}
+}
+
+func (x *ProcContext) GetUid() uint32 {
+	if x != nil {
+		return x.Uid
+	}
+	return 0
+}
+
+func (x *ProcContext) GetGid() uint32 {
+	if x != nil {
+		return x.Gid
+	}
+	return 0
+}
+
+func (x *ProcContext) GetPidNs() uint64 {
+	if x != nil {
+		return x.PidNs
+	}
+	return 0
+}
+
+func (x *ProcContext) GetNetNs() uint64 {
+	if x != nil {
+		return x.NetNs
+	}
+	return 0
+}
+
+func (x *ProcContext) GetMntNs() uint64 {
+	if x != nil {
+		return x.MntNs
+	}
+	return 0
+}
+
+func (x *ProcContext) GetUserNs() uint64 {
+	if x != nil {
+		return x.UserNs
+	}
+	return 0
+}
+
+func (x *ProcContext) GetCgroupNs() uint64 {
+	if x != nil {
+		return x.CgroupNs
+	}
+	return 0
+}
+
+func (x *ProcContext) GetIpcNs() uint64 {
+	if x != nil {
+		return x.IpcNs
+	}
+	return 0
+}
+
+func (x *ProcContext) GetUtsNs() uint64 {
+	if x != nil {
+		return x.UtsNs
+	}
+	return 0
+}
+
+func (x *ProcContext) GetCgroupId() uint64 {
+	if x != nil {
+		return x.CgroupId
+	}
+	return 0
+}
+
+func (x *ProcContext) GetCgroup() string {
+	if x != nil {
+		return x.Cgroup
+	}
+	return ""
+}
+
+func (x *ProcContext) GetContainer() string {
+	if x != nil {
+		return x.Container
+	}
+	return ""
+}
+
 // ─── File descriptors ───────────────────────────────────────────────────────
 type FdEntry struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
@@ -2151,7 +2344,7 @@ type FdEntry struct {
 
 func (x *FdEntry) Reset() {
 	*x = FdEntry{}
-	mi := &file_event_proto_msgTypes[23]
+	mi := &file_event_proto_msgTypes[24]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2163,7 +2356,7 @@ func (x *FdEntry) String() string {
 func (*FdEntry) ProtoMessage() {}
 
 func (x *FdEntry) ProtoReflect() protoreflect.Message {
-	mi := &file_event_proto_msgTypes[23]
+	mi := &file_event_proto_msgTypes[24]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2176,7 +2369,7 @@ func (x *FdEntry) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use FdEntry.ProtoReflect.Descriptor instead.
 func (*FdEntry) Descriptor() ([]byte, []int) {
-	return file_event_proto_rawDescGZIP(), []int{23}
+	return file_event_proto_rawDescGZIP(), []int{24}
 }
 
 func (x *FdEntry) GetFd() int32 {
@@ -2237,7 +2430,7 @@ type FdSnapshot struct {
 
 func (x *FdSnapshot) Reset() {
 	*x = FdSnapshot{}
-	mi := &file_event_proto_msgTypes[24]
+	mi := &file_event_proto_msgTypes[25]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2249,7 +2442,7 @@ func (x *FdSnapshot) String() string {
 func (*FdSnapshot) ProtoMessage() {}
 
 func (x *FdSnapshot) ProtoReflect() protoreflect.Message {
-	mi := &file_event_proto_msgTypes[24]
+	mi := &file_event_proto_msgTypes[25]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2262,7 +2455,7 @@ func (x *FdSnapshot) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use FdSnapshot.ProtoReflect.Descriptor instead.
 func (*FdSnapshot) Descriptor() ([]byte, []int) {
-	return file_event_proto_rawDescGZIP(), []int{24}
+	return file_event_proto_rawDescGZIP(), []int{25}
 }
 
 func (x *FdSnapshot) GetFds() []*FdEntry {
@@ -2283,7 +2476,7 @@ type FdEvent struct {
 
 func (x *FdEvent) Reset() {
 	*x = FdEvent{}
-	mi := &file_event_proto_msgTypes[25]
+	mi := &file_event_proto_msgTypes[26]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2295,7 +2488,7 @@ func (x *FdEvent) String() string {
 func (*FdEvent) ProtoMessage() {}
 
 func (x *FdEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_event_proto_msgTypes[25]
+	mi := &file_event_proto_msgTypes[26]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2308,7 +2501,7 @@ func (x *FdEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use FdEvent.ProtoReflect.Descriptor instead.
 func (*FdEvent) Descriptor() ([]byte, []int) {
-	return file_event_proto_rawDescGZIP(), []int{25}
+	return file_event_proto_rawDescGZIP(), []int{26}
 }
 
 func (x *FdEvent) GetMessage() string {
@@ -2334,7 +2527,7 @@ type LockEntry struct {
 
 func (x *LockEntry) Reset() {
 	*x = LockEntry{}
-	mi := &file_event_proto_msgTypes[26]
+	mi := &file_event_proto_msgTypes[27]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2346,7 +2539,7 @@ func (x *LockEntry) String() string {
 func (*LockEntry) ProtoMessage() {}
 
 func (x *LockEntry) ProtoReflect() protoreflect.Message {
-	mi := &file_event_proto_msgTypes[26]
+	mi := &file_event_proto_msgTypes[27]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2359,7 +2552,7 @@ func (x *LockEntry) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LockEntry.ProtoReflect.Descriptor instead.
 func (*LockEntry) Descriptor() ([]byte, []int) {
-	return file_event_proto_rawDescGZIP(), []int{26}
+	return file_event_proto_rawDescGZIP(), []int{27}
 }
 
 func (x *LockEntry) GetUaddr() uint64 {
@@ -2420,7 +2613,7 @@ type LockSnapshot struct {
 
 func (x *LockSnapshot) Reset() {
 	*x = LockSnapshot{}
-	mi := &file_event_proto_msgTypes[27]
+	mi := &file_event_proto_msgTypes[28]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2432,7 +2625,7 @@ func (x *LockSnapshot) String() string {
 func (*LockSnapshot) ProtoMessage() {}
 
 func (x *LockSnapshot) ProtoReflect() protoreflect.Message {
-	mi := &file_event_proto_msgTypes[27]
+	mi := &file_event_proto_msgTypes[28]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2445,7 +2638,7 @@ func (x *LockSnapshot) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LockSnapshot.ProtoReflect.Descriptor instead.
 func (*LockSnapshot) Descriptor() ([]byte, []int) {
-	return file_event_proto_rawDescGZIP(), []int{27}
+	return file_event_proto_rawDescGZIP(), []int{28}
 }
 
 func (x *LockSnapshot) GetLocks() []*LockEntry {
@@ -2466,7 +2659,7 @@ type TimelineEvent struct {
 
 func (x *TimelineEvent) Reset() {
 	*x = TimelineEvent{}
-	mi := &file_event_proto_msgTypes[28]
+	mi := &file_event_proto_msgTypes[29]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2478,7 +2671,7 @@ func (x *TimelineEvent) String() string {
 func (*TimelineEvent) ProtoMessage() {}
 
 func (x *TimelineEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_event_proto_msgTypes[28]
+	mi := &file_event_proto_msgTypes[29]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2491,7 +2684,7 @@ func (x *TimelineEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TimelineEvent.ProtoReflect.Descriptor instead.
 func (*TimelineEvent) Descriptor() ([]byte, []int) {
-	return file_event_proto_rawDescGZIP(), []int{28}
+	return file_event_proto_rawDescGZIP(), []int{29}
 }
 
 func (x *TimelineEvent) GetMessage() string {
@@ -2516,14 +2709,17 @@ const file_event_proto_rawDesc = "" +
 	"\x04line\x18\x03 \x01(\x05R\x04line\x12\x16\n" +
 	"\x06module\x18\x04 \x01(\tR\x06module\x12\x16\n" +
 	"\x06offset\x18\x05 \x01(\x04R\x06offset\x12\x19\n" +
-	"\bbuild_id\x18\x06 \x01(\tR\abuildId\"\xa8\b\n" +
+	"\bbuild_id\x18\x06 \x01(\tR\abuildId\"\xa4\t\n" +
 	"\x05Event\x12 \n" +
 	"\fts_unix_nano\x18\x01 \x01(\x03R\n" +
 	"tsUnixNano\x12\x10\n" +
 	"\x03pid\x18\x02 \x01(\x05R\x03pid\x12\x10\n" +
 	"\x03tid\x18\x03 \x01(\x05R\x03tid\x12-\n" +
 	"\bcategory\x18\x04 \x01(\x0e2\x11.ptop.v1.CategoryR\bcategory\x12'\n" +
-	"\x05stack\x18\x05 \x01(\v2\x11.ptop.v1.StackRefR\x05stack\x12&\n" +
+	"\x05stack\x18\x05 \x01(\v2\x11.ptop.v1.StackRefR\x05stack\x12\x10\n" +
+	"\x03uid\x18\x06 \x01(\rR\x03uid\x12\x10\n" +
+	"\x03gid\x18\a \x01(\rR\x03gid\x12\x1b\n" +
+	"\tcgroup_id\x18\b \x01(\x04R\bcgroupId\x12&\n" +
 	"\x03cpu\x18\n" +
 	" \x01(\v2\x12.ptop.v1.CpuSampleH\x00R\x03cpu\x126\n" +
 	"\bsyscalls\x18\v \x01(\v2\x18.ptop.v1.SyscallSnapshotH\x00R\bsyscalls\x124\n" +
@@ -2543,7 +2739,8 @@ const file_event_proto_rawDesc = "" +
 	"\tnet_error\x18\x18 \x01(\v2\x16.ptop.v1.NetErrorEventH\x00R\bnetError\x12-\n" +
 	"\bfs_event\x18\x19 \x01(\v2\x10.ptop.v1.FSEventH\x00R\afsEvent\x12.\n" +
 	"\x06signal\x18\x1a \x01(\v2\x14.ptop.v1.SignalEventH\x00R\x06signal\x12,\n" +
-	"\x03tls\x18\x1b \x01(\v2\x18.ptop.v1.TLSPayloadEventH\x00R\x03tlsB\t\n" +
+	"\x03tls\x18\x1b \x01(\v2\x18.ptop.v1.TLSPayloadEventH\x00R\x03tls\x129\n" +
+	"\fproc_context\x18\x1c \x01(\v2\x14.ptop.v1.ProcContextH\x00R\vprocContextB\t\n" +
 	"\apayload\"(\n" +
 	"\tCpuSample\x12\x1b\n" +
 	"\tusage_pct\x18\x01 \x01(\x01R\busagePct\"V\n" +
@@ -2671,7 +2868,21 @@ const file_event_proto_rawDesc = "" +
 	"\n" +
 	"target_tid\x18\x05 \x01(\x05R\ttargetTid\x12\x12\n" +
 	"\x04code\x18\x06 \x01(\x05R\x04code\x12\x16\n" +
-	"\x06result\x18\a \x01(\x05R\x06result\"\x9c\x01\n" +
+	"\x06result\x18\a \x01(\x05R\x06result\"\xad\x02\n" +
+	"\vProcContext\x12\x10\n" +
+	"\x03uid\x18\x01 \x01(\rR\x03uid\x12\x10\n" +
+	"\x03gid\x18\x02 \x01(\rR\x03gid\x12\x15\n" +
+	"\x06pid_ns\x18\x03 \x01(\x04R\x05pidNs\x12\x15\n" +
+	"\x06net_ns\x18\x04 \x01(\x04R\x05netNs\x12\x15\n" +
+	"\x06mnt_ns\x18\x05 \x01(\x04R\x05mntNs\x12\x17\n" +
+	"\auser_ns\x18\x06 \x01(\x04R\x06userNs\x12\x1b\n" +
+	"\tcgroup_ns\x18\a \x01(\x04R\bcgroupNs\x12\x15\n" +
+	"\x06ipc_ns\x18\b \x01(\x04R\x05ipcNs\x12\x15\n" +
+	"\x06uts_ns\x18\t \x01(\x04R\x05utsNs\x12\x1b\n" +
+	"\tcgroup_id\x18\n" +
+	" \x01(\x04R\bcgroupId\x12\x16\n" +
+	"\x06cgroup\x18\v \x01(\tR\x06cgroup\x12\x1c\n" +
+	"\tcontainer\x18\f \x01(\tR\tcontainer\"\x9c\x01\n" +
 	"\aFdEntry\x12\x0e\n" +
 	"\x02fd\x18\x01 \x01(\x05R\x02fd\x12\x12\n" +
 	"\x04type\x18\x02 \x01(\tR\x04type\x12\x12\n" +
@@ -2698,7 +2909,7 @@ const file_event_proto_rawDesc = "" +
 	"\fLockSnapshot\x12(\n" +
 	"\x05locks\x18\x01 \x03(\v2\x12.ptop.v1.LockEntryR\x05locks\")\n" +
 	"\rTimelineEvent\x12\x18\n" +
-	"\amessage\x18\x01 \x01(\tR\amessage*\xed\x01\n" +
+	"\amessage\x18\x01 \x01(\tR\amessage*\x83\x02\n" +
 	"\bCategory\x12\x18\n" +
 	"\x14CATEGORY_UNSPECIFIED\x10\x00\x12\x10\n" +
 	"\fCATEGORY_CPU\x10\x01\x12\x14\n" +
@@ -2711,7 +2922,8 @@ const file_event_proto_rawDesc = "" +
 	"\rCATEGORY_LOCK\x10\b\x12\x15\n" +
 	"\x11CATEGORY_TIMELINE\x10\t\x12\x13\n" +
 	"\x0fCATEGORY_SIGNAL\x10\n" +
-	"B\x85\x01\n" +
+	"\x12\x14\n" +
+	"\x10CATEGORY_PROCESS\x10\vB\x85\x01\n" +
 	"\vcom.ptop.v1B\n" +
 	"EventProtoP\x01Z-github.com/trentas/ptop/pkg/streampb;streampb\xa2\x02\x03PXX\xaa\x02\aPtop.V1\xca\x02\aPtop\\V1\xe2\x02\x13Ptop\\V1\\GPBMetadata\xea\x02\bPtop::V1b\x06proto3"
 
@@ -2728,7 +2940,7 @@ func file_event_proto_rawDescGZIP() []byte {
 }
 
 var file_event_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
-var file_event_proto_msgTypes = make([]protoimpl.MessageInfo, 29)
+var file_event_proto_msgTypes = make([]protoimpl.MessageInfo, 30)
 var file_event_proto_goTypes = []any{
 	(Category)(0),              // 0: ptop.v1.Category
 	(*StackRef)(nil),           // 1: ptop.v1.StackRef
@@ -2754,12 +2966,13 @@ var file_event_proto_goTypes = []any{
 	(*IoSnapshot)(nil),         // 21: ptop.v1.IoSnapshot
 	(*FSEvent)(nil),            // 22: ptop.v1.FSEvent
 	(*SignalEvent)(nil),        // 23: ptop.v1.SignalEvent
-	(*FdEntry)(nil),            // 24: ptop.v1.FdEntry
-	(*FdSnapshot)(nil),         // 25: ptop.v1.FdSnapshot
-	(*FdEvent)(nil),            // 26: ptop.v1.FdEvent
-	(*LockEntry)(nil),          // 27: ptop.v1.LockEntry
-	(*LockSnapshot)(nil),       // 28: ptop.v1.LockSnapshot
-	(*TimelineEvent)(nil),      // 29: ptop.v1.TimelineEvent
+	(*ProcContext)(nil),        // 24: ptop.v1.ProcContext
+	(*FdEntry)(nil),            // 25: ptop.v1.FdEntry
+	(*FdSnapshot)(nil),         // 26: ptop.v1.FdSnapshot
+	(*FdEvent)(nil),            // 27: ptop.v1.FdEvent
+	(*LockEntry)(nil),          // 28: ptop.v1.LockEntry
+	(*LockSnapshot)(nil),       // 29: ptop.v1.LockSnapshot
+	(*TimelineEvent)(nil),      // 30: ptop.v1.TimelineEvent
 }
 var file_event_proto_depIdxs = []int32{
 	0,  // 0: ptop.v1.Event.category:type_name -> ptop.v1.Category
@@ -2772,29 +2985,30 @@ var file_event_proto_depIdxs = []int32{
 	17, // 7: ptop.v1.Event.io_wait:type_name -> ptop.v1.IoWaitSample
 	18, // 8: ptop.v1.Event.io_throughput:type_name -> ptop.v1.IoThroughputSample
 	21, // 9: ptop.v1.Event.io:type_name -> ptop.v1.IoSnapshot
-	25, // 10: ptop.v1.Event.fds:type_name -> ptop.v1.FdSnapshot
-	26, // 11: ptop.v1.Event.fd_event:type_name -> ptop.v1.FdEvent
-	28, // 12: ptop.v1.Event.locks:type_name -> ptop.v1.LockSnapshot
-	29, // 13: ptop.v1.Event.timeline:type_name -> ptop.v1.TimelineEvent
+	26, // 10: ptop.v1.Event.fds:type_name -> ptop.v1.FdSnapshot
+	27, // 11: ptop.v1.Event.fd_event:type_name -> ptop.v1.FdEvent
+	29, // 12: ptop.v1.Event.locks:type_name -> ptop.v1.LockSnapshot
+	30, // 13: ptop.v1.Event.timeline:type_name -> ptop.v1.TimelineEvent
 	14, // 14: ptop.v1.Event.heap:type_name -> ptop.v1.HeapSnapshot
 	12, // 15: ptop.v1.Event.heap_event:type_name -> ptop.v1.HeapEvent
 	9,  // 16: ptop.v1.Event.net_error:type_name -> ptop.v1.NetErrorEvent
 	22, // 17: ptop.v1.Event.fs_event:type_name -> ptop.v1.FSEvent
 	23, // 18: ptop.v1.Event.signal:type_name -> ptop.v1.SignalEvent
 	10, // 19: ptop.v1.Event.tls:type_name -> ptop.v1.TLSPayloadEvent
-	5,  // 20: ptop.v1.SyscallSnapshot.stats:type_name -> ptop.v1.SyscallStat
-	7,  // 21: ptop.v1.NetworkSnapshot.conns:type_name -> ptop.v1.NetConn
-	13, // 22: ptop.v1.HeapSnapshot.top_call_sites:type_name -> ptop.v1.HeapCallSite
-	15, // 23: ptop.v1.ThreadSnapshot.threads:type_name -> ptop.v1.ThreadInfo
-	19, // 24: ptop.v1.IoSnapshot.top_files:type_name -> ptop.v1.IoFileStats
-	20, // 25: ptop.v1.IoSnapshot.latency_buckets:type_name -> ptop.v1.LatencyBucket
-	24, // 26: ptop.v1.FdSnapshot.fds:type_name -> ptop.v1.FdEntry
-	27, // 27: ptop.v1.LockSnapshot.locks:type_name -> ptop.v1.LockEntry
-	28, // [28:28] is the sub-list for method output_type
-	28, // [28:28] is the sub-list for method input_type
-	28, // [28:28] is the sub-list for extension type_name
-	28, // [28:28] is the sub-list for extension extendee
-	0,  // [0:28] is the sub-list for field type_name
+	24, // 20: ptop.v1.Event.proc_context:type_name -> ptop.v1.ProcContext
+	5,  // 21: ptop.v1.SyscallSnapshot.stats:type_name -> ptop.v1.SyscallStat
+	7,  // 22: ptop.v1.NetworkSnapshot.conns:type_name -> ptop.v1.NetConn
+	13, // 23: ptop.v1.HeapSnapshot.top_call_sites:type_name -> ptop.v1.HeapCallSite
+	15, // 24: ptop.v1.ThreadSnapshot.threads:type_name -> ptop.v1.ThreadInfo
+	19, // 25: ptop.v1.IoSnapshot.top_files:type_name -> ptop.v1.IoFileStats
+	20, // 26: ptop.v1.IoSnapshot.latency_buckets:type_name -> ptop.v1.LatencyBucket
+	25, // 27: ptop.v1.FdSnapshot.fds:type_name -> ptop.v1.FdEntry
+	28, // 28: ptop.v1.LockSnapshot.locks:type_name -> ptop.v1.LockEntry
+	29, // [29:29] is the sub-list for method output_type
+	29, // [29:29] is the sub-list for method input_type
+	29, // [29:29] is the sub-list for extension type_name
+	29, // [29:29] is the sub-list for extension extendee
+	0,  // [0:29] is the sub-list for field type_name
 }
 
 func init() { file_event_proto_init() }
@@ -2821,6 +3035,7 @@ func file_event_proto_init() {
 		(*Event_FsEvent)(nil),
 		(*Event_Signal)(nil),
 		(*Event_Tls)(nil),
+		(*Event_ProcContext)(nil),
 	}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
@@ -2828,7 +3043,7 @@ func file_event_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_event_proto_rawDesc), len(file_event_proto_rawDesc)),
 			NumEnums:      1,
-			NumMessages:   29,
+			NumMessages:   30,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/proto/event.proto
+++ b/proto/event.proto
@@ -18,6 +18,7 @@ enum Category {
   CATEGORY_LOCK = 8;
   CATEGORY_TIMELINE = 9;
   CATEGORY_SIGNAL = 10; // #58 — signals delivered to the target
+  CATEGORY_PROCESS = 11; // #60 — execution context + exec lineage
 }
 
 // StackRef references a stack captured at event time and resolved out-of-band
@@ -60,6 +61,16 @@ message Event {
   // Optional; unset until #54.
   StackRef stack = 5;
 
+  // Execution-context identity stamped on EVERY event (#60). uid/gid are the
+  // target's real user/group; cgroup_id is the inode of its cgroup directory
+  // (== bpf_get_current_cgroup_id() on cgroup v2). All three are 0 until the
+  // first ProcContext snapshot has been observed, and on platforms without
+  // /proc (macOS). The rich strings (cgroup path, container id, namespace
+  // inodes) live in the periodic ProcContext payload, not on every envelope.
+  uint32 uid = 6;
+  uint32 gid = 7;
+  uint64 cgroup_id = 8;
+
   oneof payload {
     CpuSample cpu = 10;
     SyscallSnapshot syscalls = 11;
@@ -80,8 +91,9 @@ message Event {
     FSEvent fs_event = 25; // #57 — filesystem semantics (denial/delete/rename)
     SignalEvent signal = 26; // #58 — signal delivered to the target, with origin
     TLSPayloadEvent tls = 27; // #55 — pre-encryption / post-decryption plaintext
-    // 28+ reserved for the remaining #52 capabilities (security/LSM,
-    // exec-context enrichment).
+    ProcContext proc_context = 28; // #60 — periodic namespace/cgroup/identity snapshot
+    // 29+ reserved for the remaining #52 capabilities (security/LSM,
+    // exec lineage — #60 ProcLifecycleEvent).
   }
 }
 
@@ -284,6 +296,33 @@ message SignalEvent {
   int32 target_tid = 5;
   int32 code = 6; // si_code
   int32 result = 7; // TRACE_SIGNAL_* disposition
+}
+
+// ─── Execution context (#60) ────────────────────────────────────────────────
+// ProcContext is the target's container/execution context, read from /proc and
+// emitted periodically (and once at start). uid/gid are the real user/group;
+// the *_ns fields are the inode numbers of the target's namespaces (from
+// /proc/<pid>/ns/*) — equal across processes in the same namespace, so they
+// identify container/sandbox membership. cgroup_id is the inode of the cgroup
+// directory (matches bpf_get_current_cgroup_id() on cgroup v2); cgroup is its
+// path. container is a best-effort id derived from the cgroup path
+// ("docker:<12hex>", "containerd:…", "kubepods:…", "libpod:…", "lxc:…"), or ""
+// when the target isn't in a recognized container. Category on the envelope is
+// PROCESS; the snapshot time lives on the envelope. This payload is Linux-only
+// (namespaces/cgroups don't exist on macOS).
+message ProcContext {
+  uint32 uid = 1;
+  uint32 gid = 2;
+  uint64 pid_ns = 3;
+  uint64 net_ns = 4;
+  uint64 mnt_ns = 5;
+  uint64 user_ns = 6;
+  uint64 cgroup_ns = 7;
+  uint64 ipc_ns = 8;
+  uint64 uts_ns = 9;
+  uint64 cgroup_id = 10;
+  string cgroup = 11; // cgroup path (v2 "0::/p" → "/p")
+  string container = 12; // derived container id; "" if none
 }
 
 // ─── File descriptors ───────────────────────────────────────────────────────


### PR DESCRIPTION
Part of #60 (epic #52). This is **PR1 of 2** — the container/execution
**context** half. The exec-**lineage** half (eBPF `fork`/`exec`/`exit` →
`ProcLifecycleEvent`) ships as a separate PR off main once this lands.

## What

Enriches the event stream with the target's container/execution context, read
purely from `/proc` (no eBPF, no caps — runs in `--no-ebpf` mode too).

A new `ProcContextCollector` (Linux-only, `!linux` stub) reads
`/proc/<pid>/{status,cgroup,ns/*}` once at start and every 3s, publishing a
`ProcContext`:

- **uid/gid** (real, from `status`)
- the **seven namespace inodes** (`pid`/`net`/`mnt`/`user`/`cgroup`/`ipc`/`uts`
  from `ns/*`) — equal across processes sharing a namespace, so they identify
  container/sandbox membership
- the **cgroup path** + its **directory inode** (`cgroup_id`, == what
  `bpf_get_current_cgroup_id()` returns on cgroup v2, so it correlates with
  eBPF-side ids)
- a best-effort **container id** derived from the cgroup path
  (`docker:…`/`containerd:…`/`crio:…`/`libpod:…`/`kubepods:…`/`lxc:…`)

## Stream surface (all additive → buf-breaking safe)

- new `CATEGORY_PROCESS`
- `ProcContext` payload (`oneof` field 28)
- cheap identity (`uid`/`gid`/`cgroup_id`, envelope fields 6–8) stamped on
  **every** `Event` by the hub from the latest snapshot (0 until the first
  snapshot / on platforms without /proc)

## TUI (stream-first, per the issue)

- derived container id → low-priority **header badge** (drops first on narrow
  terminals; width discipline preserved)
- a `context` row in the `?` overlay (real via /proc, or unavailable on macOS)
- `ProcContext` added to the snapshot export

## Tests / validation

- build-tag-free parsers unit-tested: docker (cgroupfs + systemd driver),
  containerd/cri, crio, libpod, kubepods, lxc (path + payload forms), bare-hex
  leaf, host/no-container, cgroup v1 vs v2, ns-inode, uid/gid
- a `linux`-tagged live test exercises the real `/proc` path against the test
  process on CI (asserts uid/gid match `os.Getuid/Getgid`, a pid-ns inode
  resolves)
- green on all lanes locally: `go build/test`, `GOOS=linux go build/vet`,
  `go build -tags=ebpf` (stub), `make proto` (only additive diff)

🤖 Generated with [Claude Code](https://claude.com/claude-code)