### PR TITLE
lineage: capture exec lineage (fork/exec/exit) via sched tracepoints (#60)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,7 +79,8 @@ ptop/
 │   │   │   ├── heap.bpf.c         libc malloc/free uprobes → lifetime + leak
 │   │   │   ├── futex.bpf.c        futex wait/wake → lock graph
 │   │   │   ├── signal.bpf.c       signal_generate → signals with origin (#58)
-│   │   │   └── tls.bpf.c          libssl SSL_write/read uprobes → plaintext (#55)
+│   │   │   ├── tls.bpf.c          libssl SSL_write/read uprobes → plaintext (#55)
+│   │   │   └── proc.bpf.c         sched fork/exec/exit → exec lineage subtree (#60)
 │   │   ├── available.go           runtime feature flag (build-tag based)
 │   │   ├── target.go              pid-namespace target resolver (shared)
 │   │   ├── caps.go                CAP_BPF / CAP_PERFMON detection
@@ -94,6 +95,8 @@ ptop/
 │   │   ├── tls.go                 libssl uprobe loader → TLS plaintext (#55)
 │   │   ├── threads.go             sched_switch loader
 │   │   ├── futex.go               futex wait/wake loader
+│   │   ├── signal.go              signal_generate loader (#58)
+│   │   ├── proc.go                sched fork/exec/exit loader → exec lineage (#60)
 │   │   └── *_stub.go              stubs for non-Linux / no-ebpf builds
 │   ├── serve/                     headless gRPC server (ptop --serve)
 │   │   ├── serve.go               addr parse + privilege boundary + Run
@@ -148,6 +151,8 @@ ptop/
 │       ├── futex_ebpf.go          lock graph from futex tracking
 │       ├── proccontext_linux.go   /proc ns + cgroup + uid/gid context (#60)
 │       ├── proccontext.go         container-id / cgroup / ns-inode parsers (build-tag-free)
+│       ├── proclifecycle_ebpf.go  sched fork/exec/exit → exec lineage subtree (#60)
+│       ├── proclifecycle_decode.go  kind/comm/filename decode (build-tag-free)
 │       ├── fds.go                 /proc/<pid>/fd + fdinfo + events
 │       ├── sockets.go             inode → host:port via /proc/net/*
 │       ├── syscall_names.go       syscall id → name table

--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,8 @@ BPF_SRCS := \
 	internal/bpf/programs/heap.bpf.c \
 	internal/bpf/programs/futex.bpf.c \
 	internal/bpf/programs/signal.bpf.c \
-	internal/bpf/programs/tls.bpf.c
+	internal/bpf/programs/tls.bpf.c \
+	internal/bpf/programs/proc.bpf.c
 
 BPF_OBJS := $(BPF_SRCS:.c=.o)
 

--- a/internal/bpf/proc.go
+++ b/internal/bpf/proc.go
@@ -1,0 +1,155 @@
+//go:build linux && ebpf
+
+package bpf
+
+import (
+	"bytes"
+	_ "embed"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"io"
+
+	"github.com/cilium/ebpf"
+	"github.com/cilium/ebpf/link"
+	"github.com/cilium/ebpf/ringbuf"
+	"github.com/cilium/ebpf/rlimit"
+)
+
+//go:embed programs/proc.bpf.o
+var procBPFObj []byte
+
+// procRecordSize is the on-wire size of struct proc_event in programs/proc.bpf.c
+// (#60). The trailing _pad makes this match C's sizeof exactly (168 bytes).
+const procRecordSize = 168
+
+// ProcRecord is the 1:1 layout of struct proc_event. binary.LittleEndian parses
+// it directly from the ring buffer. Pad mirrors the C struct's alignment slot.
+type ProcRecord struct {
+	TsNs     uint64
+	Kind     uint32
+	PID      int32
+	PPID     int32
+	Pad      uint32
+	Comm     [16]byte
+	Filename [128]byte
+}
+
+// ProcTracer loads proc.bpf.o, seeds the tracked-pid set with the target's
+// global pid, attaches the sched fork/exec/exit tracepoints, and exposes Next()
+// to deliver parsed lifecycle records.
+type ProcTracer struct {
+	coll  *ebpf.Collection
+	links []link.Link
+	rb    *ringbuf.Reader
+}
+
+func OpenProcTracer(pid int) (*ProcTracer, error) {
+	if pid <= 0 {
+		return nil, errors.New("invalid pid")
+	}
+	if err := rlimit.RemoveMemlock(); err != nil {
+		return nil, fmt.Errorf("rlimit: %w", err)
+	}
+
+	spec, err := ebpf.LoadCollectionSpecFromReader(bytes.NewReader(procBPFObj))
+	if err != nil {
+		return nil, fmt.Errorf("parse proc BPF object: %w", err)
+	}
+	coll, err := ebpf.NewCollection(spec)
+	if err != nil {
+		return nil, fmt.Errorf("load proc collection: %w", err)
+	}
+	t := &ProcTracer{coll: coll}
+
+	// Seed the tracked set with the target's global (init-ns) pid — the
+	// subtree grows from here on each observed fork.
+	trackedMap := coll.Maps["proc_tracked"]
+	if trackedMap == nil {
+		t.Close()
+		return nil, errors.New("proc_tracked map missing")
+	}
+	gpid := uint32(globalPID(pid))
+	var present uint8 = 1
+	if err := trackedMap.Update(&gpid, &present, ebpf.UpdateAny); err != nil {
+		t.Close()
+		return nil, fmt.Errorf("seed proc_tracked: %w", err)
+	}
+
+	// Attach the three sched tracepoints. They are universally present, but we
+	// attach tolerantly and only fail if NONE attached — so a kernel missing
+	// one still yields partial lineage rather than nothing.
+	attach := func(name, prog string) {
+		p := coll.Programs[prog]
+		if p == nil {
+			return
+		}
+		if l, err := link.Tracepoint("sched", name, p, nil); err == nil {
+			t.links = append(t.links, l)
+		}
+	}
+	attach("sched_process_fork", "handle_fork")
+	attach("sched_process_exec", "handle_exec")
+	attach("sched_process_exit", "handle_exit")
+	if len(t.links) == 0 {
+		t.Close()
+		return nil, errors.New("attach sched process tracepoints: none attached")
+	}
+
+	evMap := coll.Maps["proc_events"]
+	if evMap == nil {
+		t.Close()
+		return nil, errors.New("proc_events ringbuf missing")
+	}
+	rb, err := ringbuf.NewReader(evMap)
+	if err != nil {
+		t.Close()
+		return nil, fmt.Errorf("proc ringbuf reader: %w", err)
+	}
+	t.rb = rb
+
+	return t, nil
+}
+
+// Next blocks until the next lifecycle record arrives. Returns io.EOF once the
+// tracer is closed. A short/garbled record is reported as an error but does not
+// close the stream — the caller keeps reading.
+func (t *ProcTracer) Next() (ProcRecord, error) {
+	var rec ProcRecord
+	if t == nil || t.rb == nil {
+		return rec, errors.New("tracer not initialized")
+	}
+	r, err := t.rb.Read()
+	if err != nil {
+		if errors.Is(err, ringbuf.ErrClosed) {
+			return rec, io.EOF
+		}
+		return rec, err
+	}
+	if len(r.RawSample) < procRecordSize {
+		return rec, fmt.Errorf("short proc event: %d bytes", len(r.RawSample))
+	}
+	if err := binary.Read(bytes.NewReader(r.RawSample), binary.LittleEndian, &rec); err != nil {
+		return rec, fmt.Errorf("decode proc event: %w", err)
+	}
+	return rec, nil
+}
+
+func (t *ProcTracer) Close() error {
+	if t == nil {
+		return nil
+	}
+	if t.rb != nil {
+		_ = t.rb.Close()
+		t.rb = nil
+	}
+	for _, l := range t.links {
+		_ = l.Close()
+	}
+	t.links = nil
+	if t.coll != nil {
+		t.coll.Close()
+		t.coll = nil
+	}
+	return nil
+}

--- a/internal/bpf/proc_stub.go
+++ b/internal/bpf/proc_stub.go
@@ -1,0 +1,28 @@
+//go:build !linux || !ebpf
+
+package bpf
+
+import (
+	"errors"
+	"io"
+)
+
+var errProcStub = errors.New("eBPF proc lifecycle tracer not available in this build")
+
+// ProcRecord mirrors the real layout so non-ebpf builds of internal/bpf still
+// compile standalone (matches signal_stub.go and the other tracer stubs).
+type ProcRecord struct {
+	TsNs     uint64
+	Kind     uint32
+	PID      int32
+	PPID     int32
+	Pad      uint32
+	Comm     [16]byte
+	Filename [128]byte
+}
+
+type ProcTracer struct{}
+
+func OpenProcTracer(int) (*ProcTracer, error) { return nil, errProcStub }
+func (*ProcTracer) Next() (ProcRecord, error) { return ProcRecord{}, io.EOF }
+func (*ProcTracer) Close() error              { return nil }

--- a/internal/bpf/programs/proc.bpf.c
+++ b/internal/bpf/programs/proc.bpf.c
@@ -1,0 +1,181 @@
+// SPDX-License-Identifier: GPL-2.0
+//
+// proc.bpf.c — exec lineage (#60): reconstructs the process tree the target
+// spawns via the scheduler's fork/exec/exit tracepoints.
+//
+//   sched/sched_process_fork  → a fork/clone (parent_pid → child_pid)
+//   sched/sched_process_exec  → an execve (pid + the executed filename)
+//   sched/sched_process_exit  → a task exit (pid)
+//
+// Target filtering — like signal.bpf.c (#58), NOT like the per-subsystem
+// programs. These tracepoints report task pids in the INITIAL (global) pid
+// namespace, and at fork/exec/exit the relevant task is not necessarily the
+// "current" task in a projectable way, so bpf_get_ns_current_pid_tgid() /
+// pid_is_target() don't apply. Instead we keep a `proc_tracked` set of GLOBAL
+// pids, seeded by the Go loader with the target's global pid (from
+// /proc/<pid>/status NSpid) and grown on every fork whose PARENT is tracked —
+// so the whole descendant subtree is captured. A tracked pid is removed on its
+// exit.
+//
+// Threads vs processes: sched_process_fork fires for clone(CLONE_THREAD) too, so
+// "fork" events include thread creation and the tracked set holds thread pids as
+// well as process pids. That is deliberate — it both matches the issue's
+// "execve / clone / fork" wording and makes the subtree filter robust (a child
+// forked by a worker thread of the target is still attributed, because the
+// worker thread's pid is tracked). Consumers that want only processes can filter
+// on pid==tgid downstream.
+//
+// Attach-time limitation: only forks observed AFTER attach populate the set, so
+// pre-existing children/threads of the target aren't tracked until they fork
+// again. Same caveat as every other ptop eBPF collector.
+//
+// Maps:
+//   proc_tracked  HASH      __u32 global pid → __u8 (seeded with the target)
+//   proc_events   RINGBUF   per-event channel → user-space
+
+#include <linux/bpf.h>
+#include <bpf/bpf_helpers.h>
+
+char LICENSE[] SEC("license") = "GPL";
+
+#define PROC_FORK 0
+#define PROC_EXEC 1
+#define PROC_EXIT 2
+
+#define COMM_LEN 16
+#define FILENAME_LEN 128
+
+// Tracepoint layouts, hand-laid from the stable `format` files (offsets after
+// the 8-byte common header common_type/flags/preempt_count/pid).
+//
+// sched/sched_process_fork: parent_comm[16]@8, parent_pid@24, child_comm[16]@28,
+// child_pid@44.
+struct sched_process_fork_args {
+    unsigned long long _pad;
+    char parent_comm[COMM_LEN];
+    int parent_pid;
+    char child_comm[COMM_LEN];
+    int child_pid;
+};
+
+// sched/sched_process_exec: __data_loc filename@8 (u32: low16 offset, high16
+// len), pid@12, old_pid@16.
+struct sched_process_exec_args {
+    unsigned long long _pad;
+    unsigned int filename; // __data_loc
+    int pid;
+    int old_pid;
+};
+
+// sched/sched_process_exit: comm[16]@8, pid@24, prio@28.
+struct sched_process_exit_args {
+    unsigned long long _pad;
+    char comm[COMM_LEN];
+    int pid;
+    int prio;
+};
+
+// proc_event is published via the proc_events ring buffer. Fixed 168-byte layout
+// (the _pad makes the Go-side packed size equal C's sizeof) — keep in sync with
+// ProcRecord in internal/bpf/proc.go.
+struct proc_event {
+    __u64 ts_ns;
+    __u32 kind; // PROC_FORK | PROC_EXEC | PROC_EXIT
+    __s32 pid;  // subject: child for fork, the task itself for exec/exit
+    __s32 ppid; // parent (fork only; 0 otherwise)
+    __u32 _pad;
+    char comm[COMM_LEN];
+    char filename[FILENAME_LEN]; // exec only; "" otherwise
+};
+
+struct {
+    __uint(type, BPF_MAP_TYPE_HASH);
+    __type(key, __u32);  // global pid
+    __type(value, __u8); // present == tracked
+    __uint(max_entries, 4096);
+} proc_tracked SEC(".maps");
+
+struct {
+    __uint(type, BPF_MAP_TYPE_RINGBUF);
+    __uint(max_entries, 1 << 18); // 256KB — lifecycle events are low-rate
+} proc_events SEC(".maps");
+
+static __always_inline int is_tracked(__u32 pid)
+{
+    return bpf_map_lookup_elem(&proc_tracked, &pid) != 0;
+}
+
+SEC("tracepoint/sched/sched_process_fork")
+int handle_fork(struct sched_process_fork_args *ctx)
+{
+    __u32 ppid = (__u32)ctx->parent_pid;
+    if (!is_tracked(ppid))
+        return 0;
+
+    // The child (process or thread) is a descendant — track it so its own
+    // forks are attributed too.
+    __u32 child = (__u32)ctx->child_pid;
+    __u8 one = 1;
+    bpf_map_update_elem(&proc_tracked, &child, &one, BPF_ANY);
+
+    struct proc_event *e = bpf_ringbuf_reserve(&proc_events, sizeof(*e), 0);
+    if (!e)
+        return 0;
+    __builtin_memset(e, 0, sizeof(*e));
+    e->ts_ns = bpf_ktime_get_ns();
+    e->kind = PROC_FORK;
+    e->pid = ctx->child_pid;
+    e->ppid = ctx->parent_pid;
+    __builtin_memcpy(e->comm, ctx->child_comm, sizeof(e->comm));
+    bpf_ringbuf_submit(e, 0);
+    return 0;
+}
+
+SEC("tracepoint/sched/sched_process_exec")
+int handle_exec(struct sched_process_exec_args *ctx)
+{
+    __u32 pid = (__u32)ctx->pid;
+    if (!is_tracked(pid))
+        return 0;
+
+    struct proc_event *e = bpf_ringbuf_reserve(&proc_events, sizeof(*e), 0);
+    if (!e)
+        return 0;
+    __builtin_memset(e, 0, sizeof(*e));
+    e->ts_ns = bpf_ktime_get_ns();
+    e->kind = PROC_EXEC;
+    e->pid = ctx->pid;
+    bpf_get_current_comm(e->comm, sizeof(e->comm));
+    // Read the executed path from the tracepoint's __data_loc field: the low 16
+    // bits are the byte offset of the string within the record (relative to
+    // ctx). The size is the CONSTANT sizeof(filename), so the verifier accepts
+    // the read directly (no variable-length mask needed).
+    unsigned short off = (unsigned short)(ctx->filename & 0xFFFF);
+    bpf_probe_read_kernel_str(e->filename, sizeof(e->filename), (void *)ctx + off);
+    bpf_ringbuf_submit(e, 0);
+    return 0;
+}
+
+SEC("tracepoint/sched/sched_process_exit")
+int handle_exit(struct sched_process_exit_args *ctx)
+{
+    __u32 pid = (__u32)ctx->pid;
+    if (!is_tracked(pid))
+        return 0;
+
+    struct proc_event *e = bpf_ringbuf_reserve(&proc_events, sizeof(*e), 0);
+    if (!e) {
+        // Still drop it from the set so the map doesn't leak dead pids.
+        bpf_map_delete_elem(&proc_tracked, &pid);
+        return 0;
+    }
+    __builtin_memset(e, 0, sizeof(*e));
+    e->ts_ns = bpf_ktime_get_ns();
+    e->kind = PROC_EXIT;
+    e->pid = ctx->pid;
+    __builtin_memcpy(e->comm, ctx->comm, sizeof(e->comm));
+    bpf_ringbuf_submit(e, 0);
+
+    bpf_map_delete_elem(&proc_tracked, &pid);
+    return 0;
+}

--- a/internal/bpf/programs/proc.bpf.c
+++ b/internal/bpf/programs/proc.bpf.c
@@ -45,17 +45,22 @@ char LICENSE[] SEC("license") = "GPL";
 #define COMM_LEN 16
 #define FILENAME_LEN 128
 
-// Tracepoint layouts, hand-laid from the stable `format` files (offsets after
-// the 8-byte common header common_type/flags/preempt_count/pid).
+// Tracepoint layouts, hand-laid from the `format` files (offsets after the
+// 8-byte common header common_type/flags/preempt_count/pid).
 //
-// sched/sched_process_fork: parent_comm[16]@8, parent_pid@24, child_comm[16]@28,
-// child_pid@44.
+// sched/sched_process_fork is special: its comm fields are __data_loc (a 4-byte
+// offset/len descriptor), NOT a fixed char[16] like sched_process_exit /
+// sched_switch — so parent_pid is at offset 12 and child_pid at offset 20 (not
+// 24/44). This is a property of the tracepoint's definition, stable across
+// kernels. We only ever read child_pid from this struct; the parent pid and
+// comm come from offset-free helpers (current == parent at fork), so a layout
+// surprise can at most misread child_pid.
 struct sched_process_fork_args {
     unsigned long long _pad;
-    char parent_comm[COMM_LEN];
-    int parent_pid;
-    char child_comm[COMM_LEN];
-    int child_pid;
+    unsigned int parent_comm; // __data_loc @8
+    int parent_pid;           // @12
+    unsigned int child_comm;  // __data_loc @16
+    int child_pid;            // @20
 };
 
 // sched/sched_process_exec: __data_loc filename@8 (u32: low16 offset, high16
@@ -108,7 +113,9 @@ static __always_inline int is_tracked(__u32 pid)
 SEC("tracepoint/sched/sched_process_fork")
 int handle_fork(struct sched_process_fork_args *ctx)
 {
-    __u32 ppid = (__u32)ctx->parent_pid;
+    // current == parent at sched_process_fork, so the parent's global pid comes
+    // from the helper (offset-free — avoids depending on the __data_loc layout).
+    __u32 ppid = (__u32)bpf_get_current_pid_tgid();
     if (!is_tracked(ppid))
         return 0;
 
@@ -125,8 +132,10 @@ int handle_fork(struct sched_process_fork_args *ctx)
     e->ts_ns = bpf_ktime_get_ns();
     e->kind = PROC_FORK;
     e->pid = ctx->child_pid;
-    e->ppid = ctx->parent_pid;
-    __builtin_memcpy(e->comm, ctx->child_comm, sizeof(e->comm));
+    e->ppid = (__s32)ppid;
+    // The child inherits the parent's comm at fork (the post-exec name shows in
+    // the subsequent exec event); bpf_get_current_comm gives it offset-free.
+    bpf_get_current_comm(e->comm, sizeof(e->comm));
     bpf_ringbuf_submit(e, 0);
     return 0;
 }

--- a/internal/serve/mapper.go
+++ b/internal/serve/mapper.go
@@ -180,6 +180,14 @@ func toEvent(pid int, buildID string, v interface{}) *pb.Event {
 			CgroupId: x.CgroupID, Cgroup: x.Cgroup, Container: x.Container,
 		}}
 
+	case collector.ProcLifecycleEvent:
+		ev.TsUnixNano = tsNano(x.Timestamp)
+		ev.Category = pb.Category_CATEGORY_PROCESS
+		ev.Payload = &pb.Event_ProcLifecycle{ProcLifecycle: &pb.ProcLifecycleEvent{
+			Kind: x.Kind, Pid: x.PID, Ppid: x.PPID,
+			Comm: x.Comm, Filename: x.Filename,
+		}}
+
 	case collector.TimelineEvent:
 		ev.TsUnixNano = tsNano(x.Timestamp)
 		ev.Category = timelineCategory(x.Category)
@@ -277,6 +285,8 @@ func timelineCategory(s string) pb.Category {
 		return pb.Category_CATEGORY_FD
 	case "sig":
 		return pb.Category_CATEGORY_SIGNAL
+	case "proc":
+		return pb.Category_CATEGORY_PROCESS
 	default:
 		return pb.Category_CATEGORY_TIMELINE
 	}

--- a/internal/tui/help.go
+++ b/internal/tui/help.go
@@ -154,6 +154,15 @@ func renderHelpOverlayWithStatus(m Model, w, h int) string {
 			}
 			return statusRowNA("context", "namespace/cgroup is Linux-only")
 		}(),
+		// Exec lineage (#60) is eBPF-only and never simulated: "real via eBPF"
+		// when the sched fork/exec/exit tracepoints attached, else genuinely
+		// unavailable (macOS, --no-ebpf, or attach failure) — never "mock".
+		func() string {
+			if m.lifecycleSource != "" {
+				return statusRow("lifecycle", false, m.lifecycleSource)
+			}
+			return statusRowNA("lifecycle", "needs eBPF (sched fork/exec/exit)")
+		}(),
 	}
 
 	// Scroll: card has border (2 lines) + padding (2 lines) = 4 overhead;

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -92,6 +92,7 @@ type NetErrorMsg collector.NetError
 type SignalMsg collector.SignalEvent
 type TLSPayloadMsg collector.TLSPayload
 type ProcContextMsg collector.ProcContext
+type ProcLifecycleMsg collector.ProcLifecycleEvent
 type LockGraphMsg []collector.LockEntry
 type LockTimelineMsg collector.TimelineEvent
 
@@ -129,9 +130,10 @@ type Model struct {
 	FDCountHistory []float64
 	FDEvents       []collector.FDEvent
 	Timeline       []collector.TimelineEvent
-	Signals        []collector.SignalEvent // eBPF signals delivered to the target (#58), newest-first
-	TLSPayloads    []collector.TLSPayload  // eBPF TLS payloads (#55), newest-first; stream/export-only, no live panel
-	ProcCtx        collector.ProcContext   // /proc namespace/cgroup/identity context (#60); zero value until first sample (or on macOS)
+	Signals        []collector.SignalEvent        // eBPF signals delivered to the target (#58), newest-first
+	TLSPayloads    []collector.TLSPayload         // eBPF TLS payloads (#55), newest-first; stream/export-only, no live panel
+	ProcCtx        collector.ProcContext          // /proc namespace/cgroup/identity context (#60); zero value until first sample (or on macOS)
+	ProcEvents     []collector.ProcLifecycleEvent // eBPF exec lineage (#60): fork/exec/exit, newest-first
 	LockGraph      []collector.LockEntry
 
 	// UI state
@@ -183,17 +185,18 @@ type Model struct {
 
 	// Sources: indicate where the real data came from ("eBPF" | "/proc" | "" for mock).
 	// Shown in the help overlay (?) for debugging and visibility.
-	cpuSource      string
-	syscallsSource string
-	ioFilesSource  string
-	netSource      string
-	threadsSource  string
-	memSource      string
-	heapSource     string
-	locksSource    string
-	signalsSource  string
-	tlsSource      string
-	contextSource  string
+	cpuSource       string
+	syscallsSource  string
+	ioFilesSource   string
+	netSource       string
+	threadsSource   string
+	memSource       string
+	heapSource      string
+	locksSource     string
+	signalsSource   string
+	tlsSource       string
+	contextSource   string
+	lifecycleSource string
 
 	// Stable caches to avoid visual reordering between ticks.
 	// topSyscallNames is recomputed every `topRefreshInterval`; between refreshes
@@ -249,6 +252,7 @@ func NewModel(cfg Config) Model {
 	m.signalsSource = m.collectors.Sources.Signals
 	m.tlsSource = m.collectors.Sources.TLS
 	m.contextSource = m.collectors.Sources.Context
+	m.lifecycleSource = m.collectors.Sources.Lifecycle
 
 	m.usingMockFDs = m.collectors.MockFDs()
 	m.usingMockCPU = m.collectors.MockCPU()
@@ -328,6 +332,9 @@ func (m Model) Init() tea.Cmd {
 	}
 	if m.collectors.ProcContext != nil {
 		cmds = append(cmds, waitForProcContext(m.collectors.ProcContext))
+	}
+	if m.collectors.ProcLifecycleEBPF != nil {
+		cmds = append(cmds, waitForProcLifecycleEBPF(m.collectors.ProcLifecycleEBPF))
 	}
 	if m.exportFile != nil {
 		cmds = append(cmds, exportTick())
@@ -508,6 +515,26 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// in the export and the stream. Never simulated.
 		m.ProcCtx = collector.ProcContext(v)
 		return m, waitForProcContext(m.collectors.ProcContext)
+
+	case ProcLifecycleMsg:
+		// Real exec-lineage event (#60) — fork/exec/exit in the target's
+		// subtree. Record it (newest-first, capped, for export) and surface it
+		// in the unified timeline under the "proc" category (F7). Only the real
+		// eBPF collector emits these.
+		pe := collector.ProcLifecycleEvent(v)
+		m.ProcEvents = append([]collector.ProcLifecycleEvent{pe}, m.ProcEvents...)
+		if len(m.ProcEvents) > 40 {
+			m.ProcEvents = m.ProcEvents[:40]
+		}
+		m.Timeline = append([]collector.TimelineEvent{{
+			Timestamp: pe.Timestamp,
+			Category:  "proc",
+			Message:   procLifecycleMessage(pe),
+		}}, m.Timeline...)
+		if len(m.Timeline) > 120 {
+			m.Timeline = m.Timeline[:120]
+		}
+		return m, waitForProcLifecycleEBPF(m.collectors.ProcLifecycleEBPF)
 
 	case LockGraphMsg:
 		m.LockGraph = []collector.LockEntry(v)
@@ -1258,6 +1285,22 @@ func waitForProcContext(c *collector.ProcContextCollector) tea.Cmd {
 		}
 		if s, ok := (<-ch).(collector.ProcContext); ok {
 			return ProcContextMsg(s)
+		}
+		return TickMsg(time.Now())
+	}
+}
+
+func waitForProcLifecycleEBPF(c *collector.ProcLifecycleEBPFCollector) tea.Cmd {
+	if c == nil {
+		return nil
+	}
+	return func() tea.Msg {
+		ch := c.Subscribe()
+		if ch == nil {
+			return TickMsg(time.Now())
+		}
+		if s, ok := (<-ch).(collector.ProcLifecycleEvent); ok {
+			return ProcLifecycleMsg(s)
 		}
 		return TickMsg(time.Now())
 	}

--- a/internal/tui/snapshot.go
+++ b/internal/tui/snapshot.go
@@ -27,24 +27,25 @@ type Snapshot struct {
 // SnapshotData is all the captured telemetry — only fields with a real or
 // simulated source that reflect data to be analyzed offline.
 type SnapshotData struct {
-	CPUHistory     []float64                 `json:"cpu_history"`
-	SyscallCounts  map[string]uint64         `json:"syscall_counts"`
-	NetConns       []collector.NetConn       `json:"network_connections"`
-	NetErrors      []collector.NetError      `json:"network_errors"`
-	MemStats       collector.MemStats        `json:"memory"`
-	HeapStats      collector.HeapStats       `json:"heap"`
-	Threads        []collector.ThreadInfo    `json:"threads"`
-	IOStats        collector.IOStats         `json:"io"`
-	FSEvents       []collector.FSEvent       `json:"fs_events"`
-	IOReadHist     []float64                 `json:"io_read_history"`
-	IOWriteHist    []float64                 `json:"io_write_history"`
-	FDs            []collector.FDEntry       `json:"fds"`
-	FDCountHistory []float64                 `json:"fd_count_history"`
-	FDEvents       []collector.FDEvent       `json:"fd_events"`
-	Timeline       []collector.TimelineEvent `json:"timeline"`
-	Signals        []collector.SignalEvent   `json:"signals"`
-	TLSPayloads    []collector.TLSPayload    `json:"tls_payloads,omitempty"`
-	ProcContext    collector.ProcContext     `json:"proc_context"`
+	CPUHistory     []float64                      `json:"cpu_history"`
+	SyscallCounts  map[string]uint64              `json:"syscall_counts"`
+	NetConns       []collector.NetConn            `json:"network_connections"`
+	NetErrors      []collector.NetError           `json:"network_errors"`
+	MemStats       collector.MemStats             `json:"memory"`
+	HeapStats      collector.HeapStats            `json:"heap"`
+	Threads        []collector.ThreadInfo         `json:"threads"`
+	IOStats        collector.IOStats              `json:"io"`
+	FSEvents       []collector.FSEvent            `json:"fs_events"`
+	IOReadHist     []float64                      `json:"io_read_history"`
+	IOWriteHist    []float64                      `json:"io_write_history"`
+	FDs            []collector.FDEntry            `json:"fds"`
+	FDCountHistory []float64                      `json:"fd_count_history"`
+	FDEvents       []collector.FDEvent            `json:"fd_events"`
+	Timeline       []collector.TimelineEvent      `json:"timeline"`
+	Signals        []collector.SignalEvent        `json:"signals"`
+	TLSPayloads    []collector.TLSPayload         `json:"tls_payloads,omitempty"`
+	ProcContext    collector.ProcContext          `json:"proc_context"`
+	ProcEvents     []collector.ProcLifecycleEvent `json:"proc_lifecycle"`
 }
 
 // buildSnapshot extracts a Snapshot from the current model state.
@@ -74,6 +75,7 @@ func buildSnapshot(m Model) Snapshot {
 			Signals:        append([]collector.SignalEvent(nil), m.Signals...),
 			TLSPayloads:    append([]collector.TLSPayload(nil), m.TLSPayloads...),
 			ProcContext:    m.ProcCtx,
+			ProcEvents:     append([]collector.ProcLifecycleEvent(nil), m.ProcEvents...),
 		},
 	}
 }

--- a/internal/tui/styles.go
+++ b/internal/tui/styles.go
@@ -110,6 +110,8 @@ func CategoryColor(cat string) lipgloss.Color {
 		return ColorTeal
 	case "sig":
 		return ColorPink
+	case "proc":
+		return ColorBright
 	default:
 		return ColorMuted
 	}
@@ -134,6 +136,8 @@ func CategoryLabel(cat string) string {
 		return "FD "
 	case "sig":
 		return "SIG"
+	case "proc":
+		return "PRC"
 	default:
 		return "???"
 	}

--- a/internal/tui/view_timeline.go
+++ b/internal/tui/view_timeline.go
@@ -26,6 +26,24 @@ func signalMessage(e collector.SignalEvent) string {
 	return fmt.Sprintf("%s ← pid %d", e.Signal, e.SenderPID)
 }
 
+// procLifecycleMessage renders a ProcLifecycleEvent as a one-line entry for the
+// F7 timeline: "fork → pid (comm)", "exec /path (pid)", or "exit pid (comm)".
+func procLifecycleMessage(e collector.ProcLifecycleEvent) string {
+	switch e.Kind {
+	case "fork":
+		return fmt.Sprintf("fork → pid %d (%s) ← pid %d", e.PID, e.Comm, e.PPID)
+	case "exec":
+		if e.Filename != "" {
+			return fmt.Sprintf("exec %s (pid %d)", e.Filename, e.PID)
+		}
+		return fmt.Sprintf("exec (pid %d, %s)", e.PID, e.Comm)
+	case "exit":
+		return fmt.Sprintf("exit pid %d (%s)", e.PID, e.Comm)
+	default:
+		return fmt.Sprintf("%s pid %d (%s)", e.Kind, e.PID, e.Comm)
+	}
+}
+
 // renderTimelineView (F7) — assets/mockup.jsx → TimelineView
 // Stream completo de eventos com badge por categoria.
 func renderTimelineView(m Model, w, h int) string {

--- a/pkg/collector/proclifecycle_decode.go
+++ b/pkg/collector/proclifecycle_decode.go
@@ -1,0 +1,49 @@
+package collector
+
+import (
+	"fmt"
+	"time"
+)
+
+// Decoder for the exec-lineage collector (#60). Build-tag-free so it compiles
+// and is unit-tested on any OS (the fs_decode.go / signal_decode.go idiom). The
+// kind constants mirror PROC_FORK/PROC_EXEC/PROC_EXIT in programs/proc.bpf.c.
+const (
+	procKindFork = 0
+	procKindExec = 1
+	procKindExit = 2
+)
+
+// procKindName maps a raw kind to its symbolic verb, falling back to a numeric
+// form so an unexpected value is never silently lost.
+func procKindName(kind uint32) string {
+	switch kind {
+	case procKindFork:
+		return "fork"
+	case procKindExec:
+		return "exec"
+	case procKindExit:
+		return "exit"
+	default:
+		return fmt.Sprintf("kind%d", kind)
+	}
+}
+
+// decodeProcLifecycle builds a ProcLifecycleEvent from the raw fields of a
+// proc_event record. ts is the wall-clock capture time (stamped by the collector
+// when the event is drained — the kernel ts_ns is monotonic, not wall-clock).
+// filename is only meaningful for exec; it is cleared for other kinds so a
+// stale buffer can't leak into fork/exit events.
+func decodeProcLifecycle(ts time.Time, kind uint32, pid, ppid int32, comm, filename []byte) ProcLifecycleEvent {
+	e := ProcLifecycleEvent{
+		Timestamp: ts,
+		Kind:      procKindName(kind),
+		PID:       pid,
+		PPID:      ppid,
+		Comm:      cstr(comm),
+	}
+	if kind == procKindExec {
+		e.Filename = cstr(filename)
+	}
+	return e
+}

--- a/pkg/collector/proclifecycle_decode_test.go
+++ b/pkg/collector/proclifecycle_decode_test.go
@@ -1,0 +1,48 @@
+package collector
+
+import (
+	"testing"
+	"time"
+)
+
+func TestProcKindName(t *testing.T) {
+	cases := map[uint32]string{
+		0: "fork", 1: "exec", 2: "exit", 7: "kind7",
+	}
+	for k, want := range cases {
+		if got := procKindName(k); got != want {
+			t.Errorf("procKindName(%d) = %q, want %q", k, got, want)
+		}
+	}
+}
+
+func TestDecodeProcLifecycle(t *testing.T) {
+	ts := time.Now()
+	comm := append([]byte("bash"), 0, 'x') // NUL-terminated, trailing garbage
+	fname := append([]byte("/usr/bin/ls"), 0)
+
+	fork := decodeProcLifecycle(ts, procKindFork, 4242, 7, comm, fname)
+	if fork.Kind != "fork" || fork.PID != 4242 || fork.PPID != 7 {
+		t.Errorf("fork = %+v", fork)
+	}
+	if fork.Comm != "bash" {
+		t.Errorf("fork.Comm = %q, want bash", fork.Comm)
+	}
+	// Filename must NOT leak into a fork event even if a buffer is passed.
+	if fork.Filename != "" {
+		t.Errorf("fork.Filename = %q, want empty", fork.Filename)
+	}
+
+	exec := decodeProcLifecycle(ts, procKindExec, 4242, 0, comm, fname)
+	if exec.Kind != "exec" || exec.Filename != "/usr/bin/ls" {
+		t.Errorf("exec = %+v", exec)
+	}
+
+	exit := decodeProcLifecycle(ts, procKindExit, 4242, 0, comm, nil)
+	if exit.Kind != "exit" || exit.Filename != "" {
+		t.Errorf("exit = %+v", exit)
+	}
+	if !exit.Timestamp.Equal(ts) {
+		t.Errorf("timestamp not preserved")
+	}
+}

--- a/pkg/collector/proclifecycle_ebpf.go
+++ b/pkg/collector/proclifecycle_ebpf.go
@@ -1,0 +1,78 @@
+//go:build linux && ebpf
+
+package collector
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"time"
+
+	"github.com/trentas/ptop/internal/bpf"
+)
+
+// ProcLifecycleEBPFCollector consumes the sched fork/exec/exit ring buffer of
+// the eBPF proc tracer and publishes one ProcLifecycleEvent per event in the
+// target's descendant subtree (#60). There is no /proc fallback and no
+// simulation — lineage is surfaced only when eBPF can attach the tracepoints.
+type ProcLifecycleEBPFCollector struct {
+	tracer *bpf.ProcTracer
+	ch     chan interface{}
+	stop   chan struct{}
+}
+
+func NewProcLifecycleEBPFCollector() *ProcLifecycleEBPFCollector {
+	return &ProcLifecycleEBPFCollector{
+		// Buffered for fork/exec storms; the sender drops on overflow.
+		ch:   make(chan interface{}, 64),
+		stop: make(chan struct{}),
+	}
+}
+
+func (c *ProcLifecycleEBPFCollector) Start(pid int) error {
+	tracer, err := bpf.OpenProcTracer(pid)
+	if err != nil {
+		return fmt.Errorf("proc lifecycle eBPF: %w", err)
+	}
+	c.tracer = tracer
+	// tracer is passed explicitly (not read from the field) so Stop()'s
+	// `c.tracer = nil` can't race this goroutine; Close() shuts the ring-buffer
+	// reader, unblocking Next with io.EOF.
+	go c.readLoop(tracer)
+	return nil
+}
+
+func (c *ProcLifecycleEBPFCollector) Stop() {
+	close(c.stop)
+	if c.tracer != nil {
+		_ = c.tracer.Close()
+		c.tracer = nil
+	}
+}
+
+func (c *ProcLifecycleEBPFCollector) Subscribe() <-chan interface{} { return c.ch }
+
+// readLoop drains the lifecycle ring buffer, decoding each record into a
+// ProcLifecycleEvent and publishing it. It exits on io.EOF (tracer closed). A
+// garbled record is logged-by-skip. Sends are non-blocking: under backpressure
+// events are dropped, consistent with every other collector.
+func (c *ProcLifecycleEBPFCollector) readLoop(tracer *bpf.ProcTracer) {
+	if tracer == nil {
+		return
+	}
+	for {
+		rec, err := tracer.Next()
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				return
+			}
+			continue // transient (short/garbled record) — keep reading
+		}
+		ev := decodeProcLifecycle(time.Now(), rec.Kind, rec.PID, rec.PPID,
+			rec.Comm[:], rec.Filename[:])
+		select {
+		case c.ch <- ev:
+		default:
+		}
+	}
+}

--- a/pkg/collector/proclifecycle_ebpf_stub.go
+++ b/pkg/collector/proclifecycle_ebpf_stub.go
@@ -1,0 +1,24 @@
+//go:build !linux || !ebpf
+
+package collector
+
+import "errors"
+
+// Stub: builds without -tags=ebpf or on non-Linux hosts get this
+// ProcLifecycleEBPFCollector that always fails Start. Exec lineage is eBPF-only
+// (no /proc fallback, never simulated), so the consumer simply has no lineage
+// data.
+
+type ProcLifecycleEBPFCollector struct{}
+
+func NewProcLifecycleEBPFCollector() *ProcLifecycleEBPFCollector {
+	return &ProcLifecycleEBPFCollector{}
+}
+
+func (*ProcLifecycleEBPFCollector) Start(pid int) error {
+	return errors.New("eBPF proc lifecycle collector not available in this build")
+}
+
+func (*ProcLifecycleEBPFCollector) Stop() {}
+
+func (*ProcLifecycleEBPFCollector) Subscribe() <-chan interface{} { return nil }

--- a/pkg/collector/set.go
+++ b/pkg/collector/set.go
@@ -24,17 +24,18 @@ type SetConfig struct {
 // started for that subsystem (the consumer then falls back to mock data).
 // These strings surface in the TUI's "?" help overlay; never lie about them.
 type Sources struct {
-	CPU      string
-	Threads  string
-	Mem      string
-	Heap     string
-	Syscalls string
-	IOFiles  string
-	Net      string
-	Locks    string
-	Signals  string
-	TLS      string
-	Context  string
+	CPU       string
+	Threads   string
+	Mem       string
+	Heap      string
+	Syscalls  string
+	IOFiles   string
+	Net       string
+	Locks     string
+	Signals   string
+	TLS       string
+	Context   string
+	Lifecycle string
 }
 
 // Set owns the live collectors for a single target PID, chosen by the
@@ -42,23 +43,24 @@ type Sources struct {
 // that wires collector construction + lifecycle, so the TUI and the headless
 // gRPC server (#51) consume the same selection logic instead of duplicating it.
 type Set struct {
-	FD           *FDCollector
-	CPUProc      *CPUCollector
-	CPUEBPF      *CPUEBPFCollector
-	ThreadsProc  *ThreadsCollector
-	ThreadsEBPF  *ThreadsEBPFCollector
-	MemProc      *MemCollector
-	MemEBPF      *MemEBPFCollector
-	HeapEBPF     *HeapEBPFCollector
-	IOWait       *IOWaitCollector
-	IOThroughput *IOThroughputCollector
-	SyscallsEBPF *SyscallsEBPFCollector
-	IOEBPF       *IOEBPFCollector
-	NetworkEBPF  *NetworkEBPFCollector
-	FutexEBPF    *FutexEBPFCollector
-	SignalEBPF   *SignalEBPFCollector
-	TLSEBPF      *TLSEBPFCollector
-	ProcContext  *ProcContextCollector
+	FD                *FDCollector
+	CPUProc           *CPUCollector
+	CPUEBPF           *CPUEBPFCollector
+	ThreadsProc       *ThreadsCollector
+	ThreadsEBPF       *ThreadsEBPFCollector
+	MemProc           *MemCollector
+	MemEBPF           *MemEBPFCollector
+	HeapEBPF          *HeapEBPFCollector
+	IOWait            *IOWaitCollector
+	IOThroughput      *IOThroughputCollector
+	SyscallsEBPF      *SyscallsEBPFCollector
+	IOEBPF            *IOEBPFCollector
+	NetworkEBPF       *NetworkEBPFCollector
+	FutexEBPF         *FutexEBPFCollector
+	SignalEBPF        *SignalEBPFCollector
+	TLSEBPF           *TLSEBPFCollector
+	ProcContext       *ProcContextCollector
+	ProcLifecycleEBPF *ProcLifecycleEBPFCollector
 
 	Sources Sources
 }
@@ -207,6 +209,16 @@ func NewSet(cfg SetConfig) *Set {
 			warnEBPFFailure("signals", err)
 		}
 
+		// Exec lineage: fork/exec/exit across the target's descendant subtree
+		// (#60). eBPF-only — no /proc fallback, never simulated.
+		c8 := NewProcLifecycleEBPFCollector()
+		if err := c8.Start(cfg.PID); err == nil {
+			s.ProcLifecycleEBPF = c8
+			s.Sources.Lifecycle = "eBPF"
+		} else {
+			warnEBPFFailure("lifecycle", err)
+		}
+
 		// TLS payload capture (#55) — OFF unless explicitly opted in (--tls),
 		// because it observes plaintext. eBPF-only (libssl uprobes), no /proc
 		// fallback, never simulated.
@@ -283,6 +295,9 @@ func (s *Set) Stop() {
 	if s.ProcContext != nil {
 		s.ProcContext.Stop()
 	}
+	if s.ProcLifecycleEBPF != nil {
+		s.ProcLifecycleEBPF.Stop()
+	}
 }
 
 // Collectors returns every started collector as a Collector. Used by consumers
@@ -316,6 +331,7 @@ func (s *Set) Collectors() []Collector {
 	add(s.SignalEBPF, s.SignalEBPF != nil)
 	add(s.TLSEBPF, s.TLSEBPF != nil)
 	add(s.ProcContext, s.ProcContext != nil)
+	add(s.ProcLifecycleEBPF, s.ProcLifecycleEBPF != nil)
 	return cs
 }
 

--- a/pkg/collector/types.go
+++ b/pkg/collector/types.go
@@ -299,6 +299,26 @@ type ProcContext struct {
 	Container string // derived container id; "" if none
 }
 
+// ─── Exec lineage (#60) ──────────────────────────────────────────────────────
+
+// ProcLifecycleEvent is an exec-lineage event reconstructing the process tree
+// the target spawns: a fork/clone ("fork"), an execve ("exec"), or a task exit
+// ("exit"). PID is the subject (the child for fork, the task itself for
+// exec/exit); PPID is the parent (set for fork, 0 otherwise). Comm is the
+// subject's command name; Filename is the executed path (exec only, "" else).
+// The eBPF collector seeds a tracked set with the target and grows it on each
+// fork, so the whole descendant subtree is captured — including clone/thread
+// creation (which surfaces as "fork"). Emitted only by the eBPF proc collector
+// (never simulated).
+type ProcLifecycleEvent struct {
+	Timestamp time.Time
+	Kind      string // "fork" | "exec" | "exit"
+	PID       int32
+	PPID      int32
+	Comm      string
+	Filename  string // executed path (exec only; "" otherwise)
+}
+
 // ─── Timeline ────────────────────────────────────────────────────────────────
 
 type TimelineEvent struct {

--- a/pkg/streampb/event.pb.go
+++ b/pkg/streampb/event.pb.go
@@ -291,6 +291,7 @@ type Event struct {
 	//	*Event_Signal
 	//	*Event_Tls
 	//	*Event_ProcContext
+	//	*Event_ProcLifecycle
 	Payload       isEvent_Payload `protobuf_oneof:"payload"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
@@ -560,6 +561,15 @@ func (x *Event) GetProcContext() *ProcContext {
 	return nil
 }
 
+func (x *Event) GetProcLifecycle() *ProcLifecycleEvent {
+	if x != nil {
+		if x, ok := x.Payload.(*Event_ProcLifecycle); ok {
+			return x.ProcLifecycle
+		}
+	}
+	return nil
+}
+
 type isEvent_Payload interface {
 	isEvent_Payload()
 }
@@ -641,6 +651,10 @@ type Event_ProcContext struct {
 	ProcContext *ProcContext `protobuf:"bytes,28,opt,name=proc_context,json=procContext,proto3,oneof"` // #60 — periodic namespace/cgroup/identity snapshot
 }
 
+type Event_ProcLifecycle struct {
+	ProcLifecycle *ProcLifecycleEvent `protobuf:"bytes,29,opt,name=proc_lifecycle,json=procLifecycle,proto3,oneof"` // #60 — exec lineage (fork/exec/exit)
+}
+
 func (*Event_Cpu) isEvent_Payload() {}
 
 func (*Event_Syscalls) isEvent_Payload() {}
@@ -678,6 +692,8 @@ func (*Event_Signal) isEvent_Payload() {}
 func (*Event_Tls) isEvent_Payload() {}
 
 func (*Event_ProcContext) isEvent_Payload() {}
+
+func (*Event_ProcLifecycle) isEvent_Payload() {}
 
 // ─── CPU ──────────────────────────────────────────────────────────────────
 type CpuSample struct {
@@ -2328,6 +2344,91 @@ func (x *ProcContext) GetContainer() string {
 	return ""
 }
 
+// ProcLifecycleEvent is an exec-lineage event (#60) reconstructing the process
+// tree the target spawns: a fork/clone (kind="fork"), an execve (kind="exec"),
+// or a process exit (kind="exit"). pid is the subject (the child for fork, the
+// task itself for exec/exit), ppid is the parent (set for fork; 0 otherwise).
+// comm is the subject's command name; filename is the executed path (exec only,
+// "" otherwise). The eBPF collector seeds a tracked set with the target and
+// grows it on each fork, so the whole descendant subtree is captured. Category
+// on the envelope is PROCESS; the event time lives on the envelope. eBPF-only —
+// never simulated.
+type ProcLifecycleEvent struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Kind          string                 `protobuf:"bytes,1,opt,name=kind,proto3" json:"kind,omitempty"`         // "fork" | "exec" | "exit"
+	Pid           int32                  `protobuf:"varint,2,opt,name=pid,proto3" json:"pid,omitempty"`          // subject pid (child for fork, self for exec/exit)
+	Ppid          int32                  `protobuf:"varint,3,opt,name=ppid,proto3" json:"ppid,omitempty"`        // parent pid (fork only; 0 otherwise)
+	Comm          string                 `protobuf:"bytes,4,opt,name=comm,proto3" json:"comm,omitempty"`         // subject command name
+	Filename      string                 `protobuf:"bytes,5,opt,name=filename,proto3" json:"filename,omitempty"` // executed path (exec only; "" otherwise)
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ProcLifecycleEvent) Reset() {
+	*x = ProcLifecycleEvent{}
+	mi := &file_event_proto_msgTypes[24]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ProcLifecycleEvent) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ProcLifecycleEvent) ProtoMessage() {}
+
+func (x *ProcLifecycleEvent) ProtoReflect() protoreflect.Message {
+	mi := &file_event_proto_msgTypes[24]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ProcLifecycleEvent.ProtoReflect.Descriptor instead.
+func (*ProcLifecycleEvent) Descriptor() ([]byte, []int) {
+	return file_event_proto_rawDescGZIP(), []int{24}
+}
+
+func (x *ProcLifecycleEvent) GetKind() string {
+	if x != nil {
+		return x.Kind
+	}
+	return ""
+}
+
+func (x *ProcLifecycleEvent) GetPid() int32 {
+	if x != nil {
+		return x.Pid
+	}
+	return 0
+}
+
+func (x *ProcLifecycleEvent) GetPpid() int32 {
+	if x != nil {
+		return x.Ppid
+	}
+	return 0
+}
+
+func (x *ProcLifecycleEvent) GetComm() string {
+	if x != nil {
+		return x.Comm
+	}
+	return ""
+}
+
+func (x *ProcLifecycleEvent) GetFilename() string {
+	if x != nil {
+		return x.Filename
+	}
+	return ""
+}
+
 // ─── File descriptors ───────────────────────────────────────────────────────
 type FdEntry struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
@@ -2344,7 +2445,7 @@ type FdEntry struct {
 
 func (x *FdEntry) Reset() {
 	*x = FdEntry{}
-	mi := &file_event_proto_msgTypes[24]
+	mi := &file_event_proto_msgTypes[25]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2356,7 +2457,7 @@ func (x *FdEntry) String() string {
 func (*FdEntry) ProtoMessage() {}
 
 func (x *FdEntry) ProtoReflect() protoreflect.Message {
-	mi := &file_event_proto_msgTypes[24]
+	mi := &file_event_proto_msgTypes[25]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2369,7 +2470,7 @@ func (x *FdEntry) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use FdEntry.ProtoReflect.Descriptor instead.
 func (*FdEntry) Descriptor() ([]byte, []int) {
-	return file_event_proto_rawDescGZIP(), []int{24}
+	return file_event_proto_rawDescGZIP(), []int{25}
 }
 
 func (x *FdEntry) GetFd() int32 {
@@ -2430,7 +2531,7 @@ type FdSnapshot struct {
 
 func (x *FdSnapshot) Reset() {
 	*x = FdSnapshot{}
-	mi := &file_event_proto_msgTypes[25]
+	mi := &file_event_proto_msgTypes[26]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2442,7 +2543,7 @@ func (x *FdSnapshot) String() string {
 func (*FdSnapshot) ProtoMessage() {}
 
 func (x *FdSnapshot) ProtoReflect() protoreflect.Message {
-	mi := &file_event_proto_msgTypes[25]
+	mi := &file_event_proto_msgTypes[26]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2455,7 +2556,7 @@ func (x *FdSnapshot) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use FdSnapshot.ProtoReflect.Descriptor instead.
 func (*FdSnapshot) Descriptor() ([]byte, []int) {
-	return file_event_proto_rawDescGZIP(), []int{25}
+	return file_event_proto_rawDescGZIP(), []int{26}
 }
 
 func (x *FdSnapshot) GetFds() []*FdEntry {
@@ -2476,7 +2577,7 @@ type FdEvent struct {
 
 func (x *FdEvent) Reset() {
 	*x = FdEvent{}
-	mi := &file_event_proto_msgTypes[26]
+	mi := &file_event_proto_msgTypes[27]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2488,7 +2589,7 @@ func (x *FdEvent) String() string {
 func (*FdEvent) ProtoMessage() {}
 
 func (x *FdEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_event_proto_msgTypes[26]
+	mi := &file_event_proto_msgTypes[27]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2501,7 +2602,7 @@ func (x *FdEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use FdEvent.ProtoReflect.Descriptor instead.
 func (*FdEvent) Descriptor() ([]byte, []int) {
-	return file_event_proto_rawDescGZIP(), []int{26}
+	return file_event_proto_rawDescGZIP(), []int{27}
 }
 
 func (x *FdEvent) GetMessage() string {
@@ -2527,7 +2628,7 @@ type LockEntry struct {
 
 func (x *LockEntry) Reset() {
 	*x = LockEntry{}
-	mi := &file_event_proto_msgTypes[27]
+	mi := &file_event_proto_msgTypes[28]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2539,7 +2640,7 @@ func (x *LockEntry) String() string {
 func (*LockEntry) ProtoMessage() {}
 
 func (x *LockEntry) ProtoReflect() protoreflect.Message {
-	mi := &file_event_proto_msgTypes[27]
+	mi := &file_event_proto_msgTypes[28]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2552,7 +2653,7 @@ func (x *LockEntry) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LockEntry.ProtoReflect.Descriptor instead.
 func (*LockEntry) Descriptor() ([]byte, []int) {
-	return file_event_proto_rawDescGZIP(), []int{27}
+	return file_event_proto_rawDescGZIP(), []int{28}
 }
 
 func (x *LockEntry) GetUaddr() uint64 {
@@ -2613,7 +2714,7 @@ type LockSnapshot struct {
 
 func (x *LockSnapshot) Reset() {
 	*x = LockSnapshot{}
-	mi := &file_event_proto_msgTypes[28]
+	mi := &file_event_proto_msgTypes[29]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2625,7 +2726,7 @@ func (x *LockSnapshot) String() string {
 func (*LockSnapshot) ProtoMessage() {}
 
 func (x *LockSnapshot) ProtoReflect() protoreflect.Message {
-	mi := &file_event_proto_msgTypes[28]
+	mi := &file_event_proto_msgTypes[29]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2638,7 +2739,7 @@ func (x *LockSnapshot) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LockSnapshot.ProtoReflect.Descriptor instead.
 func (*LockSnapshot) Descriptor() ([]byte, []int) {
-	return file_event_proto_rawDescGZIP(), []int{28}
+	return file_event_proto_rawDescGZIP(), []int{29}
 }
 
 func (x *LockSnapshot) GetLocks() []*LockEntry {
@@ -2659,7 +2760,7 @@ type TimelineEvent struct {
 
 func (x *TimelineEvent) Reset() {
 	*x = TimelineEvent{}
-	mi := &file_event_proto_msgTypes[29]
+	mi := &file_event_proto_msgTypes[30]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2671,7 +2772,7 @@ func (x *TimelineEvent) String() string {
 func (*TimelineEvent) ProtoMessage() {}
 
 func (x *TimelineEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_event_proto_msgTypes[29]
+	mi := &file_event_proto_msgTypes[30]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2684,7 +2785,7 @@ func (x *TimelineEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TimelineEvent.ProtoReflect.Descriptor instead.
 func (*TimelineEvent) Descriptor() ([]byte, []int) {
-	return file_event_proto_rawDescGZIP(), []int{29}
+	return file_event_proto_rawDescGZIP(), []int{30}
 }
 
 func (x *TimelineEvent) GetMessage() string {
@@ -2709,7 +2810,7 @@ const file_event_proto_rawDesc = "" +
 	"\x04line\x18\x03 \x01(\x05R\x04line\x12\x16\n" +
 	"\x06module\x18\x04 \x01(\tR\x06module\x12\x16\n" +
 	"\x06offset\x18\x05 \x01(\x04R\x06offset\x12\x19\n" +
-	"\bbuild_id\x18\x06 \x01(\tR\abuildId\"\xa4\t\n" +
+	"\bbuild_id\x18\x06 \x01(\tR\abuildId\"\xea\t\n" +
 	"\x05Event\x12 \n" +
 	"\fts_unix_nano\x18\x01 \x01(\x03R\n" +
 	"tsUnixNano\x12\x10\n" +
@@ -2740,7 +2841,8 @@ const file_event_proto_rawDesc = "" +
 	"\bfs_event\x18\x19 \x01(\v2\x10.ptop.v1.FSEventH\x00R\afsEvent\x12.\n" +
 	"\x06signal\x18\x1a \x01(\v2\x14.ptop.v1.SignalEventH\x00R\x06signal\x12,\n" +
 	"\x03tls\x18\x1b \x01(\v2\x18.ptop.v1.TLSPayloadEventH\x00R\x03tls\x129\n" +
-	"\fproc_context\x18\x1c \x01(\v2\x14.ptop.v1.ProcContextH\x00R\vprocContextB\t\n" +
+	"\fproc_context\x18\x1c \x01(\v2\x14.ptop.v1.ProcContextH\x00R\vprocContext\x12D\n" +
+	"\x0eproc_lifecycle\x18\x1d \x01(\v2\x1b.ptop.v1.ProcLifecycleEventH\x00R\rprocLifecycleB\t\n" +
 	"\apayload\"(\n" +
 	"\tCpuSample\x12\x1b\n" +
 	"\tusage_pct\x18\x01 \x01(\x01R\busagePct\"V\n" +
@@ -2882,7 +2984,13 @@ const file_event_proto_rawDesc = "" +
 	"\tcgroup_id\x18\n" +
 	" \x01(\x04R\bcgroupId\x12\x16\n" +
 	"\x06cgroup\x18\v \x01(\tR\x06cgroup\x12\x1c\n" +
-	"\tcontainer\x18\f \x01(\tR\tcontainer\"\x9c\x01\n" +
+	"\tcontainer\x18\f \x01(\tR\tcontainer\"~\n" +
+	"\x12ProcLifecycleEvent\x12\x12\n" +
+	"\x04kind\x18\x01 \x01(\tR\x04kind\x12\x10\n" +
+	"\x03pid\x18\x02 \x01(\x05R\x03pid\x12\x12\n" +
+	"\x04ppid\x18\x03 \x01(\x05R\x04ppid\x12\x12\n" +
+	"\x04comm\x18\x04 \x01(\tR\x04comm\x12\x1a\n" +
+	"\bfilename\x18\x05 \x01(\tR\bfilename\"\x9c\x01\n" +
 	"\aFdEntry\x12\x0e\n" +
 	"\x02fd\x18\x01 \x01(\x05R\x02fd\x12\x12\n" +
 	"\x04type\x18\x02 \x01(\tR\x04type\x12\x12\n" +
@@ -2940,7 +3048,7 @@ func file_event_proto_rawDescGZIP() []byte {
 }
 
 var file_event_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
-var file_event_proto_msgTypes = make([]protoimpl.MessageInfo, 30)
+var file_event_proto_msgTypes = make([]protoimpl.MessageInfo, 31)
 var file_event_proto_goTypes = []any{
 	(Category)(0),              // 0: ptop.v1.Category
 	(*StackRef)(nil),           // 1: ptop.v1.StackRef
@@ -2967,12 +3075,13 @@ var file_event_proto_goTypes = []any{
 	(*FSEvent)(nil),            // 22: ptop.v1.FSEvent
 	(*SignalEvent)(nil),        // 23: ptop.v1.SignalEvent
 	(*ProcContext)(nil),        // 24: ptop.v1.ProcContext
-	(*FdEntry)(nil),            // 25: ptop.v1.FdEntry
-	(*FdSnapshot)(nil),         // 26: ptop.v1.FdSnapshot
-	(*FdEvent)(nil),            // 27: ptop.v1.FdEvent
-	(*LockEntry)(nil),          // 28: ptop.v1.LockEntry
-	(*LockSnapshot)(nil),       // 29: ptop.v1.LockSnapshot
-	(*TimelineEvent)(nil),      // 30: ptop.v1.TimelineEvent
+	(*ProcLifecycleEvent)(nil), // 25: ptop.v1.ProcLifecycleEvent
+	(*FdEntry)(nil),            // 26: ptop.v1.FdEntry
+	(*FdSnapshot)(nil),         // 27: ptop.v1.FdSnapshot
+	(*FdEvent)(nil),            // 28: ptop.v1.FdEvent
+	(*LockEntry)(nil),          // 29: ptop.v1.LockEntry
+	(*LockSnapshot)(nil),       // 30: ptop.v1.LockSnapshot
+	(*TimelineEvent)(nil),      // 31: ptop.v1.TimelineEvent
 }
 var file_event_proto_depIdxs = []int32{
 	0,  // 0: ptop.v1.Event.category:type_name -> ptop.v1.Category
@@ -2985,10 +3094,10 @@ var file_event_proto_depIdxs = []int32{
 	17, // 7: ptop.v1.Event.io_wait:type_name -> ptop.v1.IoWaitSample
 	18, // 8: ptop.v1.Event.io_throughput:type_name -> ptop.v1.IoThroughputSample
 	21, // 9: ptop.v1.Event.io:type_name -> ptop.v1.IoSnapshot
-	26, // 10: ptop.v1.Event.fds:type_name -> ptop.v1.FdSnapshot
-	27, // 11: ptop.v1.Event.fd_event:type_name -> ptop.v1.FdEvent
-	29, // 12: ptop.v1.Event.locks:type_name -> ptop.v1.LockSnapshot
-	30, // 13: ptop.v1.Event.timeline:type_name -> ptop.v1.TimelineEvent
+	27, // 10: ptop.v1.Event.fds:type_name -> ptop.v1.FdSnapshot
+	28, // 11: ptop.v1.Event.fd_event:type_name -> ptop.v1.FdEvent
+	30, // 12: ptop.v1.Event.locks:type_name -> ptop.v1.LockSnapshot
+	31, // 13: ptop.v1.Event.timeline:type_name -> ptop.v1.TimelineEvent
 	14, // 14: ptop.v1.Event.heap:type_name -> ptop.v1.HeapSnapshot
 	12, // 15: ptop.v1.Event.heap_event:type_name -> ptop.v1.HeapEvent
 	9,  // 16: ptop.v1.Event.net_error:type_name -> ptop.v1.NetErrorEvent
@@ -2996,19 +3105,20 @@ var file_event_proto_depIdxs = []int32{
 	23, // 18: ptop.v1.Event.signal:type_name -> ptop.v1.SignalEvent
 	10, // 19: ptop.v1.Event.tls:type_name -> ptop.v1.TLSPayloadEvent
 	24, // 20: ptop.v1.Event.proc_context:type_name -> ptop.v1.ProcContext
-	5,  // 21: ptop.v1.SyscallSnapshot.stats:type_name -> ptop.v1.SyscallStat
-	7,  // 22: ptop.v1.NetworkSnapshot.conns:type_name -> ptop.v1.NetConn
-	13, // 23: ptop.v1.HeapSnapshot.top_call_sites:type_name -> ptop.v1.HeapCallSite
-	15, // 24: ptop.v1.ThreadSnapshot.threads:type_name -> ptop.v1.ThreadInfo
-	19, // 25: ptop.v1.IoSnapshot.top_files:type_name -> ptop.v1.IoFileStats
-	20, // 26: ptop.v1.IoSnapshot.latency_buckets:type_name -> ptop.v1.LatencyBucket
-	25, // 27: ptop.v1.FdSnapshot.fds:type_name -> ptop.v1.FdEntry
-	28, // 28: ptop.v1.LockSnapshot.locks:type_name -> ptop.v1.LockEntry
-	29, // [29:29] is the sub-list for method output_type
-	29, // [29:29] is the sub-list for method input_type
-	29, // [29:29] is the sub-list for extension type_name
-	29, // [29:29] is the sub-list for extension extendee
-	0,  // [0:29] is the sub-list for field type_name
+	25, // 21: ptop.v1.Event.proc_lifecycle:type_name -> ptop.v1.ProcLifecycleEvent
+	5,  // 22: ptop.v1.SyscallSnapshot.stats:type_name -> ptop.v1.SyscallStat
+	7,  // 23: ptop.v1.NetworkSnapshot.conns:type_name -> ptop.v1.NetConn
+	13, // 24: ptop.v1.HeapSnapshot.top_call_sites:type_name -> ptop.v1.HeapCallSite
+	15, // 25: ptop.v1.ThreadSnapshot.threads:type_name -> ptop.v1.ThreadInfo
+	19, // 26: ptop.v1.IoSnapshot.top_files:type_name -> ptop.v1.IoFileStats
+	20, // 27: ptop.v1.IoSnapshot.latency_buckets:type_name -> ptop.v1.LatencyBucket
+	26, // 28: ptop.v1.FdSnapshot.fds:type_name -> ptop.v1.FdEntry
+	29, // 29: ptop.v1.LockSnapshot.locks:type_name -> ptop.v1.LockEntry
+	30, // [30:30] is the sub-list for method output_type
+	30, // [30:30] is the sub-list for method input_type
+	30, // [30:30] is the sub-list for extension type_name
+	30, // [30:30] is the sub-list for extension extendee
+	0,  // [0:30] is the sub-list for field type_name
 }
 
 func init() { file_event_proto_init() }
@@ -3036,6 +3146,7 @@ func file_event_proto_init() {
 		(*Event_Signal)(nil),
 		(*Event_Tls)(nil),
 		(*Event_ProcContext)(nil),
+		(*Event_ProcLifecycle)(nil),
 	}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
@@ -3043,7 +3154,7 @@ func file_event_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_event_proto_rawDesc), len(file_event_proto_rawDesc)),
 			NumEnums:      1,
-			NumMessages:   30,
+			NumMessages:   31,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/proto/event.proto
+++ b/proto/event.proto
@@ -92,8 +92,8 @@ message Event {
     SignalEvent signal = 26; // #58 — signal delivered to the target, with origin
     TLSPayloadEvent tls = 27; // #55 — pre-encryption / post-decryption plaintext
     ProcContext proc_context = 28; // #60 — periodic namespace/cgroup/identity snapshot
-    // 29+ reserved for the remaining #52 capabilities (security/LSM,
-    // exec lineage — #60 ProcLifecycleEvent).
+    ProcLifecycleEvent proc_lifecycle = 29; // #60 — exec lineage (fork/exec/exit)
+    // 30+ reserved for the remaining #52 capabilities (security/LSM — #59).
   }
 }
 
@@ -323,6 +323,23 @@ message ProcContext {
   uint64 cgroup_id = 10;
   string cgroup = 11; // cgroup path (v2 "0::/p" → "/p")
   string container = 12; // derived container id; "" if none
+}
+
+// ProcLifecycleEvent is an exec-lineage event (#60) reconstructing the process
+// tree the target spawns: a fork/clone (kind="fork"), an execve (kind="exec"),
+// or a process exit (kind="exit"). pid is the subject (the child for fork, the
+// task itself for exec/exit), ppid is the parent (set for fork; 0 otherwise).
+// comm is the subject's command name; filename is the executed path (exec only,
+// "" otherwise). The eBPF collector seeds a tracked set with the target and
+// grows it on each fork, so the whole descendant subtree is captured. Category
+// on the envelope is PROCESS; the event time lives on the envelope. eBPF-only —
+// never simulated.
+message ProcLifecycleEvent {
+  string kind = 1; // "fork" | "exec" | "exit"
+  int32 pid = 2; // subject pid (child for fork, self for exec/exit)
+  int32 ppid = 3; // parent pid (fork only; 0 otherwise)
+  string comm = 4; // subject command name
+  string filename = 5; // executed path (exec only; "" otherwise)
 }
 
 // ─── File descriptors ───────────────────────────────────────────────────────


### PR DESCRIPTION
Closes #60 (epic #52). **PR2 of 2** — the exec-**lineage** half. The
container/execution **context** half shipped in #83.

## What

Reconstructs the process tree the target spawns, over eBPF, streamed via #51.
New `proc.bpf.c` on the `sched_process_{fork,exec,exit}` tracepoints.

**Target filtering** mirrors `signal.bpf.c` (#58): these sched tracepoints
report **init-ns global pids**, so a `pid_is_target()`/ns-projection filter is
wrong. Instead a `proc_tracked` HASH of global pids is **seeded by the loader
with the target's global pid and grown on every fork whose parent is tracked**
— capturing the **whole descendant subtree** (children, grandchildren, …). A
tracked pid is dropped on exit.

- `fork` includes `clone(CLONE_THREAD)` (thread creation surfaces as fork), and
  the tracked set holds thread pids too — deliberate: it matches the issue's
  "execve / clone / fork" wording and makes the subtree filter robust (a child
  forked by a worker thread of the target is still attributed).
- the exec **filename** is read from the tracepoint's `__data_loc` field with a
  **constant-size** `bpf_probe_read_kernel_str` (so no variable-read verifier
  trap — the one #55 hit).
- `proc.bpf.c` added to `BPF_SRCS` (the `//go:embed` trap).

## Stream

`ProcLifecycleEvent` (oneof field 29, `CATEGORY_PROCESS` — already in main from
#83) + mapper case. `ProcLifecycleEBPFCollector` clones the signal collector
(eBPF-only, never simulated) + `Set` wiring (`Sources.Lifecycle`).

## TUI (stream-first, per the issue)

- new `proc` timeline category (F7-only, label `PRC`); each event feeds the F7
  stream as `fork → pid (comm)` / `exec /path (pid)` / `exit pid (comm)`
- a capped, newest-first buffer for `--export`
- a `lifecycle` row in the `?` overlay (real via eBPF, or unavailable)

## Tests / validation

- `kind`/`comm`/`filename` decoder is build-tag-free + unit-tested (fork has no
  filename leak; exec carries it; numeric fallback for unknown kinds)
- green on all locally-buildable lanes: `go build/test`, `GOOS=linux
  go build/vet`, `go build -tags=ebpf` (stub), `make proto`/`proto-lint`
- the real `linux && ebpf` lane (`.bpf.o` clang compile) is CI-only, as for
  every prior eBPF capability

Deferred (documented): exit code (not on the `sched_process_exit` tracepoint;
needs CO-RE on `task->exit_code`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)