### PR TITLE
security: capture runtime PROT_EXEC mappings + LSM denials (#59)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,7 +80,8 @@ ptop/
 │   │   │   ├── futex.bpf.c        futex wait/wake → lock graph
 │   │   │   ├── signal.bpf.c       signal_generate → signals with origin (#58)
 │   │   │   ├── tls.bpf.c          libssl SSL_write/read uprobes → plaintext (#55)
-│   │   │   └── proc.bpf.c         sched fork/exec/exit → exec lineage subtree (#60)
+│   │   │   ├── proc.bpf.c         sched fork/exec/exit → exec lineage subtree (#60)
+│   │   │   └── security.bpf.c     PROT_EXEC mmap/mprotect + SELinux AVC (#59)
 │   │   ├── available.go           runtime feature flag (build-tag based)
 │   │   ├── target.go              pid-namespace target resolver (shared)
 │   │   ├── caps.go                CAP_BPF / CAP_PERFMON detection
@@ -97,6 +98,7 @@ ptop/
 │   │   ├── futex.go               futex wait/wake loader
 │   │   ├── signal.go              signal_generate loader (#58)
 │   │   ├── proc.go                sched fork/exec/exit loader → exec lineage (#60)
+│   │   ├── security.go            PROT_EXEC + SELinux AVC loader + stack (#59)
 │   │   └── *_stub.go              stubs for non-Linux / no-ebpf builds
 │   ├── serve/                     headless gRPC server (ptop --serve)
 │   │   ├── serve.go               addr parse + privilege boundary + Run
@@ -153,6 +155,8 @@ ptop/
 │       ├── proccontext.go         container-id / cgroup / ns-inode parsers (build-tag-free)
 │       ├── proclifecycle_ebpf.go  sched fork/exec/exit → exec lineage subtree (#60)
 │       ├── proclifecycle_decode.go  kind/comm/filename decode (build-tag-free)
+│       ├── security_ebpf.go       PROT_EXEC mmap/mprotect + LSM denials (#59)
+│       ├── security_decode.go     prot/kind/detail decode (build-tag-free)
 │       ├── fds.go                 /proc/<pid>/fd + fdinfo + events
 │       ├── sockets.go             inode → host:port via /proc/net/*
 │       ├── syscall_names.go       syscall id → name table

--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,8 @@ BPF_SRCS := \
 	internal/bpf/programs/futex.bpf.c \
 	internal/bpf/programs/signal.bpf.c \
 	internal/bpf/programs/tls.bpf.c \
-	internal/bpf/programs/proc.bpf.c
+	internal/bpf/programs/proc.bpf.c \
+	internal/bpf/programs/security.bpf.c
 
 BPF_OBJS := $(BPF_SRCS:.c=.o)
 

--- a/internal/bpf/programs/security.bpf.c
+++ b/internal/bpf/programs/security.bpf.c
@@ -1,0 +1,174 @@
+// SPDX-License-Identifier: GPL-2.0
+//
+// security.bpf.c — security-audit signals for the target PID (#59):
+//
+//   - runtime executable mappings: tracepoint sys_enter_mmap / sys_enter_mprotect
+//     where prot includes PROT_EXEC (code mapped executable after start —
+//     dlopen, JIT, or RWX injection), with the originating user call site.
+//   - LSM decisions (best-effort): tracepoint avc/selinux_audited — SELinux
+//     denials. Attached non-fatally; absent on non-SELinux kernels (the issue
+//     allows graceful degradation).
+//
+// All three run in the target's PROCESS context, so the shared ns-aware
+// pid_is_target() filter applies (like memory.bpf.c) — no global-pid handling.
+//
+// Maps:
+//   sec_target_pid  ARRAY[1]      struct target_filter (written by the Go loader)
+//   sec_events      RINGBUF       per-event channel → user-space
+//   sec_stacks      STACK_TRACE   user stacks captured at the mapping call site
+
+#include <linux/bpf.h>
+#include <bpf/bpf_helpers.h>
+#include "target.bpf.h"
+
+char LICENSE[] SEC("license") = "GPL";
+
+#define KIND_EXEC_MAP 0
+#define KIND_LSM      1
+
+#define OP_MMAP     0
+#define OP_MPROTECT 1
+
+#define PROT_EXEC      0x4
+#define MAP_ANONYMOUS  0x20
+
+#define SEC_STACK_DEPTH 32
+
+// sys_enter_mmap: addr, len, prot, flags, fd, off (each a long after the
+// 8-byte common header + the 8-byte __syscall_nr slot). Stable layout.
+struct sys_enter_mmap_args {
+    unsigned long long _pad;
+    long id;
+    unsigned long addr;
+    unsigned long len;
+    unsigned long prot;
+    unsigned long flags;
+    unsigned long fd;
+    unsigned long off;
+};
+
+// sys_enter_mprotect: addr, len, prot.
+struct sys_enter_mprotect_args {
+    unsigned long long _pad;
+    long id;
+    unsigned long addr;
+    unsigned long len;
+    unsigned long prot;
+};
+
+// avc/selinux_audited (SELinux): requested/denied/audited perm masks + result,
+// then __data_loc context strings (not read — see the collector). Numeric
+// fields are the first after the common header and are reliable; the contexts +
+// perm-name decoding are deferred (need per-class tables / a SELinux test host).
+struct selinux_audited_args {
+    unsigned long long _pad;
+    __u32 requested;
+    __u32 denied;
+    __u32 audited;
+    int result;
+};
+
+// sec_event is published via the sec_events ring buffer. Fixed 56-byte layout
+// (multiple of 8 → Go-packed size == C sizeof) — keep in sync with SecurityRecord
+// in internal/bpf/security.go.
+struct sec_event {
+    __u64 ts_ns;
+    __u64 addr;          // exec-map mapping address; 0 for lsm
+    __u64 len;           // exec-map mapping length; 0 for lsm
+    __u32 kind;          // KIND_EXEC_MAP | KIND_LSM
+    __u32 op;            // OP_MMAP | OP_MPROTECT (exec-map); 0 for lsm
+    __u32 prot;          // PROT_* bitmask (exec-map); 0 for lsm
+    __u32 flags;         // mmap flags (exec-map mmap only); 0 otherwise
+    __u32 lsm_requested; // lsm: requested perm mask
+    __u32 lsm_denied;    // lsm: denied perm mask
+    __u32 lsm_audited;   // lsm: audited perm mask
+    __s32 stack_id;      // exec-map user stack (<0 unknown); -1 for lsm
+};
+
+struct {
+    __uint(type, BPF_MAP_TYPE_ARRAY);
+    __type(key, __u32);
+    __type(value, struct target_filter);
+    __uint(max_entries, 1);
+} sec_target_pid SEC(".maps");
+
+struct {
+    __uint(type, BPF_MAP_TYPE_RINGBUF);
+    __uint(max_entries, 1 << 18); // 256KB — these events are low-rate
+} sec_events SEC(".maps");
+
+struct {
+    __uint(type, BPF_MAP_TYPE_STACK_TRACE);
+    __uint(key_size, sizeof(__u32));
+    __uint(value_size, SEC_STACK_DEPTH * sizeof(__u64));
+    __uint(max_entries, 4096);
+} sec_stacks SEC(".maps");
+
+static __always_inline int is_sec_target(void)
+{
+    return pid_is_target(&sec_target_pid);
+}
+
+// emit_exec_map publishes a PROT_EXEC mapping event, capturing the user call
+// stack from ctx. ctx is void* so both tracepoint handlers can share it.
+static __always_inline void emit_exec_map(void *ctx, __u32 op, __u64 addr,
+                                          __u64 len, __u32 prot, __u32 flags)
+{
+    struct sec_event *e = bpf_ringbuf_reserve(&sec_events, sizeof(*e), 0);
+    if (!e)
+        return;
+    __builtin_memset(e, 0, sizeof(*e));
+    e->ts_ns = bpf_ktime_get_ns();
+    e->kind = KIND_EXEC_MAP;
+    e->op = op;
+    e->addr = addr;
+    e->len = len;
+    e->prot = prot;
+    e->flags = flags;
+    e->stack_id = bpf_get_stackid(ctx, &sec_stacks, BPF_F_USER_STACK);
+    bpf_ringbuf_submit(e, 0);
+}
+
+SEC("tracepoint/syscalls/sys_enter_mmap")
+int tp_sys_enter_mmap(struct sys_enter_mmap_args *ctx)
+{
+    if (!is_sec_target())
+        return 0;
+    if (!(ctx->prot & PROT_EXEC))
+        return 0;
+    emit_exec_map(ctx, OP_MMAP, ctx->addr, ctx->len,
+                  (__u32)ctx->prot, (__u32)ctx->flags);
+    return 0;
+}
+
+SEC("tracepoint/syscalls/sys_enter_mprotect")
+int tp_sys_enter_mprotect(struct sys_enter_mprotect_args *ctx)
+{
+    if (!is_sec_target())
+        return 0;
+    if (!(ctx->prot & PROT_EXEC))
+        return 0;
+    // mprotect changes an existing mapping; we can't tell anon from the args,
+    // so flags=0 (the collector reports anon only for mmap).
+    emit_exec_map(ctx, OP_MPROTECT, ctx->addr, ctx->len, (__u32)ctx->prot, 0);
+    return 0;
+}
+
+SEC("tracepoint/avc/selinux_audited")
+int tp_selinux_audited(struct selinux_audited_args *ctx)
+{
+    if (!is_sec_target())
+        return 0;
+    struct sec_event *e = bpf_ringbuf_reserve(&sec_events, sizeof(*e), 0);
+    if (!e)
+        return 0;
+    __builtin_memset(e, 0, sizeof(*e));
+    e->ts_ns = bpf_ktime_get_ns();
+    e->kind = KIND_LSM;
+    e->lsm_requested = ctx->requested;
+    e->lsm_denied = ctx->denied;
+    e->lsm_audited = ctx->audited;
+    e->stack_id = -1;
+    bpf_ringbuf_submit(e, 0);
+    return 0;
+}

--- a/internal/bpf/security.go
+++ b/internal/bpf/security.go
@@ -1,0 +1,193 @@
+//go:build linux && ebpf
+
+package bpf
+
+import (
+	"bytes"
+	_ "embed"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"io"
+
+	"github.com/cilium/ebpf"
+	"github.com/cilium/ebpf/link"
+	"github.com/cilium/ebpf/ringbuf"
+	"github.com/cilium/ebpf/rlimit"
+)
+
+//go:embed programs/security.bpf.o
+var securityBPFObj []byte
+
+// secStackDepth mirrors SEC_STACK_DEPTH in programs/security.bpf.c.
+const secStackDepth = 32
+
+// secRecordSize is the on-wire size of struct sec_event (56 bytes — a multiple
+// of 8, so this matches C's sizeof and the Go packed layout).
+const secRecordSize = 56
+
+// SecurityRecord is the 1:1 layout of struct sec_event in
+// programs/security.bpf.c. binary.LittleEndian parses it from the ring buffer.
+type SecurityRecord struct {
+	TsNs         uint64
+	Addr         uint64
+	Len          uint64
+	Kind         uint32
+	Op           uint32
+	Prot         uint32
+	Flags        uint32
+	LsmRequested uint32
+	LsmDenied    uint32
+	LsmAudited   uint32
+	StackID      int32
+}
+
+// SecurityTracer loads security.bpf.o, attaches the mmap/mprotect (PROT_EXEC)
+// and SELinux AVC tracepoints filtered to the target, and exposes Next() +
+// ResolveStack() for the exec-map call site.
+type SecurityTracer struct {
+	coll      *ebpf.Collection
+	links     []link.Link
+	rb        *ringbuf.Reader
+	stacksMap *ebpf.Map
+}
+
+func OpenSecurityTracer(pid int) (*SecurityTracer, error) {
+	if pid <= 0 {
+		return nil, errors.New("invalid pid")
+	}
+	if err := rlimit.RemoveMemlock(); err != nil {
+		return nil, fmt.Errorf("rlimit: %w", err)
+	}
+
+	spec, err := ebpf.LoadCollectionSpecFromReader(bytes.NewReader(securityBPFObj))
+	if err != nil {
+		return nil, fmt.Errorf("parse security BPF object: %w", err)
+	}
+	coll, err := ebpf.NewCollection(spec)
+	if err != nil {
+		return nil, fmt.Errorf("load security collection: %w", err)
+	}
+	t := &SecurityTracer{coll: coll}
+
+	tfMap := coll.Maps["sec_target_pid"]
+	if tfMap == nil {
+		t.Close()
+		return nil, errors.New("sec_target_pid map missing")
+	}
+	tf, err := resolveTarget(pid)
+	if err != nil {
+		t.Close()
+		return nil, err
+	}
+	if err := writeTargetFilter(tfMap, tf); err != nil {
+		t.Close()
+		return nil, fmt.Errorf("set sec_target_pid: %w", err)
+	}
+
+	// exec-map probes are the core; attach both, fail only if NEITHER attaches.
+	attach := func(group, name, prog string) bool {
+		p := coll.Programs[prog]
+		if p == nil {
+			return false
+		}
+		l, err := link.Tracepoint(group, name, p, nil)
+		if err != nil {
+			return false
+		}
+		t.links = append(t.links, l)
+		return true
+	}
+	okMmap := attach("syscalls", "sys_enter_mmap", "tp_sys_enter_mmap")
+	okMprot := attach("syscalls", "sys_enter_mprotect", "tp_sys_enter_mprotect")
+	if !okMmap && !okMprot {
+		t.Close()
+		return nil, errors.New("attach mmap/mprotect tracepoints: neither attached")
+	}
+	// LSM (SELinux AVC) is best-effort: absent on non-SELinux kernels.
+	attach("avc", "selinux_audited", "tp_selinux_audited")
+
+	t.stacksMap = coll.Maps["sec_stacks"]
+	if t.stacksMap == nil {
+		t.Close()
+		return nil, errors.New("sec_stacks map missing")
+	}
+
+	evMap := coll.Maps["sec_events"]
+	if evMap == nil {
+		t.Close()
+		return nil, errors.New("sec_events ringbuf missing")
+	}
+	rb, err := ringbuf.NewReader(evMap)
+	if err != nil {
+		t.Close()
+		return nil, fmt.Errorf("security ringbuf reader: %w", err)
+	}
+	t.rb = rb
+
+	return t, nil
+}
+
+// Next blocks until the next security record arrives. Returns io.EOF once the
+// tracer is closed. A short/garbled record is reported as an error but keeps
+// the stream open.
+func (t *SecurityTracer) Next() (SecurityRecord, error) {
+	var rec SecurityRecord
+	if t == nil || t.rb == nil {
+		return rec, errors.New("tracer not initialized")
+	}
+	r, err := t.rb.Read()
+	if err != nil {
+		if errors.Is(err, ringbuf.ErrClosed) {
+			return rec, io.EOF
+		}
+		return rec, err
+	}
+	if len(r.RawSample) < secRecordSize {
+		return rec, fmt.Errorf("short security event: %d bytes", len(r.RawSample))
+	}
+	if err := binary.Read(bytes.NewReader(r.RawSample), binary.LittleEndian, &rec); err != nil {
+		return rec, fmt.Errorf("decode security event: %w", err)
+	}
+	return rec, nil
+}
+
+// ResolveStack returns the user-stack frames captured for stackID (leaf first),
+// trailing zero slots trimmed. A negative id (capture failed / LSM event) yields
+// nil. Mirrors HeapTracer.ResolveStack.
+func (t *SecurityTracer) ResolveStack(stackID int32) ([]uint64, error) {
+	if stackID < 0 {
+		return nil, nil
+	}
+	if t == nil || t.stacksMap == nil {
+		return nil, errors.New("tracer not initialized")
+	}
+	var frames [secStackDepth]uint64
+	if err := t.stacksMap.Lookup(uint32(stackID), &frames); err != nil {
+		return nil, err
+	}
+	n := len(frames)
+	for n > 0 && frames[n-1] == 0 {
+		n--
+	}
+	return frames[:n], nil
+}
+
+func (t *SecurityTracer) Close() error {
+	if t == nil {
+		return nil
+	}
+	if t.rb != nil {
+		_ = t.rb.Close()
+		t.rb = nil
+	}
+	for _, l := range t.links {
+		_ = l.Close()
+	}
+	t.links = nil
+	if t.coll != nil {
+		t.coll.Close()
+		t.coll = nil
+	}
+	return nil
+}

--- a/internal/bpf/security_stub.go
+++ b/internal/bpf/security_stub.go
@@ -1,0 +1,36 @@
+//go:build !linux || !ebpf
+
+package bpf
+
+import (
+	"errors"
+	"io"
+)
+
+var errSecurityStub = errors.New("eBPF security tracer not available in this build")
+
+// SecurityRecord mirrors the real layout so non-ebpf builds of internal/bpf
+// still compile standalone (matches signal_stub.go and the other tracer stubs).
+type SecurityRecord struct {
+	TsNs         uint64
+	Addr         uint64
+	Len          uint64
+	Kind         uint32
+	Op           uint32
+	Prot         uint32
+	Flags        uint32
+	LsmRequested uint32
+	LsmDenied    uint32
+	LsmAudited   uint32
+	StackID      int32
+}
+
+type SecurityTracer struct{}
+
+func OpenSecurityTracer(int) (*SecurityTracer, error) { return nil, errSecurityStub }
+
+func (*SecurityTracer) Next() (SecurityRecord, error) { return SecurityRecord{}, io.EOF }
+
+func (*SecurityTracer) ResolveStack(int32) ([]uint64, error) { return nil, nil }
+
+func (*SecurityTracer) Close() error { return nil }

--- a/internal/serve/mapper.go
+++ b/internal/serve/mapper.go
@@ -188,6 +188,21 @@ func toEvent(pid int, buildID string, v interface{}) *pb.Event {
 			Comm: x.Comm, Filename: x.Filename,
 		}}
 
+	case collector.SecurityEvent:
+		ev.TsUnixNano = tsNano(x.Timestamp)
+		ev.Category = pb.Category_CATEGORY_SECURITY
+		sec := &pb.SecurityEvent{
+			Kind: x.Kind, Op: x.Op, Addr: x.Addr, Len: x.Len, Prot: x.Prot,
+			WriteExec: x.WriteExec, Anon: x.Anon, Detail: x.Detail,
+		}
+		if x.Kind == "exec-map" {
+			sec.CallSite = &pb.StackFrame{
+				Func: x.Func, File: x.File, Line: int32(x.Line),
+				Module: x.Module, Offset: x.Offset,
+			}
+		}
+		ev.Payload = &pb.Event_Security{Security: sec}
+
 	case collector.TimelineEvent:
 		ev.TsUnixNano = tsNano(x.Timestamp)
 		ev.Category = timelineCategory(x.Category)
@@ -287,6 +302,8 @@ func timelineCategory(s string) pb.Category {
 		return pb.Category_CATEGORY_SIGNAL
 	case "proc":
 		return pb.Category_CATEGORY_PROCESS
+	case "sec":
+		return pb.Category_CATEGORY_SECURITY
 	default:
 		return pb.Category_CATEGORY_TIMELINE
 	}

--- a/internal/tui/help.go
+++ b/internal/tui/help.go
@@ -163,6 +163,15 @@ func renderHelpOverlayWithStatus(m Model, w, h int) string {
 			}
 			return statusRowNA("lifecycle", "needs eBPF (sched fork/exec/exit)")
 		}(),
+		// Security (#59) is eBPF-only and never simulated: "real via eBPF" when
+		// the mmap/mprotect tracepoints attached (LSM is best-effort on top),
+		// else unavailable (macOS, --no-ebpf, or attach failure) — never "mock".
+		func() string {
+			if m.securitySource != "" {
+				return statusRow("security", false, m.securitySource)
+			}
+			return statusRowNA("security", "needs eBPF (PROT_EXEC mmap/mprotect, SELinux AVC)")
+		}(),
 	}
 
 	// Scroll: card has border (2 lines) + padding (2 lines) = 4 overhead;

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -93,6 +93,7 @@ type SignalMsg collector.SignalEvent
 type TLSPayloadMsg collector.TLSPayload
 type ProcContextMsg collector.ProcContext
 type ProcLifecycleMsg collector.ProcLifecycleEvent
+type SecurityMsg collector.SecurityEvent
 type LockGraphMsg []collector.LockEntry
 type LockTimelineMsg collector.TimelineEvent
 
@@ -134,6 +135,7 @@ type Model struct {
 	TLSPayloads    []collector.TLSPayload         // eBPF TLS payloads (#55), newest-first; stream/export-only, no live panel
 	ProcCtx        collector.ProcContext          // /proc namespace/cgroup/identity context (#60); zero value until first sample (or on macOS)
 	ProcEvents     []collector.ProcLifecycleEvent // eBPF exec lineage (#60): fork/exec/exit, newest-first
+	SecurityEvents []collector.SecurityEvent      // eBPF security (#59): exec-maps + LSM denials, newest-first
 	LockGraph      []collector.LockEntry
 
 	// UI state
@@ -197,6 +199,7 @@ type Model struct {
 	tlsSource       string
 	contextSource   string
 	lifecycleSource string
+	securitySource  string
 
 	// Stable caches to avoid visual reordering between ticks.
 	// topSyscallNames is recomputed every `topRefreshInterval`; between refreshes
@@ -253,6 +256,7 @@ func NewModel(cfg Config) Model {
 	m.tlsSource = m.collectors.Sources.TLS
 	m.contextSource = m.collectors.Sources.Context
 	m.lifecycleSource = m.collectors.Sources.Lifecycle
+	m.securitySource = m.collectors.Sources.Security
 
 	m.usingMockFDs = m.collectors.MockFDs()
 	m.usingMockCPU = m.collectors.MockCPU()
@@ -335,6 +339,9 @@ func (m Model) Init() tea.Cmd {
 	}
 	if m.collectors.ProcLifecycleEBPF != nil {
 		cmds = append(cmds, waitForProcLifecycleEBPF(m.collectors.ProcLifecycleEBPF))
+	}
+	if m.collectors.SecurityEBPF != nil {
+		cmds = append(cmds, waitForSecurityEBPF(m.collectors.SecurityEBPF))
 	}
 	if m.exportFile != nil {
 		cmds = append(cmds, exportTick())
@@ -535,6 +542,26 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.Timeline = m.Timeline[:120]
 		}
 		return m, waitForProcLifecycleEBPF(m.collectors.ProcLifecycleEBPF)
+
+	case SecurityMsg:
+		// Real security event (#59) — a runtime PROT_EXEC mapping or an LSM
+		// denial. Record it (newest-first, capped, for export) and surface it in
+		// the unified timeline under the "sec" category (F7). Only the real eBPF
+		// collector emits these.
+		sev := collector.SecurityEvent(v)
+		m.SecurityEvents = append([]collector.SecurityEvent{sev}, m.SecurityEvents...)
+		if len(m.SecurityEvents) > 40 {
+			m.SecurityEvents = m.SecurityEvents[:40]
+		}
+		m.Timeline = append([]collector.TimelineEvent{{
+			Timestamp: sev.Timestamp,
+			Category:  "sec",
+			Message:   securityMessage(sev),
+		}}, m.Timeline...)
+		if len(m.Timeline) > 120 {
+			m.Timeline = m.Timeline[:120]
+		}
+		return m, waitForSecurityEBPF(m.collectors.SecurityEBPF)
 
 	case LockGraphMsg:
 		m.LockGraph = []collector.LockEntry(v)
@@ -1301,6 +1328,22 @@ func waitForProcLifecycleEBPF(c *collector.ProcLifecycleEBPFCollector) tea.Cmd {
 		}
 		if s, ok := (<-ch).(collector.ProcLifecycleEvent); ok {
 			return ProcLifecycleMsg(s)
+		}
+		return TickMsg(time.Now())
+	}
+}
+
+func waitForSecurityEBPF(c *collector.SecurityEBPFCollector) tea.Cmd {
+	if c == nil {
+		return nil
+	}
+	return func() tea.Msg {
+		ch := c.Subscribe()
+		if ch == nil {
+			return TickMsg(time.Now())
+		}
+		if s, ok := (<-ch).(collector.SecurityEvent); ok {
+			return SecurityMsg(s)
 		}
 		return TickMsg(time.Now())
 	}

--- a/internal/tui/snapshot.go
+++ b/internal/tui/snapshot.go
@@ -46,6 +46,7 @@ type SnapshotData struct {
 	TLSPayloads    []collector.TLSPayload         `json:"tls_payloads,omitempty"`
 	ProcContext    collector.ProcContext          `json:"proc_context"`
 	ProcEvents     []collector.ProcLifecycleEvent `json:"proc_lifecycle"`
+	SecurityEvents []collector.SecurityEvent      `json:"security_events"`
 }
 
 // buildSnapshot extracts a Snapshot from the current model state.
@@ -76,6 +77,7 @@ func buildSnapshot(m Model) Snapshot {
 			TLSPayloads:    append([]collector.TLSPayload(nil), m.TLSPayloads...),
 			ProcContext:    m.ProcCtx,
 			ProcEvents:     append([]collector.ProcLifecycleEvent(nil), m.ProcEvents...),
+			SecurityEvents: append([]collector.SecurityEvent(nil), m.SecurityEvents...),
 		},
 	}
 }

--- a/internal/tui/styles.go
+++ b/internal/tui/styles.go
@@ -112,6 +112,8 @@ func CategoryColor(cat string) lipgloss.Color {
 		return ColorPink
 	case "proc":
 		return ColorBright
+	case "sec":
+		return ColorRed
 	default:
 		return ColorMuted
 	}
@@ -138,6 +140,8 @@ func CategoryLabel(cat string) string {
 		return "SIG"
 	case "proc":
 		return "PRC"
+	case "sec":
+		return "SEC"
 	default:
 		return "???"
 	}

--- a/internal/tui/view_timeline.go
+++ b/internal/tui/view_timeline.go
@@ -44,6 +44,60 @@ func procLifecycleMessage(e collector.ProcLifecycleEvent) string {
 	}
 }
 
+// securityMessage renders a SecurityEvent as a one-line entry for the F7
+// timeline. exec-map → "mmap rwx anon @0x… (func)" with W^X/anon called out;
+// lsm-decision → the detail summary.
+func securityMessage(e collector.SecurityEvent) string {
+	if e.Kind == "lsm-decision" {
+		return "lsm: " + e.Detail
+	}
+	tags := ""
+	if e.WriteExec {
+		tags += " W^X"
+	}
+	if e.Anon {
+		tags += " anon"
+	}
+	site := securityCallSiteLabel(e)
+	if site != "" {
+		site = " " + site
+	}
+	return fmt.Sprintf("%s %s%s @0x%x%s", e.Op, protBits(e.Prot), tags, e.Addr, site)
+}
+
+// securityCallSiteLabel renders the symbolized originating call site, preferring
+// "func (file:line)" → "func" → "module+0xoffset" → the raw hex / "unknown".
+func securityCallSiteLabel(e collector.SecurityEvent) string {
+	switch {
+	case e.Func != "" && e.File != "":
+		return fmt.Sprintf("%s (%s:%d)", e.Func, e.File, e.Line)
+	case e.Func != "":
+		return e.Func
+	case e.Module != "":
+		return fmt.Sprintf("%s+0x%x", e.Module, e.Offset)
+	case e.AddrHex != "":
+		return e.AddrHex
+	default:
+		return ""
+	}
+}
+
+// protBits renders a PROT_* bitmask as rwx (mirrors the collector's protString,
+// kept here so the TUI doesn't reach into the collector's unexported helper).
+func protBits(prot uint32) string {
+	b := []byte("---")
+	if prot&0x1 != 0 {
+		b[0] = 'r'
+	}
+	if prot&0x2 != 0 {
+		b[1] = 'w'
+	}
+	if prot&0x4 != 0 {
+		b[2] = 'x'
+	}
+	return string(b)
+}
+
 // renderTimelineView (F7) — assets/mockup.jsx → TimelineView
 // Stream completo de eventos com badge por categoria.
 func renderTimelineView(m Model, w, h int) string {

--- a/pkg/collector/security_decode.go
+++ b/pkg/collector/security_decode.go
@@ -1,0 +1,102 @@
+package collector
+
+import (
+	"fmt"
+	"strings"
+	"time"
+)
+
+// Decoder for the security collector (#59). Build-tag-free so it compiles and is
+// unit-tested on any OS (the fs_decode.go / signal_decode.go idiom). Constants
+// mirror programs/security.bpf.c.
+const (
+	secKindExecMap = 0
+	secKindLSM     = 1
+
+	secOpMmap     = 0
+	secOpMprotect = 1
+
+	protRead  = 0x1
+	protWrite = 0x2
+	protExec  = 0x4
+
+	mapAnonymous = 0x20
+)
+
+// protString renders a PROT_* bitmask as rwx, with '-' for absent bits.
+func protString(prot uint32) string {
+	b := []byte("---")
+	if prot&protRead != 0 {
+		b[0] = 'r'
+	}
+	if prot&protWrite != 0 {
+		b[1] = 'w'
+	}
+	if prot&protExec != 0 {
+		b[2] = 'x'
+	}
+	return string(b)
+}
+
+// decodeSecurityExecMap builds the structural part of an exec-map SecurityEvent
+// (the symbolized call site is filled in by the collector). ts is the wall-clock
+// capture time (the kernel ts_ns is monotonic, not wall-clock).
+func decodeSecurityExecMap(ts time.Time, op, prot, flags uint32, addr, length uint64) SecurityEvent {
+	e := SecurityEvent{
+		Timestamp: ts,
+		Kind:      "exec-map",
+		Addr:      addr,
+		Len:       length,
+		Prot:      prot,
+		WriteExec: prot&protWrite != 0, // exec-map is only emitted with PROT_EXEC set
+		Anon:      flags&mapAnonymous != 0,
+	}
+	switch op {
+	case secOpMmap:
+		e.Op = "mmap"
+	case secOpMprotect:
+		e.Op = "mprotect"
+	default:
+		e.Op = fmt.Sprintf("op%d", op)
+	}
+	return e
+}
+
+// decodeSecurityLSM builds an lsm-decision SecurityEvent from the SELinux AVC
+// perm masks. Perm-name and class/context decoding are deferred (need the SELinux
+// per-class tables), so the detail reports the raw masks — enough to flag that a
+// denial occurred and which permission bits.
+func decodeSecurityLSM(ts time.Time, requested, denied, audited uint32) SecurityEvent {
+	return SecurityEvent{
+		Timestamp: ts,
+		Kind:      "lsm-decision",
+		Detail: fmt.Sprintf("selinux denied=0x%x requested=0x%x audited=0x%x",
+			denied, requested, audited),
+	}
+}
+
+// isLoaderModule reports whether a module basename is the dynamic loader or libc
+// — frames to skip when walking a stack toward the application call site that
+// triggered the mapping (the leaf is libc's mmap/mprotect wrapper). An empty
+// module is NOT a loader: it's an unresolved address, often the JIT/anonymous
+// executable region itself, which is exactly what we want to surface.
+func isLoaderModule(mod string) bool {
+	if i := strings.LastIndexByte(mod, '/'); i >= 0 {
+		mod = mod[i+1:]
+	}
+	for _, p := range []string{"libc", "ld-", "ld.so", "ld-linux", "libpthread", "libdl"} {
+		if strings.HasPrefix(mod, p) {
+			return true
+		}
+	}
+	return false
+}
+
+// securityAddrHex formats a call-site address; 0 means the stack walk failed and
+// renders as "unknown" (same convention as heapAddrHex).
+func securityAddrHex(addr uint64) string {
+	if addr == 0 {
+		return "unknown"
+	}
+	return fmt.Sprintf("0x%x", addr)
+}

--- a/pkg/collector/security_decode_test.go
+++ b/pkg/collector/security_decode_test.go
@@ -1,0 +1,72 @@
+package collector
+
+import (
+	"testing"
+	"time"
+)
+
+func TestProtString(t *testing.T) {
+	cases := map[uint32]string{
+		0:                               "---",
+		protRead:                        "r--",
+		protRead | protExec:             "r-x",
+		protWrite | protExec:            "-wx",
+		protRead | protWrite | protExec: "rwx",
+		protExec:                        "--x",
+	}
+	for prot, want := range cases {
+		if got := protString(prot); got != want {
+			t.Errorf("protString(0x%x) = %q, want %q", prot, got, want)
+		}
+	}
+}
+
+func TestDecodeSecurityExecMap(t *testing.T) {
+	ts := time.Now()
+
+	// mmap RWX anonymous — the high-signal injection shape.
+	e := decodeSecurityExecMap(ts, secOpMmap, protRead|protWrite|protExec, mapAnonymous, 0x7f00, 4096)
+	if e.Kind != "exec-map" || e.Op != "mmap" {
+		t.Errorf("kind/op = %q/%q", e.Kind, e.Op)
+	}
+	if !e.WriteExec {
+		t.Error("WriteExec should be true for RWX")
+	}
+	if !e.Anon {
+		t.Error("Anon should be true for MAP_ANONYMOUS")
+	}
+	if e.Addr != 0x7f00 || e.Len != 4096 {
+		t.Errorf("addr/len = 0x%x/%d", e.Addr, e.Len)
+	}
+
+	// mprotect r-x (the JIT finalize step): exec, not writable, flags=0 → not anon.
+	e = decodeSecurityExecMap(ts, secOpMprotect, protRead|protExec, 0, 0x8000, 8192)
+	if e.Op != "mprotect" {
+		t.Errorf("op = %q, want mprotect", e.Op)
+	}
+	if e.WriteExec {
+		t.Error("WriteExec should be false for r-x")
+	}
+	if e.Anon {
+		t.Error("Anon should be false when flags=0 (mprotect)")
+	}
+}
+
+func TestDecodeSecurityLSM(t *testing.T) {
+	e := decodeSecurityLSM(time.Now(), 0x2, 0x8, 0x8)
+	if e.Kind != "lsm-decision" {
+		t.Errorf("kind = %q", e.Kind)
+	}
+	if e.Detail != "selinux denied=0x8 requested=0x2 audited=0x8" {
+		t.Errorf("detail = %q", e.Detail)
+	}
+}
+
+func TestSecurityAddrHex(t *testing.T) {
+	if got := securityAddrHex(0); got != "unknown" {
+		t.Errorf("securityAddrHex(0) = %q, want unknown", got)
+	}
+	if got := securityAddrHex(0x55e3f2a1b4c0); got != "0x55e3f2a1b4c0" {
+		t.Errorf("securityAddrHex = %q", got)
+	}
+}

--- a/pkg/collector/security_ebpf.go
+++ b/pkg/collector/security_ebpf.go
@@ -1,0 +1,157 @@
+//go:build linux && ebpf
+
+package collector
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"sync"
+	"time"
+
+	"github.com/trentas/ptop/internal/bpf"
+	"github.com/trentas/ptop/pkg/symbol"
+)
+
+// SecurityEBPFCollector consumes the eBPF security ring buffer (#59) and
+// publishes one SecurityEvent per runtime PROT_EXEC mapping (mmap/mprotect) or
+// SELinux AVC denial observed for the target. For exec-map events it resolves
+// the originating application call site inline (events are low-rate, so no lazy
+// ResolveStack RPC is needed). eBPF-only — no /proc fallback, never simulated.
+type SecurityEBPFCollector struct {
+	tracer *bpf.SecurityTracer
+	sym    *symbol.Symbolizer // nil if /proc maps couldn't be parsed
+	ch     chan interface{}
+	stop   chan struct{}
+
+	mu        sync.Mutex
+	siteCache map[int32]secSite // stack_id → resolved app call site
+}
+
+// secSite is the resolved application call site for a stack_id: the raw frame
+// address plus its symbolization. Cached (stacks are stable per process life).
+type secSite struct {
+	addr  uint64
+	frame symbol.Frame
+}
+
+func NewSecurityEBPFCollector() *SecurityEBPFCollector {
+	return &SecurityEBPFCollector{
+		ch:        make(chan interface{}, 64),
+		stop:      make(chan struct{}),
+		siteCache: make(map[int32]secSite),
+	}
+}
+
+func (c *SecurityEBPFCollector) Start(pid int) error {
+	tracer, err := bpf.OpenSecurityTracer(pid)
+	if err != nil {
+		return fmt.Errorf("security eBPF: %w", err)
+	}
+	c.tracer = tracer
+	// Symbolize call sites best-effort: without /proc maps the sites degrade to
+	// hex — never fail Start over it (same as the heap collector).
+	if sym, err := symbol.NewSymbolizer(pid); err == nil {
+		c.sym = sym
+	} else {
+		fmt.Fprintf(os.Stderr, "security: call-site symbolization unavailable for pid %d: %v\n", pid, err)
+	}
+	go c.readLoop(tracer)
+	return nil
+}
+
+func (c *SecurityEBPFCollector) Stop() {
+	close(c.stop)
+	if c.tracer != nil {
+		_ = c.tracer.Close()
+		c.tracer = nil
+	}
+}
+
+func (c *SecurityEBPFCollector) Subscribe() <-chan interface{} { return c.ch }
+
+// readLoop drains the security ring buffer, decoding each record and (for
+// exec-map) resolving its call site, then publishing non-blocking. Exits on
+// io.EOF (tracer closed); a garbled record is skipped, keeping the stream alive.
+func (c *SecurityEBPFCollector) readLoop(tracer *bpf.SecurityTracer) {
+	if tracer == nil {
+		return
+	}
+	for {
+		rec, err := tracer.Next()
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				return
+			}
+			continue
+		}
+		ev := c.decode(time.Now(), rec)
+		select {
+		case c.ch <- ev:
+		default:
+		}
+	}
+}
+
+// decode turns a raw record into a SecurityEvent, resolving the exec-map call
+// site inline.
+func (c *SecurityEBPFCollector) decode(ts time.Time, rec bpf.SecurityRecord) SecurityEvent {
+	if rec.Kind == secKindLSM {
+		return decodeSecurityLSM(ts, rec.LsmRequested, rec.LsmDenied, rec.LsmAudited)
+	}
+	ev := decodeSecurityExecMap(ts, rec.Op, rec.Prot, rec.Flags, rec.Addr, rec.Len)
+	addr, frame := c.resolveSite(rec.StackID)
+	ev.CallSite = addr
+	ev.AddrHex = securityAddrHex(addr)
+	ev.Func = frame.Func
+	ev.File = frame.File
+	ev.Line = frame.Line
+	ev.Module = frame.Module
+	ev.Offset = frame.Offset
+	return ev
+}
+
+// resolveSite maps a stack_id to the application call site that triggered the
+// mapping — the first frame outside libc/ld (the leaf is the libc mmap wrapper).
+// Cached under c.mu. Returns (0, zero) when the stack walk failed.
+func (c *SecurityEBPFCollector) resolveSite(stackID int32) (uint64, symbol.Frame) {
+	if stackID < 0 || c.tracer == nil {
+		return 0, symbol.Frame{}
+	}
+	c.mu.Lock()
+	if s, ok := c.siteCache[stackID]; ok {
+		c.mu.Unlock()
+		return s.addr, s.frame
+	}
+	c.mu.Unlock()
+
+	frames, err := c.tracer.ResolveStack(stackID)
+	if err != nil || len(frames) == 0 {
+		return 0, symbol.Frame{}
+	}
+
+	var site secSite
+	if c.sym != nil {
+		for _, f := range frames {
+			if f == 0 {
+				continue
+			}
+			fr := c.sym.Symbolize(f)
+			if !isLoaderModule(fr.Module) {
+				site = secSite{addr: f, frame: fr}
+				break
+			}
+		}
+		if site.addr == 0 { // every frame was loader/libc — fall back to the leaf
+			site = secSite{addr: frames[0], frame: c.sym.Symbolize(frames[0])}
+		}
+	} else {
+		site = secSite{addr: frames[0]}
+	}
+
+	c.mu.Lock()
+	c.siteCache[stackID] = site
+	c.mu.Unlock()
+	return site.addr, site.frame
+}

--- a/pkg/collector/security_ebpf_stub.go
+++ b/pkg/collector/security_ebpf_stub.go
@@ -1,0 +1,21 @@
+//go:build !linux || !ebpf
+
+package collector
+
+import "errors"
+
+// Stub: builds without -tags=ebpf or on non-Linux hosts get this
+// SecurityEBPFCollector that always fails Start. Security events are eBPF-only
+// (no /proc fallback, never simulated), so the consumer simply has no data.
+
+type SecurityEBPFCollector struct{}
+
+func NewSecurityEBPFCollector() *SecurityEBPFCollector { return &SecurityEBPFCollector{} }
+
+func (*SecurityEBPFCollector) Start(pid int) error {
+	return errors.New("eBPF security collector not available in this build")
+}
+
+func (*SecurityEBPFCollector) Stop() {}
+
+func (*SecurityEBPFCollector) Subscribe() <-chan interface{} { return nil }

--- a/pkg/collector/set.go
+++ b/pkg/collector/set.go
@@ -36,6 +36,7 @@ type Sources struct {
 	TLS       string
 	Context   string
 	Lifecycle string
+	Security  string
 }
 
 // Set owns the live collectors for a single target PID, chosen by the
@@ -61,6 +62,7 @@ type Set struct {
 	TLSEBPF           *TLSEBPFCollector
 	ProcContext       *ProcContextCollector
 	ProcLifecycleEBPF *ProcLifecycleEBPFCollector
+	SecurityEBPF      *SecurityEBPFCollector
 
 	Sources Sources
 }
@@ -219,6 +221,16 @@ func NewSet(cfg SetConfig) *Set {
 			warnEBPFFailure("lifecycle", err)
 		}
 
+		// Security: runtime PROT_EXEC mappings + best-effort SELinux LSM
+		// denials (#59). eBPF-only — no /proc fallback, never simulated.
+		c9 := NewSecurityEBPFCollector()
+		if err := c9.Start(cfg.PID); err == nil {
+			s.SecurityEBPF = c9
+			s.Sources.Security = "eBPF"
+		} else {
+			warnEBPFFailure("security", err)
+		}
+
 		// TLS payload capture (#55) — OFF unless explicitly opted in (--tls),
 		// because it observes plaintext. eBPF-only (libssl uprobes), no /proc
 		// fallback, never simulated.
@@ -298,6 +310,9 @@ func (s *Set) Stop() {
 	if s.ProcLifecycleEBPF != nil {
 		s.ProcLifecycleEBPF.Stop()
 	}
+	if s.SecurityEBPF != nil {
+		s.SecurityEBPF.Stop()
+	}
 }
 
 // Collectors returns every started collector as a Collector. Used by consumers
@@ -332,6 +347,7 @@ func (s *Set) Collectors() []Collector {
 	add(s.TLSEBPF, s.TLSEBPF != nil)
 	add(s.ProcContext, s.ProcContext != nil)
 	add(s.ProcLifecycleEBPF, s.ProcLifecycleEBPF != nil)
+	add(s.SecurityEBPF, s.SecurityEBPF != nil)
 	return cs
 }
 

--- a/pkg/collector/types.go
+++ b/pkg/collector/types.go
@@ -319,6 +319,41 @@ type ProcLifecycleEvent struct {
 	Filename  string // executed path (exec only; "" otherwise)
 }
 
+// ─── Security (#59) ──────────────────────────────────────────────────────────
+
+// SecurityEvent surfaces a kernel security-relevant action on the target. Kind
+// is "exec-map" (a runtime mmap/mprotect that set PROT_EXEC — code mapped
+// executable after start: dlopen, JIT, or RWX injection) or "lsm-decision" (a
+// SELinux AVC denial, best-effort; absent where the hook isn't exposed).
+//
+// For exec-map: Op is "mmap"|"mprotect"; Addr/Len/Prot describe the mapping
+// (Prot is the PROT_* bitmask); WriteExec flags simultaneous write+exec (W^X)
+// and Anon a non-file-backed mapping (mmap only) — the higher-signal cases. The
+// Func/File/Line/Module/Offset/AddrHex fields are the symbolized originating
+// application call site (#54; Func "" and Offset = raw address when unresolved,
+// AddrHex "unknown" when the stack walk failed). For lsm-decision: Detail
+// carries the human summary and the mapping/call-site fields are zero. Emitted
+// only by the eBPF security collector (never simulated).
+type SecurityEvent struct {
+	Timestamp time.Time
+	Kind      string // "exec-map" | "lsm-decision"
+	Op        string // "mmap" | "mprotect" (exec-map); "" for lsm
+	Addr      uint64
+	Len       uint64
+	Prot      uint32
+	WriteExec bool
+	Anon      bool
+	Detail    string
+	// Symbolized originating call site (exec-map only):
+	CallSite uint64
+	Func     string
+	File     string
+	Line     int
+	Module   string
+	Offset   uint64
+	AddrHex  string
+}
+
 // ─── Timeline ────────────────────────────────────────────────────────────────
 
 type TimelineEvent struct {

--- a/pkg/streampb/event.pb.go
+++ b/pkg/streampb/event.pb.go
@@ -38,6 +38,7 @@ const (
 	Category_CATEGORY_TIMELINE    Category = 9
 	Category_CATEGORY_SIGNAL      Category = 10 // #58 — signals delivered to the target
 	Category_CATEGORY_PROCESS     Category = 11 // #60 — execution context + exec lineage
+	Category_CATEGORY_SECURITY    Category = 12 // #59 — LSM decisions + runtime executable mappings
 )
 
 // Enum value maps for Category.
@@ -55,6 +56,7 @@ var (
 		9:  "CATEGORY_TIMELINE",
 		10: "CATEGORY_SIGNAL",
 		11: "CATEGORY_PROCESS",
+		12: "CATEGORY_SECURITY",
 	}
 	Category_value = map[string]int32{
 		"CATEGORY_UNSPECIFIED": 0,
@@ -69,6 +71,7 @@ var (
 		"CATEGORY_TIMELINE":    9,
 		"CATEGORY_SIGNAL":      10,
 		"CATEGORY_PROCESS":     11,
+		"CATEGORY_SECURITY":    12,
 	}
 )
 
@@ -292,6 +295,7 @@ type Event struct {
 	//	*Event_Tls
 	//	*Event_ProcContext
 	//	*Event_ProcLifecycle
+	//	*Event_Security
 	Payload       isEvent_Payload `protobuf_oneof:"payload"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
@@ -570,6 +574,15 @@ func (x *Event) GetProcLifecycle() *ProcLifecycleEvent {
 	return nil
 }
 
+func (x *Event) GetSecurity() *SecurityEvent {
+	if x != nil {
+		if x, ok := x.Payload.(*Event_Security); ok {
+			return x.Security
+		}
+	}
+	return nil
+}
+
 type isEvent_Payload interface {
 	isEvent_Payload()
 }
@@ -655,6 +668,10 @@ type Event_ProcLifecycle struct {
 	ProcLifecycle *ProcLifecycleEvent `protobuf:"bytes,29,opt,name=proc_lifecycle,json=procLifecycle,proto3,oneof"` // #60 — exec lineage (fork/exec/exit)
 }
 
+type Event_Security struct {
+	Security *SecurityEvent `protobuf:"bytes,30,opt,name=security,proto3,oneof"` // #59 — LSM decision / runtime executable mapping
+}
+
 func (*Event_Cpu) isEvent_Payload() {}
 
 func (*Event_Syscalls) isEvent_Payload() {}
@@ -694,6 +711,8 @@ func (*Event_Tls) isEvent_Payload() {}
 func (*Event_ProcContext) isEvent_Payload() {}
 
 func (*Event_ProcLifecycle) isEvent_Payload() {}
+
+func (*Event_Security) isEvent_Payload() {}
 
 // ─── CPU ──────────────────────────────────────────────────────────────────
 type CpuSample struct {
@@ -2429,6 +2448,129 @@ func (x *ProcLifecycleEvent) GetFilename() string {
 	return ""
 }
 
+// ─── Security (#59) ──────────────────────────────────────────────────────────
+// SecurityEvent surfaces a kernel security-relevant action on the target. kind
+// is "exec-map" (a runtime mmap/mprotect that set PROT_EXEC — code mapped
+// executable after start: dlopen, JIT, or RWX injection) or "lsm-decision" (a
+// kernel LSM denial, best-effort via the SELinux AVC tracepoint; absent where
+// the hook isn't exposed).
+//
+// For exec-map: op is "mmap"|"mprotect"; addr/len/prot describe the mapping
+// (prot is the PROT_* bitmask); write_exec flags simultaneous write+exec (W^X),
+// anon flags a non-file-backed mapping (mmap only) — the two higher-signal
+// cases. call_site is the symbolized originating application frame (#54; func ""
+// and offset = raw address when unresolved). For lsm-decision: detail carries
+// the human summary (denied perms, class, contexts) and the mmap fields are 0.
+// Category on the envelope is SECURITY; the event time lives on the envelope.
+// eBPF-only — never simulated.
+type SecurityEvent struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Kind          string                 `protobuf:"bytes,1,opt,name=kind,proto3" json:"kind,omitempty"` // "exec-map" | "lsm-decision"
+	Op            string                 `protobuf:"bytes,2,opt,name=op,proto3" json:"op,omitempty"`     // "mmap" | "mprotect" (exec-map); "" for lsm
+	Addr          uint64                 `protobuf:"varint,3,opt,name=addr,proto3" json:"addr,omitempty"`
+	Len           uint64                 `protobuf:"varint,4,opt,name=len,proto3" json:"len,omitempty"`
+	Prot          uint32                 `protobuf:"varint,5,opt,name=prot,proto3" json:"prot,omitempty"`                            // PROT_* bitmask (exec-map)
+	WriteExec     bool                   `protobuf:"varint,6,opt,name=write_exec,json=writeExec,proto3" json:"write_exec,omitempty"` // PROT_WRITE & PROT_EXEC (W^X)
+	Anon          bool                   `protobuf:"varint,7,opt,name=anon,proto3" json:"anon,omitempty"`                            // non-file-backed mapping (mmap only)
+	Detail        string                 `protobuf:"bytes,8,opt,name=detail,proto3" json:"detail,omitempty"`                         // lsm summary, or extra exec-map context
+	CallSite      *StackFrame            `protobuf:"bytes,9,opt,name=call_site,json=callSite,proto3" json:"call_site,omitempty"`     // exec-map originating frame (symbolized, #54)
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *SecurityEvent) Reset() {
+	*x = SecurityEvent{}
+	mi := &file_event_proto_msgTypes[25]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *SecurityEvent) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*SecurityEvent) ProtoMessage() {}
+
+func (x *SecurityEvent) ProtoReflect() protoreflect.Message {
+	mi := &file_event_proto_msgTypes[25]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use SecurityEvent.ProtoReflect.Descriptor instead.
+func (*SecurityEvent) Descriptor() ([]byte, []int) {
+	return file_event_proto_rawDescGZIP(), []int{25}
+}
+
+func (x *SecurityEvent) GetKind() string {
+	if x != nil {
+		return x.Kind
+	}
+	return ""
+}
+
+func (x *SecurityEvent) GetOp() string {
+	if x != nil {
+		return x.Op
+	}
+	return ""
+}
+
+func (x *SecurityEvent) GetAddr() uint64 {
+	if x != nil {
+		return x.Addr
+	}
+	return 0
+}
+
+func (x *SecurityEvent) GetLen() uint64 {
+	if x != nil {
+		return x.Len
+	}
+	return 0
+}
+
+func (x *SecurityEvent) GetProt() uint32 {
+	if x != nil {
+		return x.Prot
+	}
+	return 0
+}
+
+func (x *SecurityEvent) GetWriteExec() bool {
+	if x != nil {
+		return x.WriteExec
+	}
+	return false
+}
+
+func (x *SecurityEvent) GetAnon() bool {
+	if x != nil {
+		return x.Anon
+	}
+	return false
+}
+
+func (x *SecurityEvent) GetDetail() string {
+	if x != nil {
+		return x.Detail
+	}
+	return ""
+}
+
+func (x *SecurityEvent) GetCallSite() *StackFrame {
+	if x != nil {
+		return x.CallSite
+	}
+	return nil
+}
+
 // ─── File descriptors ───────────────────────────────────────────────────────
 type FdEntry struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
@@ -2445,7 +2587,7 @@ type FdEntry struct {
 
 func (x *FdEntry) Reset() {
 	*x = FdEntry{}
-	mi := &file_event_proto_msgTypes[25]
+	mi := &file_event_proto_msgTypes[26]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2457,7 +2599,7 @@ func (x *FdEntry) String() string {
 func (*FdEntry) ProtoMessage() {}
 
 func (x *FdEntry) ProtoReflect() protoreflect.Message {
-	mi := &file_event_proto_msgTypes[25]
+	mi := &file_event_proto_msgTypes[26]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2470,7 +2612,7 @@ func (x *FdEntry) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use FdEntry.ProtoReflect.Descriptor instead.
 func (*FdEntry) Descriptor() ([]byte, []int) {
-	return file_event_proto_rawDescGZIP(), []int{25}
+	return file_event_proto_rawDescGZIP(), []int{26}
 }
 
 func (x *FdEntry) GetFd() int32 {
@@ -2531,7 +2673,7 @@ type FdSnapshot struct {
 
 func (x *FdSnapshot) Reset() {
 	*x = FdSnapshot{}
-	mi := &file_event_proto_msgTypes[26]
+	mi := &file_event_proto_msgTypes[27]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2543,7 +2685,7 @@ func (x *FdSnapshot) String() string {
 func (*FdSnapshot) ProtoMessage() {}
 
 func (x *FdSnapshot) ProtoReflect() protoreflect.Message {
-	mi := &file_event_proto_msgTypes[26]
+	mi := &file_event_proto_msgTypes[27]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2556,7 +2698,7 @@ func (x *FdSnapshot) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use FdSnapshot.ProtoReflect.Descriptor instead.
 func (*FdSnapshot) Descriptor() ([]byte, []int) {
-	return file_event_proto_rawDescGZIP(), []int{26}
+	return file_event_proto_rawDescGZIP(), []int{27}
 }
 
 func (x *FdSnapshot) GetFds() []*FdEntry {
@@ -2577,7 +2719,7 @@ type FdEvent struct {
 
 func (x *FdEvent) Reset() {
 	*x = FdEvent{}
-	mi := &file_event_proto_msgTypes[27]
+	mi := &file_event_proto_msgTypes[28]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2589,7 +2731,7 @@ func (x *FdEvent) String() string {
 func (*FdEvent) ProtoMessage() {}
 
 func (x *FdEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_event_proto_msgTypes[27]
+	mi := &file_event_proto_msgTypes[28]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2602,7 +2744,7 @@ func (x *FdEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use FdEvent.ProtoReflect.Descriptor instead.
 func (*FdEvent) Descriptor() ([]byte, []int) {
-	return file_event_proto_rawDescGZIP(), []int{27}
+	return file_event_proto_rawDescGZIP(), []int{28}
 }
 
 func (x *FdEvent) GetMessage() string {
@@ -2628,7 +2770,7 @@ type LockEntry struct {
 
 func (x *LockEntry) Reset() {
 	*x = LockEntry{}
-	mi := &file_event_proto_msgTypes[28]
+	mi := &file_event_proto_msgTypes[29]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2640,7 +2782,7 @@ func (x *LockEntry) String() string {
 func (*LockEntry) ProtoMessage() {}
 
 func (x *LockEntry) ProtoReflect() protoreflect.Message {
-	mi := &file_event_proto_msgTypes[28]
+	mi := &file_event_proto_msgTypes[29]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2653,7 +2795,7 @@ func (x *LockEntry) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LockEntry.ProtoReflect.Descriptor instead.
 func (*LockEntry) Descriptor() ([]byte, []int) {
-	return file_event_proto_rawDescGZIP(), []int{28}
+	return file_event_proto_rawDescGZIP(), []int{29}
 }
 
 func (x *LockEntry) GetUaddr() uint64 {
@@ -2714,7 +2856,7 @@ type LockSnapshot struct {
 
 func (x *LockSnapshot) Reset() {
 	*x = LockSnapshot{}
-	mi := &file_event_proto_msgTypes[29]
+	mi := &file_event_proto_msgTypes[30]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2726,7 +2868,7 @@ func (x *LockSnapshot) String() string {
 func (*LockSnapshot) ProtoMessage() {}
 
 func (x *LockSnapshot) ProtoReflect() protoreflect.Message {
-	mi := &file_event_proto_msgTypes[29]
+	mi := &file_event_proto_msgTypes[30]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2739,7 +2881,7 @@ func (x *LockSnapshot) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LockSnapshot.ProtoReflect.Descriptor instead.
 func (*LockSnapshot) Descriptor() ([]byte, []int) {
-	return file_event_proto_rawDescGZIP(), []int{29}
+	return file_event_proto_rawDescGZIP(), []int{30}
 }
 
 func (x *LockSnapshot) GetLocks() []*LockEntry {
@@ -2760,7 +2902,7 @@ type TimelineEvent struct {
 
 func (x *TimelineEvent) Reset() {
 	*x = TimelineEvent{}
-	mi := &file_event_proto_msgTypes[30]
+	mi := &file_event_proto_msgTypes[31]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2772,7 +2914,7 @@ func (x *TimelineEvent) String() string {
 func (*TimelineEvent) ProtoMessage() {}
 
 func (x *TimelineEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_event_proto_msgTypes[30]
+	mi := &file_event_proto_msgTypes[31]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2785,7 +2927,7 @@ func (x *TimelineEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TimelineEvent.ProtoReflect.Descriptor instead.
 func (*TimelineEvent) Descriptor() ([]byte, []int) {
-	return file_event_proto_rawDescGZIP(), []int{30}
+	return file_event_proto_rawDescGZIP(), []int{31}
 }
 
 func (x *TimelineEvent) GetMessage() string {
@@ -2810,7 +2952,8 @@ const file_event_proto_rawDesc = "" +
 	"\x04line\x18\x03 \x01(\x05R\x04line\x12\x16\n" +
 	"\x06module\x18\x04 \x01(\tR\x06module\x12\x16\n" +
 	"\x06offset\x18\x05 \x01(\x04R\x06offset\x12\x19\n" +
-	"\bbuild_id\x18\x06 \x01(\tR\abuildId\"\xea\t\n" +
+	"\bbuild_id\x18\x06 \x01(\tR\abuildId\"\xa0\n" +
+	"\n" +
 	"\x05Event\x12 \n" +
 	"\fts_unix_nano\x18\x01 \x01(\x03R\n" +
 	"tsUnixNano\x12\x10\n" +
@@ -2842,7 +2985,8 @@ const file_event_proto_rawDesc = "" +
 	"\x06signal\x18\x1a \x01(\v2\x14.ptop.v1.SignalEventH\x00R\x06signal\x12,\n" +
 	"\x03tls\x18\x1b \x01(\v2\x18.ptop.v1.TLSPayloadEventH\x00R\x03tls\x129\n" +
 	"\fproc_context\x18\x1c \x01(\v2\x14.ptop.v1.ProcContextH\x00R\vprocContext\x12D\n" +
-	"\x0eproc_lifecycle\x18\x1d \x01(\v2\x1b.ptop.v1.ProcLifecycleEventH\x00R\rprocLifecycleB\t\n" +
+	"\x0eproc_lifecycle\x18\x1d \x01(\v2\x1b.ptop.v1.ProcLifecycleEventH\x00R\rprocLifecycle\x124\n" +
+	"\bsecurity\x18\x1e \x01(\v2\x16.ptop.v1.SecurityEventH\x00R\bsecurityB\t\n" +
 	"\apayload\"(\n" +
 	"\tCpuSample\x12\x1b\n" +
 	"\tusage_pct\x18\x01 \x01(\x01R\busagePct\"V\n" +
@@ -2990,7 +3134,18 @@ const file_event_proto_rawDesc = "" +
 	"\x03pid\x18\x02 \x01(\x05R\x03pid\x12\x12\n" +
 	"\x04ppid\x18\x03 \x01(\x05R\x04ppid\x12\x12\n" +
 	"\x04comm\x18\x04 \x01(\tR\x04comm\x12\x1a\n" +
-	"\bfilename\x18\x05 \x01(\tR\bfilename\"\x9c\x01\n" +
+	"\bfilename\x18\x05 \x01(\tR\bfilename\"\xea\x01\n" +
+	"\rSecurityEvent\x12\x12\n" +
+	"\x04kind\x18\x01 \x01(\tR\x04kind\x12\x0e\n" +
+	"\x02op\x18\x02 \x01(\tR\x02op\x12\x12\n" +
+	"\x04addr\x18\x03 \x01(\x04R\x04addr\x12\x10\n" +
+	"\x03len\x18\x04 \x01(\x04R\x03len\x12\x12\n" +
+	"\x04prot\x18\x05 \x01(\rR\x04prot\x12\x1d\n" +
+	"\n" +
+	"write_exec\x18\x06 \x01(\bR\twriteExec\x12\x12\n" +
+	"\x04anon\x18\a \x01(\bR\x04anon\x12\x16\n" +
+	"\x06detail\x18\b \x01(\tR\x06detail\x120\n" +
+	"\tcall_site\x18\t \x01(\v2\x13.ptop.v1.StackFrameR\bcallSite\"\x9c\x01\n" +
 	"\aFdEntry\x12\x0e\n" +
 	"\x02fd\x18\x01 \x01(\x05R\x02fd\x12\x12\n" +
 	"\x04type\x18\x02 \x01(\tR\x04type\x12\x12\n" +
@@ -3017,7 +3172,7 @@ const file_event_proto_rawDesc = "" +
 	"\fLockSnapshot\x12(\n" +
 	"\x05locks\x18\x01 \x03(\v2\x12.ptop.v1.LockEntryR\x05locks\")\n" +
 	"\rTimelineEvent\x12\x18\n" +
-	"\amessage\x18\x01 \x01(\tR\amessage*\x83\x02\n" +
+	"\amessage\x18\x01 \x01(\tR\amessage*\x9a\x02\n" +
 	"\bCategory\x12\x18\n" +
 	"\x14CATEGORY_UNSPECIFIED\x10\x00\x12\x10\n" +
 	"\fCATEGORY_CPU\x10\x01\x12\x14\n" +
@@ -3031,7 +3186,8 @@ const file_event_proto_rawDesc = "" +
 	"\x11CATEGORY_TIMELINE\x10\t\x12\x13\n" +
 	"\x0fCATEGORY_SIGNAL\x10\n" +
 	"\x12\x14\n" +
-	"\x10CATEGORY_PROCESS\x10\vB\x85\x01\n" +
+	"\x10CATEGORY_PROCESS\x10\v\x12\x15\n" +
+	"\x11CATEGORY_SECURITY\x10\fB\x85\x01\n" +
 	"\vcom.ptop.v1B\n" +
 	"EventProtoP\x01Z-github.com/trentas/ptop/pkg/streampb;streampb\xa2\x02\x03PXX\xaa\x02\aPtop.V1\xca\x02\aPtop\\V1\xe2\x02\x13Ptop\\V1\\GPBMetadata\xea\x02\bPtop::V1b\x06proto3"
 
@@ -3048,7 +3204,7 @@ func file_event_proto_rawDescGZIP() []byte {
 }
 
 var file_event_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
-var file_event_proto_msgTypes = make([]protoimpl.MessageInfo, 31)
+var file_event_proto_msgTypes = make([]protoimpl.MessageInfo, 32)
 var file_event_proto_goTypes = []any{
 	(Category)(0),              // 0: ptop.v1.Category
 	(*StackRef)(nil),           // 1: ptop.v1.StackRef
@@ -3076,12 +3232,13 @@ var file_event_proto_goTypes = []any{
 	(*SignalEvent)(nil),        // 23: ptop.v1.SignalEvent
 	(*ProcContext)(nil),        // 24: ptop.v1.ProcContext
 	(*ProcLifecycleEvent)(nil), // 25: ptop.v1.ProcLifecycleEvent
-	(*FdEntry)(nil),            // 26: ptop.v1.FdEntry
-	(*FdSnapshot)(nil),         // 27: ptop.v1.FdSnapshot
-	(*FdEvent)(nil),            // 28: ptop.v1.FdEvent
-	(*LockEntry)(nil),          // 29: ptop.v1.LockEntry
-	(*LockSnapshot)(nil),       // 30: ptop.v1.LockSnapshot
-	(*TimelineEvent)(nil),      // 31: ptop.v1.TimelineEvent
+	(*SecurityEvent)(nil),      // 26: ptop.v1.SecurityEvent
+	(*FdEntry)(nil),            // 27: ptop.v1.FdEntry
+	(*FdSnapshot)(nil),         // 28: ptop.v1.FdSnapshot
+	(*FdEvent)(nil),            // 29: ptop.v1.FdEvent
+	(*LockEntry)(nil),          // 30: ptop.v1.LockEntry
+	(*LockSnapshot)(nil),       // 31: ptop.v1.LockSnapshot
+	(*TimelineEvent)(nil),      // 32: ptop.v1.TimelineEvent
 }
 var file_event_proto_depIdxs = []int32{
 	0,  // 0: ptop.v1.Event.category:type_name -> ptop.v1.Category
@@ -3094,10 +3251,10 @@ var file_event_proto_depIdxs = []int32{
 	17, // 7: ptop.v1.Event.io_wait:type_name -> ptop.v1.IoWaitSample
 	18, // 8: ptop.v1.Event.io_throughput:type_name -> ptop.v1.IoThroughputSample
 	21, // 9: ptop.v1.Event.io:type_name -> ptop.v1.IoSnapshot
-	27, // 10: ptop.v1.Event.fds:type_name -> ptop.v1.FdSnapshot
-	28, // 11: ptop.v1.Event.fd_event:type_name -> ptop.v1.FdEvent
-	30, // 12: ptop.v1.Event.locks:type_name -> ptop.v1.LockSnapshot
-	31, // 13: ptop.v1.Event.timeline:type_name -> ptop.v1.TimelineEvent
+	28, // 10: ptop.v1.Event.fds:type_name -> ptop.v1.FdSnapshot
+	29, // 11: ptop.v1.Event.fd_event:type_name -> ptop.v1.FdEvent
+	31, // 12: ptop.v1.Event.locks:type_name -> ptop.v1.LockSnapshot
+	32, // 13: ptop.v1.Event.timeline:type_name -> ptop.v1.TimelineEvent
 	14, // 14: ptop.v1.Event.heap:type_name -> ptop.v1.HeapSnapshot
 	12, // 15: ptop.v1.Event.heap_event:type_name -> ptop.v1.HeapEvent
 	9,  // 16: ptop.v1.Event.net_error:type_name -> ptop.v1.NetErrorEvent
@@ -3106,19 +3263,21 @@ var file_event_proto_depIdxs = []int32{
 	10, // 19: ptop.v1.Event.tls:type_name -> ptop.v1.TLSPayloadEvent
 	24, // 20: ptop.v1.Event.proc_context:type_name -> ptop.v1.ProcContext
 	25, // 21: ptop.v1.Event.proc_lifecycle:type_name -> ptop.v1.ProcLifecycleEvent
-	5,  // 22: ptop.v1.SyscallSnapshot.stats:type_name -> ptop.v1.SyscallStat
-	7,  // 23: ptop.v1.NetworkSnapshot.conns:type_name -> ptop.v1.NetConn
-	13, // 24: ptop.v1.HeapSnapshot.top_call_sites:type_name -> ptop.v1.HeapCallSite
-	15, // 25: ptop.v1.ThreadSnapshot.threads:type_name -> ptop.v1.ThreadInfo
-	19, // 26: ptop.v1.IoSnapshot.top_files:type_name -> ptop.v1.IoFileStats
-	20, // 27: ptop.v1.IoSnapshot.latency_buckets:type_name -> ptop.v1.LatencyBucket
-	26, // 28: ptop.v1.FdSnapshot.fds:type_name -> ptop.v1.FdEntry
-	29, // 29: ptop.v1.LockSnapshot.locks:type_name -> ptop.v1.LockEntry
-	30, // [30:30] is the sub-list for method output_type
-	30, // [30:30] is the sub-list for method input_type
-	30, // [30:30] is the sub-list for extension type_name
-	30, // [30:30] is the sub-list for extension extendee
-	0,  // [0:30] is the sub-list for field type_name
+	26, // 22: ptop.v1.Event.security:type_name -> ptop.v1.SecurityEvent
+	5,  // 23: ptop.v1.SyscallSnapshot.stats:type_name -> ptop.v1.SyscallStat
+	7,  // 24: ptop.v1.NetworkSnapshot.conns:type_name -> ptop.v1.NetConn
+	13, // 25: ptop.v1.HeapSnapshot.top_call_sites:type_name -> ptop.v1.HeapCallSite
+	15, // 26: ptop.v1.ThreadSnapshot.threads:type_name -> ptop.v1.ThreadInfo
+	19, // 27: ptop.v1.IoSnapshot.top_files:type_name -> ptop.v1.IoFileStats
+	20, // 28: ptop.v1.IoSnapshot.latency_buckets:type_name -> ptop.v1.LatencyBucket
+	2,  // 29: ptop.v1.SecurityEvent.call_site:type_name -> ptop.v1.StackFrame
+	27, // 30: ptop.v1.FdSnapshot.fds:type_name -> ptop.v1.FdEntry
+	30, // 31: ptop.v1.LockSnapshot.locks:type_name -> ptop.v1.LockEntry
+	32, // [32:32] is the sub-list for method output_type
+	32, // [32:32] is the sub-list for method input_type
+	32, // [32:32] is the sub-list for extension type_name
+	32, // [32:32] is the sub-list for extension extendee
+	0,  // [0:32] is the sub-list for field type_name
 }
 
 func init() { file_event_proto_init() }
@@ -3147,6 +3306,7 @@ func file_event_proto_init() {
 		(*Event_Tls)(nil),
 		(*Event_ProcContext)(nil),
 		(*Event_ProcLifecycle)(nil),
+		(*Event_Security)(nil),
 	}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
@@ -3154,7 +3314,7 @@ func file_event_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_event_proto_rawDesc), len(file_event_proto_rawDesc)),
 			NumEnums:      1,
-			NumMessages:   31,
+			NumMessages:   32,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/proto/event.proto
+++ b/proto/event.proto
@@ -19,6 +19,7 @@ enum Category {
   CATEGORY_TIMELINE = 9;
   CATEGORY_SIGNAL = 10; // #58 — signals delivered to the target
   CATEGORY_PROCESS = 11; // #60 — execution context + exec lineage
+  CATEGORY_SECURITY = 12; // #59 — LSM decisions + runtime executable mappings
 }
 
 // StackRef references a stack captured at event time and resolved out-of-band
@@ -93,7 +94,7 @@ message Event {
     TLSPayloadEvent tls = 27; // #55 — pre-encryption / post-decryption plaintext
     ProcContext proc_context = 28; // #60 — periodic namespace/cgroup/identity snapshot
     ProcLifecycleEvent proc_lifecycle = 29; // #60 — exec lineage (fork/exec/exit)
-    // 30+ reserved for the remaining #52 capabilities (security/LSM — #59).
+    SecurityEvent security = 30; // #59 — LSM decision / runtime executable mapping
   }
 }
 
@@ -340,6 +341,33 @@ message ProcLifecycleEvent {
   int32 ppid = 3; // parent pid (fork only; 0 otherwise)
   string comm = 4; // subject command name
   string filename = 5; // executed path (exec only; "" otherwise)
+}
+
+// ─── Security (#59) ──────────────────────────────────────────────────────────
+// SecurityEvent surfaces a kernel security-relevant action on the target. kind
+// is "exec-map" (a runtime mmap/mprotect that set PROT_EXEC — code mapped
+// executable after start: dlopen, JIT, or RWX injection) or "lsm-decision" (a
+// kernel LSM denial, best-effort via the SELinux AVC tracepoint; absent where
+// the hook isn't exposed).
+//
+// For exec-map: op is "mmap"|"mprotect"; addr/len/prot describe the mapping
+// (prot is the PROT_* bitmask); write_exec flags simultaneous write+exec (W^X),
+// anon flags a non-file-backed mapping (mmap only) — the two higher-signal
+// cases. call_site is the symbolized originating application frame (#54; func ""
+// and offset = raw address when unresolved). For lsm-decision: detail carries
+// the human summary (denied perms, class, contexts) and the mmap fields are 0.
+// Category on the envelope is SECURITY; the event time lives on the envelope.
+// eBPF-only — never simulated.
+message SecurityEvent {
+  string kind = 1; // "exec-map" | "lsm-decision"
+  string op = 2; // "mmap" | "mprotect" (exec-map); "" for lsm
+  uint64 addr = 3;
+  uint64 len = 4;
+  uint32 prot = 5; // PROT_* bitmask (exec-map)
+  bool write_exec = 6; // PROT_WRITE & PROT_EXEC (W^X)
+  bool anon = 7; // non-file-backed mapping (mmap only)
+  string detail = 8; // lsm summary, or extra exec-map context
+  StackFrame call_site = 9; // exec-map originating frame (symbolized, #54)
 }
 
 // ─── File descriptors ───────────────────────────────────────────────────────


### PR DESCRIPTION
Closes #59 — the **last** capability of epic #52 (#53/#54/#55/#56/#57/#58/#60 all merged).

## What

A single eBPF-only `SecurityEvent` (never simulated) on the #51 stream surfaces two security-audit signals:

- **exec-map** — runtime `mmap`/`mprotect` that sets `PROT_EXEC` (code mapped executable after start: dlopen, JIT, or RWX injection). `write_exec` (W^X) and `anon` (non-file-backed) flag the high-signal cases. Each is tied to its originating **application call site**, symbolized inline via #54's `symbol.Symbolizer` (events are low-rate → no lazy RPC needed; libc/ld frames skipped to reach the app frame).
- **lsm-decision** — SELinux AVC denials, **best-effort** via the `avc/selinux_audited` tracepoint attached **non-fatally**. Absent (zero events, collector still healthy) where the hook isn't exposed — exactly as the issue allows.

## How

- New `security.bpf.c` (in `BPF_SRCS`) on `sys_enter_mmap`/`sys_enter_mprotect` + `avc/selinux_audited`. Process-context → reuses the shared ns-aware `pid_is_target` filter (plain `--pid` works; **no** global-pid trick unlike #58/#60).
- A `sec_stacks` STACK_TRACE map + `bpf_get_stackid(BPF_F_USER_STACK)` captures the call site (mirrors `heap.bpf.c`); the collector resolves the app frame inline.
- proto `SecurityEvent` (oneof 30) + new `CATEGORY_SECURITY=12`, reusing `StackFrame` for the call site. Loader/collector/stubs + `Set` wiring; build-tag-free decoder (`protString`, kind/op, detail) + unit tests.
- TUI: new `sec` timeline category (red / `SEC`), F7 feed, capped export buffer, `?` overlay row. Stream/audit-oriented — no dedicated live panel (per the issue).

## Validation

**Runtime (privileged Docker, real verifier + capture)** — a C target doing `mmap(RWX-anon)`, `mmap(r-x-anon)`, and `mmap(RW)+mprotect(RX)` (the JIT pattern) in a loop:
- verifier loads + all 3 tracepoints attach
- captured 13× each: `mmap prot:7 writeExec anon`, `mmap prot:5`, `mprotect prot:5` — with a symbolized call site into the target binary
- **0× `prot:3`** — the benign RW-only `mmap` is correctly excluded (only PROT_EXEC emitted)

**LSM** — not runtime-testable on the Docker kernel (no SELinux); validated by CI-compile + graceful non-fatal attach.

**Local** — `go build/test ./...` (stub), `GOOS=linux go build/vet`, `go build -tags=ebpf` (stub), decoder unit tests, `make proto` additive-only diff.

## Deferred (documented)
AppArmor LSM (separate audit path), SELinux perm-name/context decoding (per-class tables), `memfd`, mprotect anon-detection (not in the args), C call-site `file:line` (needs DWARF, per #54).

🤖 Generated with [Claude Code](https://claude.com/claude-code)