### PR TITLE
threads: surface per-thread off-CPU% in F4 (#61)

### DIFF
--- a/internal/serve/mapper.go
+++ b/internal/serve/mapper.go
@@ -97,6 +97,7 @@ func toEvent(pid int, buildID string, v interface{}) *pb.Event {
 			threads[i] = &pb.ThreadInfo{
 				Tid: int32(t.TID), Name: t.Name, State: t.State,
 				CpuPct: t.CPUPct, Waiting: t.Waiting, CtxSwitches: t.CtxSwitches,
+				OffCpuPct: t.OffCpuPct,
 			}
 		}
 		ev.Payload = &pb.Event_Threads{Threads: &pb.ThreadSnapshot{Threads: threads}}

--- a/internal/serve/mapper_test.go
+++ b/internal/serve/mapper_test.go
@@ -51,10 +51,11 @@ func TestToEventCategoriesAndPayloads(t *testing.T) {
 				return he.GetOp() == "free" && he.GetSize() == 256 && he.GetLifetimeMs() == 7.5 &&
 					e.GetStack().GetStackId() == 9 && e.GetStack().GetBuildId() == buildID
 			}},
-		{"threads", []collector.ThreadInfo{{TID: 11, Name: "main", CtxSwitches: 4}},
+		{"threads", []collector.ThreadInfo{{TID: 11, Name: "main", CtxSwitches: 4, OffCpuPct: 62.5}},
 			pb.Category_CATEGORY_THREAD, func(e *pb.Event) bool {
 				th := e.GetThreads().GetThreads()
-				return len(th) == 1 && th[0].GetTid() == 11 && th[0].GetCtxSwitches() == 4
+				return len(th) == 1 && th[0].GetTid() == 11 && th[0].GetCtxSwitches() == 4 &&
+					th[0].GetOffCpuPct() == 62.5
 			}},
 		{"io_wait", collector.IOWaitSample{Pct: 12.5, Timestamp: time.Unix(2, 0)},
 			pb.Category_CATEGORY_IO, func(e *pb.Event) bool { return e.GetIoWait().GetPct() == 12.5 }},

--- a/internal/tui/panels.go
+++ b/internal/tui/panels.go
@@ -263,17 +263,22 @@ func renderThreadTable(threads []collector.ThreadInfo, w, h int) string {
 	const nameW = 14
 	const stateW = 10
 	const cpuW = 5
+	const offW = 5
 	const waitW = 18
-	barW := w - 2 - nameW - stateW - cpuW - waitW - 5
+	barW := w - 2 - nameW - stateW - cpuW - offW - waitW - 6
 	if barW < 5 {
 		barW = 5
 	}
 
+	rightCol := func(s string) string {
+		return lipgloss.NewStyle().Width(cpuW).Background(ColorPanel).Align(lipgloss.Right).Render(s)
+	}
 	header := MutedStyle.Render(
 		padRight("  NAME", 2+nameW) + " " +
 			padRight("STATE", stateW) + " " +
 			padRight("CPU", barW) + " " +
-			lipgloss.NewStyle().Width(cpuW).Background(ColorPanel).Align(lipgloss.Right).Render("%") + " " +
+			rightCol("ON%") + " " +
+			rightCol("OFF%") + " " +
 			padRight("WAITING ON", waitW),
 	)
 
@@ -299,6 +304,19 @@ func renderThreadTable(threads []collector.ThreadInfo, w, h int) string {
 		}
 		cpuStr := lipgloss.NewStyle().Foreground(ColorMuted).Background(ColorPanel).Width(cpuW).Align(lipgloss.Right).Render(cpuLabel)
 
+		// off-CPU%: time blocked/waiting (not idle). High off-CPU on a blocked
+		// thread is the stall signal — flag it amber; otherwise stay muted so
+		// idle sleepers don't read as alarms.
+		offLabel := "--"
+		offColor := ColorMuted
+		if t.OffCpuPct > 0 {
+			offLabel = fmt.Sprintf("%.0f%%", t.OffCpuPct)
+			if t.State == "blocked" && t.OffCpuPct >= 50 {
+				offColor = ColorAmber
+			}
+		}
+		offStr := lipgloss.NewStyle().Foreground(offColor).Background(ColorPanel).Width(offW).Align(lipgloss.Right).Render(offLabel)
+
 		wait := "–"
 		waitColor := ColorDim
 		if t.Waiting != "" {
@@ -307,7 +325,7 @@ func renderThreadTable(threads []collector.ThreadInfo, w, h int) string {
 		}
 		waitStr := lipgloss.NewStyle().Foreground(waitColor).Background(ColorPanel).Width(waitW).Render(truncate(wait, waitW))
 
-		lines = append(lines, panelRow(gly+name, state, bar, cpuStr, waitStr))
+		lines = append(lines, panelRow(gly+name, state, bar, cpuStr, offStr, waitStr))
 
 	}
 	return strings.Join(lines, "\n")

--- a/pkg/collector/threads_ebpf.go
+++ b/pkg/collector/threads_ebpf.go
@@ -36,9 +36,10 @@ type ThreadsEBPFCollector struct {
 	ch     chan interface{}
 	stop   chan struct{}
 
-	mu          sync.Mutex
-	prevOnNs    map[uint32]uint64 // tid → on_cpu_ns_total at last sample
-	prevSwitch  map[uint32]uint64 // tid → ctx_switches at last sample
+	mu           sync.Mutex
+	prevOnNs     map[uint32]uint64 // tid → on_cpu_ns_total at last sample
+	prevOffNs    map[uint32]uint64 // tid → off_cpu_ns_total at last sample
+	prevSwitch   map[uint32]uint64 // tid → ctx_switches at last sample
 	lastSampleAt time.Time
 }
 
@@ -47,6 +48,7 @@ func NewThreadsEBPFCollector() *ThreadsEBPFCollector {
 		ch:         make(chan interface{}, 4),
 		stop:       make(chan struct{}),
 		prevOnNs:   make(map[uint32]uint64),
+		prevOffNs:  make(map[uint32]uint64),
 		prevSwitch: make(map[uint32]uint64),
 	}
 }
@@ -113,9 +115,9 @@ func (c *ThreadsEBPFCollector) collect() ([]ThreadInfo, error) {
 
 	// 1st pass: read /proc/task/* and build TID list + metadata.
 	type procData struct {
-		comm    string
-		state   byte
-		wchan   string
+		comm  string
+		state byte
+		wchan string
 	}
 	procByTID := make(map[uint32]procData, len(entries))
 	tidList := make([]int, 0, len(entries))
@@ -158,7 +160,7 @@ func (c *ThreadsEBPFCollector) collect() ([]ThreadInfo, error) {
 	out := make([]ThreadInfo, 0, len(procByTID))
 	for tid, pd := range procByTID {
 		s := stats[tid]
-		var cpuPct float64
+		var cpuPct, offCpuPct float64
 		var switches uint64
 
 		if elapsed > 0 {
@@ -167,9 +169,15 @@ func (c *ThreadsEBPFCollector) collect() ([]ThreadInfo, error) {
 			if cpuPct > 100 {
 				cpuPct = 100 // ceiling — single thread on multi-core can't exceed 100%
 			}
+			deltaOff := s.OffCpuNsTotal - c.prevOffNs[tid]
+			offCpuPct = (float64(deltaOff) / 1e9) / elapsed * 100
+			if offCpuPct > 100 {
+				offCpuPct = 100 // same single-thread ceiling
+			}
 			switches = s.CtxSwitches - c.prevSwitch[tid]
 		}
 		c.prevOnNs[tid] = s.OnCpuNsTotal
+		c.prevOffNs[tid] = s.OffCpuNsTotal
 		c.prevSwitch[tid] = s.CtxSwitches
 
 		out = append(out, ThreadInfo{
@@ -179,6 +187,7 @@ func (c *ThreadsEBPFCollector) collect() ([]ThreadInfo, error) {
 			CPUPct:      cpuPct,
 			Waiting:     pd.wchan,
 			CtxSwitches: switches,
+			OffCpuPct:   offCpuPct,
 		})
 	}
 
@@ -186,6 +195,7 @@ func (c *ThreadsEBPFCollector) collect() ([]ThreadInfo, error) {
 	for tid := range c.prevOnNs {
 		if _, alive := procByTID[tid]; !alive {
 			delete(c.prevOnNs, tid)
+			delete(c.prevOffNs, tid)
 			delete(c.prevSwitch, tid)
 		}
 	}

--- a/pkg/collector/types.go
+++ b/pkg/collector/types.go
@@ -136,6 +136,15 @@ type ThreadInfo struct {
 	// window (interval between collector publishes). Only populated when the
 	// eBPF threads collector is active; via /proc this stays zero.
 	CtxSwitches uint64
+	// OffCpuPct: % of the window the thread spent off-CPU — blocked/waiting on
+	// a lock, I/O or syscall, NOT merely idle. This is what distinguishes a
+	// stalled thread from one that simply had no work. eBPF-only (derived from
+	// off_cpu_ns_total, same window delta as CPUPct); 0 via /proc.
+	//
+	// OffCpuPct + CPUPct do NOT sum to 100%: the remainder is time the thread
+	// was runnable-but-unscheduled or didn't exist in the window. Render them
+	// as independent "on"/"off" figures, never as a split.
+	OffCpuPct float64
 }
 
 // ─── Locks (futex) ───────────────────────────────────────────────────────────

--- a/pkg/streampb/event.pb.go
+++ b/pkg/streampb/event.pb.go
@@ -1536,13 +1536,17 @@ func (x *HeapSnapshot) GetTopCallSites() []*HeapCallSite {
 
 // ─── Threads ────────────────────────────────────────────────────────────────
 type ThreadInfo struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Tid           int32                  `protobuf:"varint,1,opt,name=tid,proto3" json:"tid,omitempty"`
-	Name          string                 `protobuf:"bytes,2,opt,name=name,proto3" json:"name,omitempty"`
-	State         string                 `protobuf:"bytes,3,opt,name=state,proto3" json:"state,omitempty"` // "running" | "blocked" | "sleeping"
-	CpuPct        float64                `protobuf:"fixed64,4,opt,name=cpu_pct,json=cpuPct,proto3" json:"cpu_pct,omitempty"`
-	Waiting       string                 `protobuf:"bytes,5,opt,name=waiting,proto3" json:"waiting,omitempty"`                             // blocking lock/syscall name, empty if none
-	CtxSwitches   uint64                 `protobuf:"varint,6,opt,name=ctx_switches,json=ctxSwitches,proto3" json:"ctx_switches,omitempty"` // eBPF-only; 0 via /proc
+	state       protoimpl.MessageState `protogen:"open.v1"`
+	Tid         int32                  `protobuf:"varint,1,opt,name=tid,proto3" json:"tid,omitempty"`
+	Name        string                 `protobuf:"bytes,2,opt,name=name,proto3" json:"name,omitempty"`
+	State       string                 `protobuf:"bytes,3,opt,name=state,proto3" json:"state,omitempty"` // "running" | "blocked" | "sleeping"
+	CpuPct      float64                `protobuf:"fixed64,4,opt,name=cpu_pct,json=cpuPct,proto3" json:"cpu_pct,omitempty"`
+	Waiting     string                 `protobuf:"bytes,5,opt,name=waiting,proto3" json:"waiting,omitempty"`                             // blocking lock/syscall name, empty if none
+	CtxSwitches uint64                 `protobuf:"varint,6,opt,name=ctx_switches,json=ctxSwitches,proto3" json:"ctx_switches,omitempty"` // eBPF-only; 0 via /proc
+	// off_cpu_pct: % of the window the thread spent off-CPU (blocked/waiting,
+	// not merely idle). eBPF-only; 0 via /proc. Does NOT sum to 100% with
+	// cpu_pct — the remainder is time runnable-but-unscheduled or non-existent.
+	OffCpuPct     float64 `protobuf:"fixed64,7,opt,name=off_cpu_pct,json=offCpuPct,proto3" json:"off_cpu_pct,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -1615,6 +1619,13 @@ func (x *ThreadInfo) GetWaiting() string {
 func (x *ThreadInfo) GetCtxSwitches() uint64 {
 	if x != nil {
 		return x.CtxSwitches
+	}
+	return 0
+}
+
+func (x *ThreadInfo) GetOffCpuPct() float64 {
+	if x != nil {
+		return x.OffCpuPct
 	}
 	return 0
 }
@@ -3056,7 +3067,7 @@ const file_event_proto_rawDesc = "" +
 	"\n" +
 	"alloc_rate\x18\x02 \x01(\x01R\tallocRate\x120\n" +
 	"\x14suspected_leak_bytes\x18\x03 \x01(\x04R\x12suspectedLeakBytes\x12;\n" +
-	"\x0etop_call_sites\x18\x04 \x03(\v2\x15.ptop.v1.HeapCallSiteR\ftopCallSites\"\x9e\x01\n" +
+	"\x0etop_call_sites\x18\x04 \x03(\v2\x15.ptop.v1.HeapCallSiteR\ftopCallSites\"\xbe\x01\n" +
 	"\n" +
 	"ThreadInfo\x12\x10\n" +
 	"\x03tid\x18\x01 \x01(\x05R\x03tid\x12\x12\n" +
@@ -3064,7 +3075,8 @@ const file_event_proto_rawDesc = "" +
 	"\x05state\x18\x03 \x01(\tR\x05state\x12\x17\n" +
 	"\acpu_pct\x18\x04 \x01(\x01R\x06cpuPct\x12\x18\n" +
 	"\awaiting\x18\x05 \x01(\tR\awaiting\x12!\n" +
-	"\fctx_switches\x18\x06 \x01(\x04R\vctxSwitches\"?\n" +
+	"\fctx_switches\x18\x06 \x01(\x04R\vctxSwitches\x12\x1e\n" +
+	"\voff_cpu_pct\x18\a \x01(\x01R\toffCpuPct\"?\n" +
 	"\x0eThreadSnapshot\x12-\n" +
 	"\athreads\x18\x01 \x03(\v2\x13.ptop.v1.ThreadInfoR\athreads\" \n" +
 	"\fIoWaitSample\x12\x10\n" +

--- a/proto/event.proto
+++ b/proto/event.proto
@@ -225,6 +225,10 @@ message ThreadInfo {
   double cpu_pct = 4;
   string waiting = 5; // blocking lock/syscall name, empty if none
   uint64 ctx_switches = 6; // eBPF-only; 0 via /proc
+  // off_cpu_pct: % of the window the thread spent off-CPU (blocked/waiting,
+  // not merely idle). eBPF-only; 0 via /proc. Does NOT sum to 100% with
+  // cpu_pct — the remainder is time runnable-but-unscheduled or non-existent.
+  double off_cpu_pct = 7;
 }
 message ThreadSnapshot {
   repeated ThreadInfo threads = 1;


### PR DESCRIPTION
Closes #61. Follow-up to #13.

## What

`threads.bpf.c` already accumulates `off_cpu_ns_total` per TID, but the Go side
only derived on-CPU `CPUPct`. This derives **off-CPU%** with the same
window-delta math and surfaces it in the F4 Threads view — the diagnostic that
distinguishes a thread *blocked* on a lock/IO/syscall (high off-CPU, low
on-CPU) from one that is merely *idle*.

## Changes

- **collector**: `ThreadInfo.OffCpuPct`; `ThreadsEBPFCollector` tracks
  `prevOffNs` and computes the per-window delta (100% ceiling, GC'd alongside
  the on-CPU maps).
- **TUI**: new `OFF%` column in `renderThreadTable`, header `ON%`/`OFF%`; amber
  when a blocked thread reads ≥50% off-CPU (stall flag), muted otherwise.
- **stream**: `off_cpu_pct = 7` on the `ThreadInfo` proto message (additive,
  buf-breaking-safe) + mapper + test.

## Notes

- off-CPU% is **eBPF-only** — mock and `/proc` leave it `--` (like
  `CtxSwitches`, never simulated).
- `on%` + `off%` do **not** sum to 100% (the remainder is time
  runnable-but-unscheduled or non-existent in the window); rendered as
  independent figures, not a split.
- Task 2 from the issue (500ms snapshot tick) **intentionally deferred** — the
  1s interval was a deliberate cost choice and there is no measured lag.

## Test

- `go test ./...` green; new mapper assertion for `off_cpu_pct`.
- Real `linux && ebpf` lane type-checked; F4 dump verified at 180/100 cols (no
  overflow, columns aligned).

🤖 Generated with [Claude Code](https://claude.com/claude-code)