### PR TITLE
tui: decouple render from data ingestion (17.7% → 8.6% CPU) + pprof flag

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -348,8 +348,16 @@ ptop --pid <PID> --serve unix:///run/ptop.sock   headless: stream events over gR
 ptop --pid <PID> --serve tcp://127.0.0.1:50051   headless over TCP (loopback)
 ptop --pid <PID> --tls       TLS payload metadata (libssl uprobes) — OFF by default (#55)
 ptop --pid <PID> --tls-bytes 256   also capture ≤256 plaintext bytes/call (implies --tls)
+ptop --pid <PID> --pprof localhost:6060   dev: serve net/http/pprof to profile ptop itself
 ptop --version              print version + commit + build date
 ```
+
+`--pprof <addr>` is a dev-only profiling endpoint: it starts `net/http/pprof`
+on `addr` (works in both TUI and `--serve` modes) so you can profile ptop's own
+CPU/heap/goroutines — e.g. dogfood with `ptop --pid $(pgrep ptop) --pprof
+localhost:6060`, then `go tool pprof http://localhost:6060/debug/pprof/profile`.
+It exposes process internals, so bind a loopback addr. Off when the flag is
+empty (no server, zero cost).
 
 `--tls` opts into pre-encryption/post-decryption payload capture via uprobes on
 the target's libssl (`SSL_write`/`SSL_read`, resolved by symbol — Go targets have

--- a/cmd/ptop/main.go
+++ b/cmd/ptop/main.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"net/http"
+	_ "net/http/pprof" // registers /debug/pprof handlers on http.DefaultServeMux
 	"os"
 	"os/signal"
 	"runtime"
@@ -11,6 +13,7 @@ import (
 	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
 	"github.com/trentas/ptop/internal/bpf"
 	"github.com/trentas/ptop/internal/serve"
 	"github.com/trentas/ptop/internal/tui"
@@ -33,6 +36,7 @@ func main() {
 	serveAddr := flag.String("serve", "", "Headless mode: stream events over gRPC instead of the TUI (unix:///path or tcp://host:port)")
 	tls := flag.Bool("tls", false, "Capture TLS payload metadata (direction/fd/byte count) via libssl uprobes — OFF by default (#55)")
 	tlsBytes := flag.Int("tls-bytes", 0, "Also capture up to N bytes of PLAINTEXT per TLS call (implies --tls; 0=metadata only, max 4096). Sensitive: may include credentials/PII")
+	pprofAddr := flag.String("pprof", "", "Dev: serve net/http/pprof on this addr (e.g. localhost:6060) for profiling ptop itself")
 	showVer := flag.Bool("version", false, "Print version and exit")
 	flag.Parse()
 
@@ -47,6 +51,20 @@ func main() {
 		fmt.Fprintln(os.Stderr, "       ptop --pid <PID> --serve unix:///run/ptop.sock")
 		fmt.Fprintln(os.Stderr, "       ptop --version")
 		os.Exit(1)
+	}
+
+	// Profiling endpoint (dev tool, opt-in). Serves /debug/pprof for inspecting
+	// ptop's own CPU/heap/goroutines — dogfood with `ptop --pid $(pgrep ptop)`.
+	// It exposes process internals, so prefer a loopback addr.
+	if *pprofAddr != "" {
+		addr := *pprofAddr
+		fmt.Fprintf(os.Stderr, "[ptop] pprof listening on http://%s/debug/pprof/\n", addr)
+		go func() {
+			srv := &http.Server{Addr: addr, ReadHeaderTimeout: 5 * time.Second}
+			if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+				fmt.Fprintf(os.Stderr, "[ptop] pprof server error: %v\n", err)
+			}
+		}()
 	}
 
 	if !*noEBPF {
@@ -110,6 +128,11 @@ func main() {
 		TLS:         tlsEnabled,
 		TLSMaxBytes: tlsCap,
 	}
+
+	// Resolve the terminal color profile once and pin it. Otherwise lipgloss
+	// re-resolves it lazily and each styled segment re-probes the profile when
+	// converting the 24-bit palette to ANSI — wasteful on the render hot path.
+	lipgloss.SetColorProfile(lipgloss.ColorProfile())
 
 	m := tui.NewModel(cfg)
 	p := tea.NewProgram(m, tea.WithAltScreen(), tea.WithMouseCellMotion())

--- a/internal/tui/dump_test.go
+++ b/internal/tui/dump_test.go
@@ -25,6 +25,7 @@ func TestDumpFrames(t *testing.T) {
 	m.Height = h
 	for tab := 0; tab < TabCount; tab++ {
 		m.ActiveTab = tab
+		m.render.commit = true // bypass frame memoization: force a fresh render
 		out := m.View()
 		safe := strings.ReplaceAll(tabNames[tab], "/", "-")
 		safe = strings.ReplaceAll(safe, " ", "_")

--- a/internal/tui/help_test.go
+++ b/internal/tui/help_test.go
@@ -185,6 +185,7 @@ func TestFilterFDView_substring(t *testing.T) {
 
 	// Apply filter "TCP"
 	m.filter = "TCP"
+	m.render.commit = true // direct state mutation (no Update) — force a fresh render
 	out = m.View()
 	if !strings.Contains(out, "TCP") {
 		t.Error("after filter=TCP, expected to see TCP")

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -211,6 +211,24 @@ type Model struct {
 	// IO maxima with slow decay — avoids rescaling sparklines every tick.
 	ioMaxRead  float64
 	ioMaxWrite float64
+
+	// render memoizes the last frame so View() stays cheap on the high-rate
+	// collector messages. See renderState.
+	render *renderState
+}
+
+// renderState memoizes rendered frames for the FPS-bounded render loop.
+// bubbletea calls View() once per message (its eventLoop does
+// `renderer.write(model.View())` after every Update), so without this the full
+// lipgloss layout is rebuilt on every collector publish (~20+/s) even though
+// the terminal only repaints at the framerate. It is a pointer field so the
+// value-copied Model shares one cache across Update/View calls: data messages
+// just mutate state (commit stays false → View returns the cached frame), while
+// the FPS TickMsg, key presses and resizes set commit=true to force a fresh
+// render. Worst-case staleness of a data update is one frame (1/FPS).
+type renderState struct {
+	frame  string // last fully-rendered frame
+	commit bool   // when true, View() rebuilds; otherwise it returns `frame`
 }
 
 // ─── Construction ────────────────────────────────────────────────────────────
@@ -229,6 +247,7 @@ func NewModel(cfg Config) Model {
 		FDFilter:      "all",
 		SyscallCounts: make(map[string]uint64),
 		rng:           rand.New(rand.NewSource(time.Now().UnixNano())),
+		render:        &renderState{},
 	}
 
 	m.seedMockData()
@@ -358,21 +377,27 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case tea.WindowSizeMsg:
 		m.Width = v.Width
 		m.Height = v.Height
+		m.render.commit = true // layout reflow — render now
 		return m, nil
 
 	case tea.KeyMsg:
 		next, cmd := m.handleKey(v)
+		next.render.commit = true // user input — render now for responsiveness
 		return next, cmd
 
 	case TickMsg:
-		// Render at configured FPS (clock/uptime stay smooth), but the simulation
-		// only advances every simInterval — avoids the "everything jumping" effect
-		// from too many changes per second. When the frame is identical, bubbletea
-		// detects an empty diff and doesn't even repaint.
+		// The FPS heartbeat. This is the ONLY periodic render trigger: data
+		// messages (CpuMsg, NetMsg, …) just mutate state and leave the frame
+		// cached, so the full lipgloss layout is rebuilt at most FPS times/s
+		// instead of once per collector publish. The clock/uptime stay smooth
+		// because this fires at FPS; the simulation still only advances every
+		// simInterval to avoid the "everything jumping" effect. When the frame
+		// is identical, bubbletea detects an empty diff and doesn't repaint.
 		if !m.Paused && time.Since(m.lastSimAt) >= simInterval {
 			m.tick()
 			m.lastSimAt = time.Now()
 		}
+		m.render.commit = true
 		return m, tick(m.cfg.FPS)
 
 	case FDMsg:
@@ -635,6 +660,27 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 }
 
 func (m Model) View() string {
+	// Frame memoization: bubbletea calls View() once per message, but only the
+	// FPS TickMsg, key presses and resizes ask for a fresh render (commit). On
+	// the high-rate collector messages commit stays false, so we return the
+	// last frame and skip the entire lipgloss layout (StringWidth, color
+	// conversion, ~MBs of allocation). See renderState.
+	if m.render != nil && !m.render.commit && m.render.frame != "" {
+		return m.render.frame
+	}
+
+	out := m.renderFrame()
+
+	if m.render != nil {
+		m.render.frame = out
+		m.render.commit = false
+	}
+	return out
+}
+
+// renderFrame builds the full frame from the current state. Pure (no caching);
+// View() owns the memoization.
+func (m Model) renderFrame() string {
 	if m.Width == 0 || m.Height == 0 {
 		return "starting..."
 	}

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -31,6 +31,7 @@ func TestRenderAllTabs(t *testing.T) {
 		m.Height = sz.h
 		for tab := 0; tab < TabCount; tab++ {
 			m.ActiveTab = tab
+			m.render.commit = true // bypass frame memoization: force a fresh render
 			out := m.View()
 			if out == "" {
 				t.Errorf("size=%dx%d tab=%d: empty", sz.w, sz.h, tab)

--- a/internal/tui/render_memo_test.go
+++ b/internal/tui/render_memo_test.go
@@ -1,0 +1,75 @@
+package tui
+
+import (
+	"testing"
+	"time"
+
+	"github.com/trentas/ptop/pkg/collector"
+)
+
+// TestViewMemoization locks in the render-decoupling contract: collector (data)
+// messages mutate state but must NOT trigger a re-render — View() returns the
+// cached frame — while the FPS TickMsg forces a fresh one. This is what caps the
+// lipgloss layout cost at ~FPS/s instead of once per collector publish (~20+/s).
+// If someone adds commit=true to a data handler (or drops the View() gate), this
+// test fails — the optimization would silently regress otherwise.
+func TestViewMemoization(t *testing.T) {
+	m := NewModel(Config{PID: 1, FPS: 5, NoEBPF: true})
+	m.Width, m.Height = 180, 50
+	m.ActiveTab = TabOverview
+
+	// First View renders fresh (no cached frame yet) and caches it.
+	base := m.View()
+	if base == "" {
+		t.Fatal("baseline frame is empty")
+	}
+
+	// Data messages change visible state (the CPU sparkline) but must leave the
+	// frame cached — the next View returns the exact same bytes.
+	for i := 0; i < 5; i++ {
+		nm, _ := m.Update(CpuMsg(collector.CpuSample{UsagePct: float64(10 + i*15)}))
+		m = nm.(Model)
+	}
+	if got := m.View(); got != base {
+		t.Error("a collector message triggered a re-render; expected the cached frame")
+	}
+
+	// The FPS heartbeat commits: the next frame reflects the new CPU samples.
+	nm, _ := m.Update(TickMsg(time.Now()))
+	m = nm.(Model)
+	if got := m.View(); got == base {
+		t.Error("TickMsg did not produce a fresh frame after state changed")
+	}
+}
+
+func benchModel() Model {
+	m := NewModel(Config{PID: 1, FPS: 5, NoEBPF: true})
+	m.Width, m.Height = 180, 50
+	m.ActiveTab = TabOverview
+	return m
+}
+
+// BenchmarkViewCached is the cost View() pays on a collector message after the
+// decoupling: it returns the cached frame, so this is what the ~20+ data
+// messages/s now cost instead of a full render.
+func BenchmarkViewCached(b *testing.B) {
+	m := benchModel()
+	m.View() // prime the cache (commit path resets commit=false)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = m.View()
+	}
+}
+
+// BenchmarkViewFresh is the full lipgloss render — what EVERY message cost
+// before the decoupling, and what the FPS TickMsg still costs.
+func BenchmarkViewFresh(b *testing.B) {
+	m := benchModel()
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		m.render.commit = true
+		_ = m.View()
+	}
+}


### PR DESCRIPTION
## Problem

ptop's TUI burned CPU even idle. Profiled with the new `--pprof` flag: bubbletea's
eventLoop does `renderer.write(model.View())` after **every** message, so the full
lipgloss layout (StringWidth, color conversion, ~MBs of allocation) was rebuilt
once per message. With ~10 ticker-based collectors publishing every 500ms–1s
(+ per-event timeline messages), that's **~20+ full renders/s** — and `--fps` only
throttles the terminal *flush*, not `View()` itself.

## Fix

**Frame memoization (#1).** `View()` returns a cached frame on the high-rate
collector messages and only rebuilds on the FPS heartbeat (`TickMsg`), key presses
and resizes. `renderState` is a pointer field so the value-copied `Model` shares
one cache across Update/View; data messages mutate state and leave `commit=false`,
so a data update shows on the next tick (≤1/FPS staleness, keys/resize are
immediate). The old `View()` body moved to a pure `renderFrame()`.

**Pin the color profile (#2).** `lipgloss.SetColorProfile(lipgloss.ColorProfile())`
once at startup, so it isn't re-resolved per styled segment.

**`--pprof <addr>` flag.** Dev-only `net/http/pprof` endpoint (works in TUI and
`--serve`; off when empty) to profile ptop itself. Documented in CLAUDE.md.

## Results

| | CPU (30s profile, busy target) |
|---|---|
| before | 17.7% of a core |
| after | **8.6%** |

Microbenchmark (`render_memo_test.go`):

```
BenchmarkViewCached   17.6 ns/op       0 B/op      0 allocs/op   ← collector msgs now
BenchmarkViewFresh   2103657 ns/op  805770 B/op  7715 allocs/op   ← was every msg; now FPS only
```

## Tests

- `go test ./...` green. `render_memo_test.go` locks in the contract (data msg →
  cached frame, `TickMsg` → fresh) so a future `commit=true` in a data handler
  can't silently regress it.
- dump/model/help tests that mutate state directly (outside `Update`) force
  `commit` before `View()`.

## Follow-ups (not in this PR)

Residual cost is now collection-side (`Syscall6` ~22%) and per-render color hex
parsing (`go-colorful.Hex`→`Sscanf`, ~15%). Next levers: lower default FPS, gate
collector cadence by active tab, and pre-resolve palette colors. Tracked for a
later pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)