### PR TITLE
main: fail fast when --pid does not exist

### DIFF
--- a/cmd/ptop/main.go
+++ b/cmd/ptop/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"flag"
 	"fmt"
 	"net/http"
@@ -45,11 +46,20 @@ func main() {
 		os.Exit(0)
 	}
 
-	if *pid == 0 {
-		fmt.Fprintln(os.Stderr, "error: --pid is required")
+	if *pid <= 0 {
+		if *pid == 0 {
+			fmt.Fprintln(os.Stderr, "error: --pid is required")
+		} else {
+			fmt.Fprintf(os.Stderr, "error: --pid %d is not a valid PID\n", *pid)
+		}
 		fmt.Fprintln(os.Stderr, "usage: ptop --pid <PID> [--fps 5] [--no-ebpf] [--export]")
 		fmt.Fprintln(os.Stderr, "       ptop --pid <PID> --serve unix:///run/ptop.sock")
 		fmt.Fprintln(os.Stderr, "       ptop --version")
+		os.Exit(1)
+	}
+
+	if err := checkPIDExists(*pid); err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
 		os.Exit(1)
 	}
 
@@ -153,6 +163,29 @@ func main() {
 				fmt.Fprintf(os.Stderr, "warning: final snapshot failed: %v\n", err)
 			}
 		}
+	}
+}
+
+// checkPIDExists verifies the target process exists before anything starts.
+// Without this, a nonexistent PID silently fails every collector and the TUI
+// falls back to simulated data — plausible-looking numbers for a process that
+// isn't there (#90). kill(pid, 0) delivers no signal, it only performs the
+// existence/permission check; same semantics on Linux and macOS.
+func checkPIDExists(pid int) error {
+	err := syscall.Kill(pid, 0)
+	switch {
+	case err == nil:
+		return nil
+	case errors.Is(err, syscall.ESRCH):
+		return fmt.Errorf("process %d does not exist", pid)
+	case errors.Is(err, syscall.EPERM):
+		// EPERM means the process exists but belongs to another user.
+		// Collectors will degrade (macOS libproc needs same-euid), so warn
+		// rather than fail: partial data for a real process is still useful.
+		fmt.Fprintf(os.Stderr, "[ptop] warning: process %d is owned by another user — data may be limited or unavailable\n", pid)
+		return nil
+	default:
+		return fmt.Errorf("cannot check process %d: %w", pid, err)
 	}
 }
 

--- a/cmd/ptop/main_test.go
+++ b/cmd/ptop/main_test.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+func TestCheckPIDExistsSelf(t *testing.T) {
+	if err := checkPIDExists(os.Getpid()); err != nil {
+		t.Fatalf("checkPIDExists(self) = %v, want nil", err)
+	}
+}
+
+func TestCheckPIDExistsPID1(t *testing.T) {
+	// PID 1 (init/launchd) always exists and is owned by root, so this
+	// exercises the EPERM branch whenever the test doesn't run as root.
+	if err := checkPIDExists(1); err != nil {
+		t.Fatalf("checkPIDExists(1) = %v, want nil", err)
+	}
+}
+
+func TestCheckPIDExistsGone(t *testing.T) {
+	// Spawn a short-lived process and reap it; its PID is then free. PID
+	// reuse inside this window is theoretically possible but negligible.
+	cmd := exec.Command("true")
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("spawning `true`: %v", err)
+	}
+	err := checkPIDExists(cmd.Process.Pid)
+	if err == nil {
+		t.Fatalf("checkPIDExists(%d) = nil, want error for reaped pid", cmd.Process.Pid)
+	}
+	if !strings.Contains(err.Error(), "does not exist") {
+		t.Fatalf("checkPIDExists(%d) = %q, want a 'does not exist' error", cmd.Process.Pid, err)
+	}
+}


### PR DESCRIPTION
Closes #90.

## Problem

`ptop --pid <nonexistent>` started normally: every collector failed `Start` (ESRCH), the stderr warnings vanished under the altscreen, and the model fell back to **simulated data** — the TUI showed plausible-looking CPU/mem/net/IO numbers for a process that isn't there. The header's process-name segment also fails silently (empty → omitted), so the only cue was the `?` overlay showing `○ mock`. Reported on macOS; Linux behaved the same.

## Fix

Validate the target in `cmd/ptop/main.go` before the TUI/serve path starts, via `kill(pid, 0)` (no signal delivered, same semantics on Linux and macOS):

- `ESRCH` → `error: process <pid> does not exist`, exit 1
- `EPERM` (exists, owned by another user) → warn that data may be limited, continue
- `--pid <negative>`, which passed the old `pid == 0` check, is now rejected with usage

## Verification

- `go test ./...` green; new tests cover the self/EPERM/ESRCH branches of `checkPIDExists`
- Manually exercised the built binary on macOS:
  - nonexistent PID → `error: process 50838 does not exist`, exit 1, no TUI
  - `--pid -5` → `error: --pid -5 is not a valid PID` + usage
  - `--pid 1` → EPERM warning, startup continues

🤖 Generated with [Claude Code](https://claude.com/claude-code)