### PR TITLE
serve: TLS/mTLS on the event stream, cleartext TCP by opt-in only

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -102,6 +102,7 @@ ptop/
 │   │   └── *_stub.go              stubs for non-Linux / no-ebpf builds
 │   ├── serve/                     headless gRPC server (ptop --serve)
 │   │   ├── serve.go               addr parse + privilege boundary + Run
+│   │   ├── tls.go                 transport security policy: TLS/mTLS or opt-in cleartext (#95)
 │   │   ├── hub.go                 fan-in collectors → fan-out to sinks
 │   │   ├── sink.go                Sink iface: gRPC subscriber + JSONL writer
 │   │   ├── service.go             EventStream gRPC service impl
@@ -345,7 +346,9 @@ ptop --pid <PID> --fps 10   render rate (default: 5)
 ptop --pid <PID> --export   save JSON snapshot on exit (also bound to 'e')
 ptop --pid <PID> --no-ebpf  degraded mode: /proc only, no eBPF
 ptop --pid <PID> --serve unix:///run/ptop.sock   headless: stream events over gRPC, no TUI
-ptop --pid <PID> --serve tcp://127.0.0.1:50051   headless over TCP (loopback)
+ptop --pid <PID> --serve tcp://127.0.0.1:50051 --serve-insecure   headless over TCP, cleartext (opt-in)
+ptop --pid <PID> --serve tcp://<ip>:50051 --serve-tls-cert <crt> --serve-tls-key <key>   over TLS
+ptop --pid <PID> ... --serve-tls-client-ca <ca>   also require a client certificate (mTLS)
 ptop --pid <PID> --tls       TLS payload metadata (libssl uprobes) — OFF by default (#55)
 ptop --pid <PID> --tls-bytes 256   also capture ≤256 plaintext bytes/call (implies --tls)
 ptop --pid <PID> --pprof localhost:6060   dev: serve net/http/pprof to profile ptop itself
@@ -411,6 +414,17 @@ Version metadata is injected via `-ldflags` at release time
   `0600` (owner-only) and removed on exit. For TCP, binding all interfaces
   (`0.0.0.0`/`::`) is refused — the stream exposes process internals, so bind
   loopback or a specific interface IP.
+- Transport security of the stream (#95) lives in `internal/serve/tls.go`:
+  `serverCredentials(addr, TLSOptions)` is the single policy gate, resolved
+  **before** the listener is created so a bad certificate path fails before
+  anything binds. A `tcp://` endpoint must carry TLS (`--serve-tls-cert` +
+  `--serve-tls-key`, plus `--serve-tls-client-ca` for
+  `RequireAndVerifyClientCert`) or an explicit `--serve-insecure`; a bare
+  `tcp://` is refused at startup. Unix sockets take no TLS at all (the flags are
+  refused there — file permissions are the boundary), and contradictory
+  combinations fail fast rather than silently picking a winner. Mind the naming:
+  `--tls`/`--tls-bytes` capture the **target's** plaintext, `--serve-tls-*`
+  encrypt **ptop's own** stream.
 - TLS payload capture (`--tls`/`--tls-bytes`, #55) observes plaintext and is
   **off by default**. It attaches no uprobes unless `--tls` is passed, and emits
   payload bytes only with the additional `--tls-bytes N` (capped 4096/call) —

--- a/README.md
+++ b/README.md
@@ -129,6 +129,12 @@ sudo ./bin/ptop --pid <PID> --export   # save JSON snapshot on exit
 # Stream events headless (no TUI) over gRPC + JSONL
 sudo ./bin/ptop --pid <PID> --serve unix:///run/ptop.sock --export
 
+# Same stream over TCP, encrypted and mutually authenticated (see below)
+sudo ./bin/ptop --pid <PID> --serve tcp://10.1.2.3:50051 \
+  --serve-tls-cert /etc/ptop/tls/tls.crt \
+  --serve-tls-key  /etc/ptop/tls/tls.key \
+  --serve-tls-client-ca /etc/ptop/tls/ca.crt
+
 # Capture TLS plaintext around libssl (OFF by default; sensitive — see below)
 sudo ./bin/ptop --pid <PID> --tls-bytes 256 --serve unix:///run/ptop.sock --export
 ```
@@ -223,8 +229,30 @@ The TUI is one consumer of a richer event model. `ptop --pid <PID> --serve
 <addr>` runs headless and streams every observation as a typed protobuf `Event`
 over gRPC (package `ptop.v1`) to any number of unprivileged subscribers — and,
 with `--export`, also as one protojson line per event to a JSONL file. ptop
-holds `CAP_BPF`/`CAP_PERFMON`; subscribers connect with none (the unix socket is
-`0600`, TCP refuses non-loopback binds).
+holds `CAP_BPF`/`CAP_PERFMON`; subscribers connect with none.
+
+### Transport security
+
+The stream carries process internals — heap call sites, filesystem paths and,
+with `--tls-bytes`, the target's TLS plaintext. What protects it depends on the
+endpoint:
+
+| Endpoint | Protection | Flags |
+|---|---|---|
+| `unix:///path` | Filesystem: the socket is created `0600` and unlinked on exit | none (TLS flags are refused here) |
+| `tcp://host:port` + TLS | Encrypted; the subscriber verifies ptop | `--serve-tls-cert` + `--serve-tls-key` |
+| `tcp://host:port` + mTLS | Encrypted **and** only subscribers holding a certificate from your CA are served | the two above + `--serve-tls-client-ca` |
+| `tcp://host:port` cleartext | None — anyone who reaches the port reads everything | `--serve-insecure` (explicit opt-in, warns on stderr) |
+
+A `tcp://` endpoint with no certificate and no `--serve-insecure` is **refused
+at startup**: cleartext on the wire is a decision, not a default. Binding all
+interfaces (`0.0.0.0`/`::`) is refused either way — bind loopback or a specific
+interface IP. TLS 1.2 is the floor, and the certificate is read once at startup
+(rotate it by restarting the process).
+
+> Not to be confused with `--tls`/`--tls-bytes`, which are the opposite
+> direction: those capture the *target's* TLS plaintext. `--serve-tls-*`
+> encrypts *ptop's own* stream.
 
 Beyond the seven TUI tabs, the stream carries the full process-behavior surface
 (each event tagged by `category`, with `uid`/`gid`/`cgroup_id` stamped on every

--- a/cmd/ptop/main.go
+++ b/cmd/ptop/main.go
@@ -35,6 +35,10 @@ func main() {
 	noEBPF := flag.Bool("no-ebpf", false, "Degraded mode: use only /proc, no eBPF (useful for development)")
 	export := flag.Bool("export", false, "Save JSON snapshot on exit (equivalent to the 'e' key)")
 	serveAddr := flag.String("serve", "", "Headless mode: stream events over gRPC instead of the TUI (unix:///path or tcp://host:port)")
+	serveTLSCert := flag.String("serve-tls-cert", "", "--serve over TLS: PEM server certificate (needs --serve-tls-key; tcp:// only)")
+	serveTLSKey := flag.String("serve-tls-key", "", "--serve over TLS: PEM server private key (needs --serve-tls-cert)")
+	serveTLSClientCA := flag.String("serve-tls-client-ca", "", "--serve over mTLS: PEM CA bundle; subscribers must present a certificate signed by it")
+	serveInsecure := flag.Bool("serve-insecure", false, "Allow a PLAINTEXT tcp:// --serve endpoint (unencrypted, unauthenticated) — deliberate opt-in")
 	tls := flag.Bool("tls", false, "Capture TLS payload metadata (direction/fd/byte count) via libssl uprobes — OFF by default (#55)")
 	tlsBytes := flag.Int("tls-bytes", 0, "Also capture up to N bytes of PLAINTEXT per TLS call (implies --tls; 0=metadata only, max 4096). Sensitive: may include credentials/PII")
 	pprofAddr := flag.String("pprof", "", "Dev: serve net/http/pprof on this addr (e.g. localhost:6060) for profiling ptop itself")
@@ -54,6 +58,7 @@ func main() {
 		}
 		fmt.Fprintln(os.Stderr, "usage: ptop --pid <PID> [--fps 5] [--no-ebpf] [--export]")
 		fmt.Fprintln(os.Stderr, "       ptop --pid <PID> --serve unix:///run/ptop.sock")
+		fmt.Fprintln(os.Stderr, "       ptop --pid <PID> --serve tcp://<ip>:50051 --serve-tls-cert <crt> --serve-tls-key <key>")
 		fmt.Fprintln(os.Stderr, "       ptop --version")
 		os.Exit(1)
 	}
@@ -124,9 +129,28 @@ func main() {
 		fmt.Fprintln(os.Stderr, "       payload bytes (credentials/PII). Keep the stream/export private.")
 	}
 
+	// Transport security of the event stream (#95) — distinct from --tls, which
+	// captures the *target's* TLS payload. It configures the --serve endpoint,
+	// so it is meaningless (and probably a mistake) without one.
+	serveTLS := serve.TLSOptions{
+		CertFile:      *serveTLSCert,
+		KeyFile:       *serveTLSKey,
+		ClientCAFile:  *serveTLSClientCA,
+		AllowInsecure: *serveInsecure,
+	}
+	if *serveAddr == "" && (serveTLS.CertFile != "" || serveTLS.KeyFile != "" ||
+		serveTLS.ClientCAFile != "" || serveTLS.AllowInsecure) {
+		fmt.Fprintln(os.Stderr, "error: --serve-tls-*/--serve-insecure configure the --serve endpoint, but --serve was not given")
+		os.Exit(1)
+	}
+
 	// Headless mode: serve the collector stream over gRPC instead of the TUI.
 	if *serveAddr != "" {
-		runServe(*serveAddr, *pid, *noEBPF, *export, tlsEnabled, tlsCap)
+		opts := serve.Options{TLS: serveTLS}
+		if *export {
+			opts.JSONLPath = fmt.Sprintf("ptop-events-%s.jsonl", time.Now().Format("20060102-150405"))
+		}
+		runServe(*serveAddr, *pid, *noEBPF, tlsEnabled, tlsCap, opts)
 		return
 	}
 
@@ -191,16 +215,12 @@ func checkPIDExists(pid int) error {
 
 // runServe builds the collector Set and streams it over gRPC until SIGINT/
 // SIGTERM. The Set's lifecycle is owned here: serve.Run only stops the server,
-// so we stop the collectors after it returns. With export, it also writes an
-// event-level JSONL (distinct from the TUI's state-snapshot ptop-export-*.jsonl).
-func runServe(addr string, pid int, noEBPF, export, tlsEnabled bool, tlsBytes int) {
+// so we stop the collectors after it returns. opts carries the transport
+// security and, with --export, the event-level JSONL path (distinct from the
+// TUI's state-snapshot ptop-export-*.jsonl).
+func runServe(addr string, pid int, noEBPF, tlsEnabled bool, tlsBytes int, opts serve.Options) {
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
-
-	var opts serve.Options
-	if export {
-		opts.JSONLPath = fmt.Sprintf("ptop-events-%s.jsonl", time.Now().Format("20060102-150405"))
-	}
 
 	set := collector.NewSet(collector.SetConfig{
 		PID: pid, NoEBPF: noEBPF, TLS: tlsEnabled, TLSMaxBytes: tlsBytes,

--- a/internal/serve/serve.go
+++ b/internal/serve/serve.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
 
 	"github.com/trentas/ptop/pkg/collector"
 	pb "github.com/trentas/ptop/pkg/streampb"
@@ -24,24 +25,44 @@ type Options struct {
 	// JSONLPath, if set, also writes every event as one protojson line to this
 	// file (an interchangeable sink alongside the gRPC subscribers).
 	JSONLPath string
+
+	// TLS carries the transport security of a tcp:// endpoint (issue #95).
+	// Serving tcp:// in cleartext requires TLS.AllowInsecure; a unix socket
+	// takes no TLS at all. See serverCredentials for the full policy.
+	TLS TLSOptions
 }
 
 // Run starts the gRPC server bound to addr, streaming events for the given
 // target pid from cols. It blocks until ctx is cancelled, then stops the server
 // and returns. The caller owns the collectors' lifecycle (typically
 // set.Collectors() here and set.Stop() after Run returns). addr is
-// "unix:///path" or "tcp://host:port".
+// "unix:///path" or "tcp://host:port"; a tcp:// endpoint must carry TLS
+// material or an explicit opt-in to cleartext (see serverCredentials).
 //
 // resolver (optional, nil-safe) symbolizes captured stacks: it stamps the
 // per-process build-id onto every StackRef and backs the ResolveStack RPC. Pass
 // set.HeapEBPF when non-nil; nil leaves heap events without stack references.
 func Run(ctx context.Context, addr string, pid int, cols []collector.Collector, resolver StackResolver, opts Options) error {
+	// Resolve transport security first: a missing certificate or a refused
+	// cleartext endpoint should fail before anything is bound.
+	creds, mode, err := serverCredentials(addr, opts.TLS)
+	if err != nil {
+		return err
+	}
+
 	lis, cleanup, err := listen(addr)
 	if err != nil {
 		return err
 	}
 	defer cleanup()
 
+	return runServer(ctx, lis, creds, mode, pid, cols, resolver, opts)
+}
+
+// runServer owns everything after the listener exists: the hub, the sinks, the
+// gRPC server and the shutdown. Split out of Run so tests can drive a real
+// server on an ephemeral tcp port (listen() picks it, only lis knows it).
+func runServer(ctx context.Context, lis net.Listener, creds credentials.TransportCredentials, mode string, pid int, cols []collector.Collector, resolver StackResolver, opts Options) error {
 	var buildID string
 	if resolver != nil {
 		buildID = resolver.ProcessBuildID()
@@ -61,7 +82,7 @@ func Run(ctx context.Context, addr string, pid int, cols []collector.Collector, 
 		fmt.Fprintf(os.Stderr, "[ptop] also exporting events to %s\n", opts.JSONLPath)
 	}
 
-	srv := grpc.NewServer()
+	srv := grpc.NewServer(grpc.Creds(creds))
 	pb.RegisterEventStreamServiceServer(srv, &eventStreamService{hub: hub, resolver: resolver})
 
 	// On cancel, Stop() (not GracefulStop): Subscribe streams are long-lived and
@@ -72,7 +93,12 @@ func Run(ctx context.Context, addr string, pid int, cols []collector.Collector, 
 		srv.Stop()
 	}()
 
-	fmt.Fprintf(os.Stderr, "[ptop] serving events for pid %d on %s\n", pid, addr)
+	if mode == modePlaintext {
+		fmt.Fprintln(os.Stderr, "[ptop] ⚠ --serve-insecure: this TCP stream is unencrypted and")
+		fmt.Fprintln(os.Stderr, "       unauthenticated. Anyone who reaches the port reads process internals.")
+	}
+	fmt.Fprintf(os.Stderr, "[ptop] serving events for pid %d on %s://%s (%s)\n",
+		pid, lis.Addr().Network(), lis.Addr().String(), mode)
 	if err := srv.Serve(lis); err != nil {
 		return fmt.Errorf("serve: %w", err)
 	}

--- a/internal/serve/tls.go
+++ b/internal/serve/tls.go
@@ -1,0 +1,124 @@
+package serve
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+
+	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/credentials/insecure"
+)
+
+// TLSOptions configures the transport security of a `tcp://` --serve endpoint
+// (issue #95). The zero value means "no TLS configured", which is only allowed
+// for a unix socket or with AllowInsecure explicitly set.
+//
+// A unix socket needs none of this: it never leaves the host and listen()
+// already restricts it to its owner (0600). TCP is the exposed case — the
+// stream carries heap call sites, filesystem paths and, with --tls-bytes, TLS
+// plaintext of the target, so cleartext on the wire has to be a decision
+// instead of the default.
+type TLSOptions struct {
+	// CertFile and KeyFile are the server's PEM certificate and private key.
+	// Set both to serve TLS.
+	CertFile string
+	KeyFile  string
+
+	// ClientCAFile is a PEM CA bundle. When set, clients must present a
+	// certificate signed by it — that is the mTLS mode.
+	ClientCAFile string
+
+	// AllowInsecure opts into a plaintext TCP listener. Without it, a `tcp://`
+	// address and no certificate is an error, not a silent downgrade.
+	AllowInsecure bool
+}
+
+// configured reports whether any certificate path was given.
+func (o TLSOptions) configured() bool {
+	return o.CertFile != "" || o.KeyFile != "" || o.ClientCAFile != ""
+}
+
+// Transport modes reported by serverCredentials, for the startup log line.
+const (
+	modeUnix      = "unix socket, owner-only"
+	modeTLS       = "TLS"
+	modeMTLS      = "mTLS, client certificate required"
+	modePlaintext = "PLAINTEXT — cleartext on the wire"
+)
+
+// serverCredentials turns addr + o into the gRPC transport credentials to serve
+// with, plus a short human-readable mode for the startup log. It is the policy
+// gate for issue #95: TLS material belongs to tcp:// endpoints, a tcp://
+// endpoint without it must be opted into, and contradictory flags fail here
+// rather than resolving to whichever one the code happens to read first.
+//
+// It is called before the listener is created, so a bad certificate path fails
+// before anything is bound.
+func serverCredentials(addr string, o TLSOptions) (credentials.TransportCredentials, string, error) {
+	if strings.HasPrefix(addr, "unix://") {
+		if o.configured() {
+			return nil, "", fmt.Errorf(
+				"serve: --serve-tls-* configures a tcp:// endpoint, but %q is a unix socket "+
+					"(already restricted to its owner, 0600) — drop the TLS flags or serve on tcp://", addr)
+		}
+		if o.AllowInsecure {
+			return nil, "", fmt.Errorf(
+				"serve: --serve-insecure is about cleartext TCP, but %q is a unix socket — drop the flag", addr)
+		}
+		return insecure.NewCredentials(), modeUnix, nil
+	}
+
+	switch {
+	case o.CertFile != "" && o.KeyFile == "":
+		return nil, "", errors.New("serve: --serve-tls-cert needs --serve-tls-key")
+	case o.KeyFile != "" && o.CertFile == "":
+		return nil, "", errors.New("serve: --serve-tls-key needs --serve-tls-cert")
+	case o.CertFile == "" && o.ClientCAFile != "":
+		return nil, "", errors.New(
+			"serve: --serve-tls-client-ca requires --serve-tls-cert/--serve-tls-key — " +
+				"verifying client certificates still needs a server certificate")
+	case o.CertFile != "" && o.AllowInsecure:
+		return nil, "", errors.New(
+			"serve: --serve-insecure contradicts --serve-tls-cert — pick cleartext or TLS, not both")
+	case o.CertFile == "" && !o.AllowInsecure:
+		return nil, "", fmt.Errorf(
+			"serve: refusing to serve %s in cleartext — the stream carries process internals "+
+				"(heap call sites, filesystem paths, and TLS plaintext with --tls-bytes). "+
+				"Pass --serve-tls-cert/--serve-tls-key (add --serve-tls-client-ca for mTLS), "+
+				"or --serve-insecure to accept cleartext deliberately", addr)
+	case o.CertFile == "":
+		return insecure.NewCredentials(), modePlaintext, nil
+	}
+
+	cert, err := tls.LoadX509KeyPair(o.CertFile, o.KeyFile)
+	if err != nil {
+		return nil, "", fmt.Errorf("serve: load tls keypair: %w", err)
+	}
+	// TLS 1.2 floor: 1.0/1.1 are deprecated (RFC 8996), while Go's 1.2 defaults
+	// already offer only AEAD suites with forward secrecy. Requiring 1.3 would
+	// buy little here and lock out consumers on older gRPC stacks.
+	cfg := &tls.Config{
+		Certificates: []tls.Certificate{cert},
+		MinVersion:   tls.VersionTLS12,
+	}
+	mode := modeTLS
+
+	if o.ClientCAFile != "" {
+		pem, err := os.ReadFile(o.ClientCAFile)
+		if err != nil {
+			return nil, "", fmt.Errorf("serve: read client CA: %w", err)
+		}
+		pool := x509.NewCertPool()
+		if !pool.AppendCertsFromPEM(pem) {
+			return nil, "", fmt.Errorf("serve: no certificate found in client CA %q", o.ClientCAFile)
+		}
+		cfg.ClientCAs = pool
+		cfg.ClientAuth = tls.RequireAndVerifyClientCert
+		mode = modeMTLS
+	}
+
+	return credentials.NewTLS(cfg), mode, nil
+}

--- a/internal/serve/tls_test.go
+++ b/internal/serve/tls_test.go
@@ -1,0 +1,393 @@
+package serve
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"net"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/credentials/insecure"
+
+	"github.com/trentas/ptop/pkg/collector"
+	pb "github.com/trentas/ptop/pkg/streampb"
+)
+
+// --- certificate fixtures -------------------------------------------------
+//
+// Everything is generated in-process: a CA, a server leaf with a 127.0.0.1 IP
+// SAN (the tests dial by IP) and client leaves. No checked-in key material, and
+// nothing expires on us.
+
+type testCA struct {
+	cert    *x509.Certificate
+	key     *ecdsa.PrivateKey
+	certPEM []byte
+}
+
+func newTestCA(t *testing.T, cn string) *testCA {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("ca key: %v", err)
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: cn},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(time.Hour),
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageDigitalSignature,
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	if err != nil {
+		t.Fatalf("ca cert: %v", err)
+	}
+	cert, err := x509.ParseCertificate(der)
+	if err != nil {
+		t.Fatalf("parse ca: %v", err)
+	}
+	return &testCA{
+		cert:    cert,
+		key:     key,
+		certPEM: pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der}),
+	}
+}
+
+// issue signs a leaf certificate and returns its PEM cert and key bytes.
+func (ca *testCA) issue(t *testing.T, cn string, server bool) (certPEM, keyPEM []byte) {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("leaf key: %v", err)
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(time.Now().UnixNano()),
+		Subject:      pkix.Name{CommonName: cn},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+	}
+	if server {
+		tmpl.ExtKeyUsage = []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth}
+		tmpl.IPAddresses = []net.IP{net.ParseIP("127.0.0.1"), net.IPv6loopback}
+	} else {
+		tmpl.ExtKeyUsage = []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth}
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, ca.cert, &key.PublicKey, ca.key)
+	if err != nil {
+		t.Fatalf("leaf cert: %v", err)
+	}
+	keyDER, err := x509.MarshalECPrivateKey(key)
+	if err != nil {
+		t.Fatalf("marshal leaf key: %v", err)
+	}
+	return pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der}),
+		pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: keyDER})
+}
+
+// writePEM drops bytes into dir/name and returns the path.
+func writePEM(t *testing.T, dir, name string, b []byte) string {
+	t.Helper()
+	path := filepath.Join(dir, name)
+	if err := os.WriteFile(path, b, 0o600); err != nil {
+		t.Fatalf("write %s: %v", name, err)
+	}
+	return path
+}
+
+// serverFiles issues a server keypair from ca and writes cert/key/CA to dir.
+func serverFiles(t *testing.T, ca *testCA, dir string) (certPath, keyPath, caPath string) {
+	t.Helper()
+	certPEM, keyPEM := ca.issue(t, "ptop-server", true)
+	return writePEM(t, dir, "server.crt", certPEM),
+		writePEM(t, dir, "server.key", keyPEM),
+		writePEM(t, dir, "ca.crt", ca.certPEM)
+}
+
+// clientCreds builds client-side credentials trusting ca, optionally presenting
+// a certificate issued by certCA (nil = no client certificate).
+func clientCreds(t *testing.T, ca *testCA, certCA *testCA) credentials.TransportCredentials {
+	t.Helper()
+	pool := x509.NewCertPool()
+	if !pool.AppendCertsFromPEM(ca.certPEM) {
+		t.Fatal("client pool: no cert in CA PEM")
+	}
+	cfg := &tls.Config{RootCAs: pool, MinVersion: tls.VersionTLS12}
+	if certCA != nil {
+		certPEM, keyPEM := certCA.issue(t, "witness", false)
+		pair, err := tls.X509KeyPair(certPEM, keyPEM)
+		if err != nil {
+			t.Fatalf("client keypair: %v", err)
+		}
+		// GetClientCertificate, not Certificates: with Certificates the Go client
+		// silently withholds a certificate whose issuer is not in the server's
+		// advertised CA list, so an untrusted cert would look like "no cert at
+		// all" and the server-side verification would never run. Forcing the send
+		// is what puts RequireAndVerifyClientCert under test.
+		cfg.GetClientCertificate = func(*tls.CertificateRequestInfo) (*tls.Certificate, error) {
+			return &pair, nil
+		}
+	}
+	return credentials.NewTLS(cfg)
+}
+
+// --- the server under test ------------------------------------------------
+
+// startTCPServer brings up a real gRPC server on 127.0.0.1:0 through the same
+// runServer path Run uses, with credentials resolved by serverCredentials from
+// opts, and a fake collector emitting CPU samples. It returns the dial target.
+func startTCPServer(ctx context.Context, t *testing.T, opts TLSOptions) string {
+	t.Helper()
+	addr := "tcp://127.0.0.1:0"
+
+	creds, _, err := serverCredentials(addr, opts)
+	if err != nil {
+		t.Fatalf("serverCredentials: %v", err)
+	}
+	lis, cleanup, err := listen(addr)
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	t.Cleanup(cleanup)
+
+	f := newFake(64)
+	go func() {
+		tick := time.NewTicker(10 * time.Millisecond)
+		defer tick.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-tick.C:
+				select {
+				case f.ch <- collector.CpuSample{UsagePct: 42, Timestamp: time.Now()}:
+				default:
+				}
+			}
+		}
+	}()
+
+	target := lis.Addr().String()
+	done := make(chan error, 1)
+	go func() {
+		done <- runServer(ctx, lis, creds, "test", 4242, []collector.Collector{f}, nil, Options{})
+	}()
+	t.Cleanup(func() {
+		select {
+		case <-done:
+		case <-time.After(3 * time.Second):
+			t.Error("runServer did not return after cancel")
+		}
+	})
+	return target
+}
+
+// firstEvent subscribes and returns the first event, or the error that stopped
+// it. Used both for the success path and for the handshake-refusal paths, where
+// the failure surfaces on Subscribe or on the first Recv depending on timing.
+func firstEvent(ctx context.Context, target string, creds credentials.TransportCredentials) (*pb.Event, error) {
+	conn, err := grpc.NewClient(target, grpc.WithTransportCredentials(creds))
+	if err != nil {
+		return nil, err
+	}
+	defer conn.Close()
+
+	recvCtx, cancel := context.WithTimeout(ctx, 3*time.Second)
+	defer cancel()
+	stream, err := pb.NewEventStreamServiceClient(conn).Subscribe(recvCtx, &pb.SubscribeRequest{})
+	if err != nil {
+		return nil, err
+	}
+	resp, err := stream.Recv()
+	if err != nil {
+		return nil, err
+	}
+	return resp.GetEvent(), nil
+}
+
+// A subscriber presenting a certificate from the trusted CA streams events
+// end-to-end over mTLS — the acceptance case of #95.
+func TestServeMTLSEndToEnd(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	ca := newTestCA(t, "ptop-test-ca")
+	dir := t.TempDir()
+	cert, key, caPath := serverFiles(t, ca, dir)
+
+	target := startTCPServer(ctx, t, TLSOptions{CertFile: cert, KeyFile: key, ClientCAFile: caPath})
+
+	ev, err := firstEvent(ctx, target, clientCreds(t, ca, ca))
+	if err != nil {
+		t.Fatalf("mTLS subscriber failed: %v", err)
+	}
+	if ev == nil || ev.GetCategory() != pb.Category_CATEGORY_CPU {
+		t.Fatalf("unexpected first event: %v", ev)
+	}
+	if ev.GetPid() != 4242 {
+		t.Errorf("pid = %d, want 4242", ev.GetPid())
+	}
+}
+
+// With --serve-tls-client-ca, a client that presents no certificate must be
+// refused: that is the difference between mTLS and plain server-side TLS.
+func TestServeMTLSRejectsClientWithoutCert(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	ca := newTestCA(t, "ptop-test-ca")
+	cert, key, caPath := serverFiles(t, ca, t.TempDir())
+	target := startTCPServer(ctx, t, TLSOptions{CertFile: cert, KeyFile: key, ClientCAFile: caPath})
+
+	_, err := firstEvent(ctx, target, clientCreds(t, ca, nil))
+	if err == nil {
+		t.Fatal("subscriber without a client certificate was served; want handshake failure")
+	}
+	if !strings.Contains(err.Error(), "certificate required") {
+		t.Errorf("error = %q, want the server to demand a client certificate", err)
+	}
+}
+
+// A client certificate signed by some other CA is not a client certificate.
+func TestServeMTLSRejectsUntrustedClientCert(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	ca := newTestCA(t, "ptop-test-ca")
+	rogue := newTestCA(t, "rogue-ca")
+	cert, key, caPath := serverFiles(t, ca, t.TempDir())
+	target := startTCPServer(ctx, t, TLSOptions{CertFile: cert, KeyFile: key, ClientCAFile: caPath})
+
+	_, err := firstEvent(ctx, target, clientCreds(t, ca, rogue))
+	if err == nil {
+		t.Fatal("client certificate from an untrusted CA was accepted")
+	}
+	// The certificate is sent (see clientCreds) and rejected by the server's
+	// RequireAndVerifyClientCert against ClientCAs — not withheld by the client.
+	if !strings.Contains(err.Error(), "unknown certificate authority") {
+		t.Errorf("error = %q, want rejection by the server's client CA", err)
+	}
+}
+
+// A plaintext client gets nothing out of a TLS endpoint (the inverse of the
+// exposure #95 is about: no accidental cleartext fallback).
+func TestServeTLSRefusesPlaintextClient(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	ca := newTestCA(t, "ptop-test-ca")
+	cert, key, _ := serverFiles(t, ca, t.TempDir())
+	target := startTCPServer(ctx, t, TLSOptions{CertFile: cert, KeyFile: key})
+
+	// The exact transport error here is platform-dependent (the server drops the
+	// connection mid-handshake), so only the refusal itself is asserted.
+	if ev, err := firstEvent(ctx, target, insecure.NewCredentials()); err == nil {
+		t.Fatalf("plaintext client was served by a TLS endpoint: got event %v", ev)
+	}
+}
+
+// --serve-insecure still works, so the opt-in is a real escape hatch.
+func TestServeInsecureTCPStillStreams(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	target := startTCPServer(ctx, t, TLSOptions{AllowInsecure: true})
+	ev, err := firstEvent(ctx, target, insecure.NewCredentials())
+	if err != nil {
+		t.Fatalf("plaintext subscriber failed with --serve-insecure: %v", err)
+	}
+	if ev.GetCategory() != pb.Category_CATEGORY_CPU {
+		t.Fatalf("unexpected first event: %v", ev)
+	}
+}
+
+// --- policy table ---------------------------------------------------------
+
+func TestServerCredentialsPolicy(t *testing.T) {
+	ca := newTestCA(t, "ptop-test-ca")
+	dir := t.TempDir()
+	cert, key, caPath := serverFiles(t, ca, dir)
+	notPEM := writePEM(t, dir, "garbage.crt", []byte("not a certificate\n"))
+
+	const tcp, unix = "tcp://127.0.0.1:50051", "unix:///tmp/ptop.sock"
+
+	cases := []struct {
+		name     string
+		addr     string
+		opts     TLSOptions
+		wantMode string // "" = expect an error
+		wantErr  string // substring, checked when wantMode == ""
+	}{
+		{name: "unix bare", addr: unix, wantMode: modeUnix},
+		{name: "unix with cert", addr: unix, opts: TLSOptions{CertFile: cert, KeyFile: key},
+			wantErr: "unix socket"},
+		{name: "unix with insecure", addr: unix, opts: TLSOptions{AllowInsecure: true},
+			wantErr: "cleartext TCP"},
+
+		{name: "tcp bare is refused", addr: tcp, wantErr: "refusing to serve"},
+		{name: "tcp opt-in plaintext", addr: tcp, opts: TLSOptions{AllowInsecure: true},
+			wantMode: modePlaintext},
+		{name: "tcp tls", addr: tcp, opts: TLSOptions{CertFile: cert, KeyFile: key},
+			wantMode: modeTLS},
+		{name: "tcp mtls", addr: tcp, opts: TLSOptions{CertFile: cert, KeyFile: key, ClientCAFile: caPath},
+			wantMode: modeMTLS},
+
+		{name: "cert without key", addr: tcp, opts: TLSOptions{CertFile: cert},
+			wantErr: "needs --serve-tls-key"},
+		{name: "key without cert", addr: tcp, opts: TLSOptions{KeyFile: key},
+			wantErr: "needs --serve-tls-cert"},
+		{name: "client ca alone", addr: tcp, opts: TLSOptions{ClientCAFile: caPath},
+			wantErr: "requires --serve-tls-cert"},
+		{name: "tls plus insecure contradict", addr: tcp,
+			opts:    TLSOptions{CertFile: cert, KeyFile: key, AllowInsecure: true},
+			wantErr: "contradicts"},
+
+		{name: "missing cert file", addr: tcp,
+			opts:    TLSOptions{CertFile: filepath.Join(dir, "nope.crt"), KeyFile: key},
+			wantErr: "load tls keypair"},
+		{name: "missing client ca file", addr: tcp,
+			opts:    TLSOptions{CertFile: cert, KeyFile: key, ClientCAFile: filepath.Join(dir, "nope.crt")},
+			wantErr: "read client CA"},
+		{name: "client ca without a certificate in it", addr: tcp,
+			opts:    TLSOptions{CertFile: cert, KeyFile: key, ClientCAFile: notPEM},
+			wantErr: "no certificate found"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			creds, mode, err := serverCredentials(tc.addr, tc.opts)
+			if tc.wantMode == "" {
+				if err == nil {
+					t.Fatalf("serverCredentials = mode %q, want error containing %q", mode, tc.wantErr)
+				}
+				if !strings.Contains(err.Error(), tc.wantErr) {
+					t.Errorf("error = %q, want it to contain %q", err, tc.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("serverCredentials: %v", err)
+			}
+			if mode != tc.wantMode {
+				t.Errorf("mode = %q, want %q", mode, tc.wantMode)
+			}
+			if creds == nil {
+				t.Error("credentials are nil")
+			}
+		})
+	}
+}

--- a/internal/serve/tls_test.go
+++ b/internal/serve/tls_test.go
@@ -118,9 +118,15 @@ func serverFiles(t *testing.T, ca *testCA, dir string) (certPath, keyPath, caPat
 		writePEM(t, dir, "ca.crt", ca.certPEM)
 }
 
-// clientCreds builds client-side credentials trusting ca, optionally presenting
-// a certificate issued by certCA (nil = no client certificate).
+// clientCreds wraps clientTLSConfig as gRPC transport credentials.
 func clientCreds(t *testing.T, ca *testCA, certCA *testCA) credentials.TransportCredentials {
+	t.Helper()
+	return credentials.NewTLS(clientTLSConfig(t, ca, certCA))
+}
+
+// clientTLSConfig builds a client-side tls.Config trusting ca, optionally
+// presenting a certificate issued by certCA (nil = no client certificate).
+func clientTLSConfig(t *testing.T, ca *testCA, certCA *testCA) *tls.Config {
 	t.Helper()
 	pool := x509.NewCertPool()
 	if !pool.AppendCertsFromPEM(ca.certPEM) {
@@ -142,7 +148,30 @@ func clientCreds(t *testing.T, ca *testCA, certCA *testCA) credentials.Transport
 			return &pair, nil
 		}
 	}
-	return credentials.NewTLS(cfg)
+	return cfg
+}
+
+// tlsHandshakeErr dials target and reads one byte, returning the error the
+// server ends the connection with.
+//
+// Reading is the point: under TLS 1.3 the client finishes its side of the
+// handshake before the server has judged the client certificate, so tls.Dial
+// itself usually succeeds and the server's alert only lands on the next read.
+// Through gRPC the same rejection surfaces as whatever operation happens to
+// lose the race — a plain "broken pipe" on the request write, on Linux — so the
+// *reason* for a refusal is asserted here instead.
+func tlsHandshakeErr(t *testing.T, target string, cfg *tls.Config) error {
+	t.Helper()
+	conn, err := tls.Dial("tcp", target, cfg)
+	if err != nil {
+		return err
+	}
+	defer conn.Close()
+	if err := conn.SetDeadline(time.Now().Add(3 * time.Second)); err != nil {
+		t.Fatalf("set deadline: %v", err)
+	}
+	_, err = conn.Read(make([]byte, 1))
+	return err
 }
 
 // --- the server under test ------------------------------------------------
@@ -253,9 +282,12 @@ func TestServeMTLSRejectsClientWithoutCert(t *testing.T) {
 	cert, key, caPath := serverFiles(t, ca, t.TempDir())
 	target := startTCPServer(ctx, t, TLSOptions{CertFile: cert, KeyFile: key, ClientCAFile: caPath})
 
-	_, err := firstEvent(ctx, target, clientCreds(t, ca, nil))
+	if ev, err := firstEvent(ctx, target, clientCreds(t, ca, nil)); err == nil {
+		t.Fatalf("subscriber without a client certificate was served: got event %v", ev)
+	}
+	err := tlsHandshakeErr(t, target, clientTLSConfig(t, ca, nil))
 	if err == nil {
-		t.Fatal("subscriber without a client certificate was served; want handshake failure")
+		t.Fatal("TLS connection without a client certificate stayed open")
 	}
 	if !strings.Contains(err.Error(), "certificate required") {
 		t.Errorf("error = %q, want the server to demand a client certificate", err)
@@ -272,12 +304,15 @@ func TestServeMTLSRejectsUntrustedClientCert(t *testing.T) {
 	cert, key, caPath := serverFiles(t, ca, t.TempDir())
 	target := startTCPServer(ctx, t, TLSOptions{CertFile: cert, KeyFile: key, ClientCAFile: caPath})
 
-	_, err := firstEvent(ctx, target, clientCreds(t, ca, rogue))
-	if err == nil {
-		t.Fatal("client certificate from an untrusted CA was accepted")
+	if ev, err := firstEvent(ctx, target, clientCreds(t, ca, rogue)); err == nil {
+		t.Fatalf("client certificate from an untrusted CA was accepted: got event %v", ev)
 	}
-	// The certificate is sent (see clientCreds) and rejected by the server's
+	// The certificate is sent (see clientTLSConfig) and rejected by the server's
 	// RequireAndVerifyClientCert against ClientCAs — not withheld by the client.
+	err := tlsHandshakeErr(t, target, clientTLSConfig(t, ca, rogue))
+	if err == nil {
+		t.Fatal("TLS connection with an untrusted client certificate stayed open")
+	}
 	if !strings.Contains(err.Error(), "unknown certificate authority") {
 		t.Errorf("error = %q, want rejection by the server's client CA", err)
 	}


### PR DESCRIPTION
Closes #95.

The gRPC stream was plaintext on every transport. On a unix socket that is fine — it never leaves the host and the socket is `0600` — but the Kubernetes path is pod-to-pod TCP, and the whole raw stream goes over it: syscalls, heap call sites, filesystem paths and, with `--tls-bytes`, the target's decrypted TLS payload. Refusing to bind `0.0.0.0`/`::` bounded *who could reach the port*; it did nothing about *what crossed the wire* or *who was on the other end*.

## What this does

`internal/serve/tls.go` adds `serverCredentials(addr, TLSOptions)` as the single policy gate, resolved **before** the listener is created so a bad certificate path fails before anything binds.

| Configuration | Result |
|---|---|
| `--serve-tls-cert` + `--serve-tls-key` | server-side TLS (1.2 floor) |
| ↑ plus `--serve-tls-client-ca` | `RequireAndVerifyClientCert` — mTLS |
| `--serve-insecure` | cleartext TCP, deliberate, warned on stderr |
| bare `tcp://` | **refused at startup** |
| `unix://` with TLS flags | refused — file permissions are the boundary there |
| contradictory combinations | fail fast instead of electing a silent winner |

`Run` splits into `Run` + `runServer` so tests can drive a real server on an ephemeral port (`listen()` picks it; only the listener knows which).

## Flag naming

The issue sketched `--tls-cert`/`--tls-key`. These land as `--serve-tls-*` instead, because `--tls`/`--tls-bytes` already mean the **opposite direction** — capturing the *target's* plaintext via libssl uprobes (#55). Five flags under one prefix carrying two unrelated meanings is a `--help` nobody can read, and renaming after a release would be breaking.

## Verification

- 5 end-to-end tests over a real gRPC server plus a 14-case policy table; green under `-race`.
- The untrusted-client-cert test initially passed for a weak reason: the Go client **withholds** a certificate that does not chain to the server's advertised CA, so the server-side check never ran and the failure was indistinguishable from "no certificate". Forcing the send via `GetClientCertificate` puts `RequireAndVerifyClientCert` under test for real — the error is now `unknown certificate authority`.
- Against the real binary with `openssl s_client`: TLS alert 116 (`certificate_required`) without a certificate, complete handshake with one, TLS 1.3 + ALPN h2. All four refusal paths exit 1 with an actionable message.

## Out of scope

- Matching **client** flags live in the witness repo, not here.
- **Certificate rotation**: the certificate is read once at startup, so a cert-manager secret rotation needs a pod restart. Documented in the README rather than implemented — it was not in the acceptance criteria; worth its own issue if you want hot reload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)