### PR TITLE
serve: reload TLS material on change, no restart for a rotated certificate

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -102,7 +102,7 @@ ptop/
 │   │   └── *_stub.go              stubs for non-Linux / no-ebpf builds
 │   ├── serve/                     headless gRPC server (ptop --serve)
 │   │   ├── serve.go               addr parse + privilege boundary + Run
-│   │   ├── tls.go                 transport security policy: TLS/mTLS or opt-in cleartext (#95)
+│   │   ├── tls.go                 transport security: TLS/mTLS policy + hot reload (#95)
 │   │   ├── hub.go                 fan-in collectors → fan-out to sinks
 │   │   ├── sink.go                Sink iface: gRPC subscriber + JSONL writer
 │   │   ├── service.go             EventStream gRPC service impl
@@ -422,7 +422,13 @@ Version metadata is injected via `-ldflags` at release time
   `RequireAndVerifyClientCert`) or an explicit `--serve-insecure`; a bare
   `tcp://` is refused at startup. Unix sockets take no TLS at all (the flags are
   refused there — file permissions are the boundary), and contradictory
-  combinations fail fast rather than silently picking a winner. Mind the naming:
+  combinations fail fast rather than silently picking a winner. The material is
+  loaded through `tlsReloader`, hooked in as `tls.Config.GetConfigForClient`, so
+  a rotated certificate or client CA bundle is adopted on the next handshake
+  (fingerprint = size + mtime; a failed reload keeps the last good config and
+  warns). Note the trap it documents: a config returned by `GetConfigForClient`
+  replaces the outer one wholesale, so it must carry `NextProtos: ["h2"]` or
+  every gRPC client fails ALPN. Mind the naming:
   `--tls`/`--tls-bytes` capture the **target's** plaintext, `--serve-tls-*`
   encrypt **ptop's own** stream.
 - TLS payload capture (`--tls`/`--tls-bytes`, #55) observes plaintext and is

--- a/README.md
+++ b/README.md
@@ -247,8 +247,13 @@ endpoint:
 A `tcp://` endpoint with no certificate and no `--serve-insecure` is **refused
 at startup**: cleartext on the wire is a decision, not a default. Binding all
 interfaces (`0.0.0.0`/`::`) is refused either way — bind loopback or a specific
-interface IP. TLS 1.2 is the floor, and the certificate is read once at startup
-(rotate it by restarting the process).
+interface IP. TLS 1.2 is the floor.
+
+The certificate and the client CA bundle are re-read from disk whenever they
+change, so a rotated secret (cert-manager and friends) is picked up on the next
+handshake with no restart. If a rotation lands broken — a key caught
+half-written — the last good material keeps serving and the reason goes to
+stderr, because dropping every subscriber is the worse failure.
 
 > Not to be confused with `--tls`/`--tls-bytes`, which are the opposite
 > direction: those capture the *target's* TLS plaintext. `--serve-tls-*`

--- a/internal/serve/tls.go
+++ b/internal/serve/tls.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"sync"
 
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/insecure"
@@ -93,32 +94,131 @@ func serverCredentials(addr string, o TLSOptions) (credentials.TransportCredenti
 		return insecure.NewCredentials(), modePlaintext, nil
 	}
 
+	// Load once here so a bad path, an unreadable key or an empty CA bundle is a
+	// startup error rather than a handshake-time surprise.
+	r := &tlsReloader{opts: o}
+	if _, err := r.current(); err != nil {
+		return nil, "", err
+	}
+
+	mode := modeTLS
+	if o.ClientCAFile != "" {
+		mode = modeMTLS
+	}
+
+	// GetConfigForClient, not a fixed Certificates list: the config is rebuilt
+	// from disk whenever the files change, so rotating certificates (or the
+	// client CA bundle) does not need a restart.
+	return credentials.NewTLS(&tls.Config{
+		MinVersion:         tls.VersionTLS12,
+		GetConfigForClient: r.configForClient,
+	}), mode, nil
+}
+
+// tlsReloader keeps the server's TLS config in sync with the files it was built
+// from. A long-running ptop outlives its certificate: cert-manager and friends
+// rotate the secret under the process, and without this the endpoint would keep
+// presenting the expired material until someone restarted the pod.
+type tlsReloader struct {
+	opts TLSOptions
+
+	mu    sync.Mutex
+	stamp string      // identity of the files behind cur
+	cur   *tls.Config // last successfully built config
+}
+
+// configForClient is the tls.Config.GetConfigForClient hook: it runs once per
+// handshake, which is where a rotation gets noticed.
+func (r *tlsReloader) configForClient(*tls.ClientHelloInfo) (*tls.Config, error) {
+	return r.current()
+}
+
+// current returns the cached config, rebuilding it when the files changed.
+func (r *tlsReloader) current() (*tls.Config, error) {
+	stamp := r.fingerprint()
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.cur != nil && stamp == r.stamp {
+		return r.cur, nil
+	}
+
+	cfg, err := buildServerTLSConfig(r.opts)
+	if err != nil {
+		if r.cur == nil {
+			return nil, err // startup: nothing to fall back to
+		}
+		// Mid-flight the files can be briefly inconsistent (a half-written key,
+		// a cert swapped a moment before its key). Dropping the endpoint over
+		// that would be worse than serving the material that still works, so
+		// keep the last good config and say so. Adopting the stamp keeps this to
+		// one line per broken state instead of one per handshake.
+		fmt.Fprintf(os.Stderr, "[ptop] TLS material changed but does not load (%v) — still serving the previous certificate\n", err)
+		r.stamp = stamp
+		return r.cur, nil
+	}
+
+	if r.cur != nil {
+		fmt.Fprintln(os.Stderr, "[ptop] reloaded TLS material after a change on disk")
+	}
+	r.cur, r.stamp = cfg, stamp
+	return cfg, nil
+}
+
+// fingerprint identifies the current TLS files by size and modification time.
+// A content hash would be exact, but this runs on every handshake while
+// rotation happens on the order of hours — three stat calls is the right price.
+// A missing file gets its own marker so the reload retries once it reappears.
+func (r *tlsReloader) fingerprint() string {
+	var b strings.Builder
+	for _, f := range []string{r.opts.CertFile, r.opts.KeyFile, r.opts.ClientCAFile} {
+		if f == "" {
+			continue
+		}
+		fi, err := os.Stat(f)
+		if err != nil {
+			fmt.Fprintf(&b, "%s:absent;", f)
+			continue
+		}
+		fmt.Fprintf(&b, "%s:%d:%d;", f, fi.Size(), fi.ModTime().UnixNano())
+	}
+	return b.String()
+}
+
+// buildServerTLSConfig reads the certificate (and client CA bundle, for mTLS)
+// off disk into a server tls.Config.
+func buildServerTLSConfig(o TLSOptions) (*tls.Config, error) {
 	cert, err := tls.LoadX509KeyPair(o.CertFile, o.KeyFile)
 	if err != nil {
-		return nil, "", fmt.Errorf("serve: load tls keypair: %w", err)
+		return nil, fmt.Errorf("serve: load tls keypair: %w", err)
 	}
+
 	// TLS 1.2 floor: 1.0/1.1 are deprecated (RFC 8996), while Go's 1.2 defaults
 	// already offer only AEAD suites with forward secrecy. Requiring 1.3 would
 	// buy little here and lock out consumers on older gRPC stacks.
+	//
+	// NextProtos has to be set here too: a config returned by
+	// GetConfigForClient replaces the outer one wholesale, including the "h2"
+	// ALPN protocol gRPC put there — and a gRPC client that cannot negotiate h2
+	// is refused.
 	cfg := &tls.Config{
 		Certificates: []tls.Certificate{cert},
 		MinVersion:   tls.VersionTLS12,
+		NextProtos:   []string{"h2"},
 	}
-	mode := modeTLS
 
 	if o.ClientCAFile != "" {
 		pem, err := os.ReadFile(o.ClientCAFile)
 		if err != nil {
-			return nil, "", fmt.Errorf("serve: read client CA: %w", err)
+			return nil, fmt.Errorf("serve: read client CA: %w", err)
 		}
 		pool := x509.NewCertPool()
 		if !pool.AppendCertsFromPEM(pem) {
-			return nil, "", fmt.Errorf("serve: no certificate found in client CA %q", o.ClientCAFile)
+			return nil, fmt.Errorf("serve: no certificate found in client CA %q", o.ClientCAFile)
 		}
 		cfg.ClientCAs = pool
 		cfg.ClientAuth = tls.RequireAndVerifyClientCert
-		mode = modeMTLS
 	}
 
-	return credentials.NewTLS(cfg), mode, nil
+	return cfg, nil
 }

--- a/internal/serve/tls_test.go
+++ b/internal/serve/tls_test.go
@@ -426,3 +426,120 @@ func TestServerCredentialsPolicy(t *testing.T) {
 		})
 	}
 }
+
+// --- rotation -------------------------------------------------------------
+
+// rewrite replaces a PEM file's contents and pushes its modification time
+// forward. The push is what makes the test deterministic: the reloader
+// fingerprints files by size and mtime, and a test rewriting a same-sized file
+// within one filesystem timestamp tick would otherwise look unchanged.
+func rewrite(t *testing.T, path string, b []byte) {
+	t.Helper()
+	if err := os.WriteFile(path, b, 0o600); err != nil {
+		t.Fatalf("rewrite %s: %v", path, err)
+	}
+	future := time.Now().Add(time.Second)
+	if err := os.Chtimes(path, future, future); err != nil {
+		t.Fatalf("chtimes %s: %v", path, err)
+	}
+}
+
+// servedLeaf handshakes with the server and returns the certificate it
+// presented.
+func servedLeaf(t *testing.T, target string, cfg *tls.Config) *x509.Certificate {
+	t.Helper()
+	conn, err := tls.Dial("tcp", target, cfg)
+	if err != nil {
+		t.Fatalf("tls dial: %v", err)
+	}
+	defer conn.Close()
+	certs := conn.ConnectionState().PeerCertificates
+	if len(certs) == 0 {
+		t.Fatal("server presented no certificate")
+	}
+	return certs[0]
+}
+
+// A certificate rotated on disk is picked up on the next handshake — no
+// restart, which is the point for a long-running process whose cert-manager
+// secret rotates under it.
+func TestServeTLSReloadsRotatedCertificate(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	ca := newTestCA(t, "ptop-test-ca")
+	cert, key, _ := serverFiles(t, ca, t.TempDir())
+	target := startTCPServer(ctx, t, TLSOptions{CertFile: cert, KeyFile: key})
+
+	before := servedLeaf(t, target, clientTLSConfig(t, ca, nil))
+
+	certPEM, keyPEM := ca.issue(t, "ptop-server-rotated", true)
+	rewrite(t, cert, certPEM)
+	rewrite(t, key, keyPEM)
+
+	after := servedLeaf(t, target, clientTLSConfig(t, ca, nil))
+	if after.SerialNumber.Cmp(before.SerialNumber) == 0 {
+		t.Fatal("server still presents the pre-rotation certificate")
+	}
+	if got := after.Subject.CommonName; got != "ptop-server-rotated" {
+		t.Errorf("served certificate CN = %q, want the rotated one", got)
+	}
+}
+
+// A torn or invalid write must not take the endpoint down: the last good
+// material keeps serving. Losing every subscriber because a key was caught
+// half-written would be a worse failure than the stale certificate.
+func TestServeTLSKeepsLastGoodOnBrokenRotation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	ca := newTestCA(t, "ptop-test-ca")
+	cert, key, _ := serverFiles(t, ca, t.TempDir())
+	target := startTCPServer(ctx, t, TLSOptions{CertFile: cert, KeyFile: key})
+
+	before := servedLeaf(t, target, clientTLSConfig(t, ca, nil))
+	rewrite(t, cert, []byte("-----BEGIN CERTIFICATE-----\ntruncated"))
+
+	after := servedLeaf(t, target, clientTLSConfig(t, ca, nil))
+	if after.SerialNumber.Cmp(before.SerialNumber) != 0 {
+		t.Error("served certificate changed after a broken rotation")
+	}
+
+	// And a later good write is still adopted — the reloader is not stuck on the
+	// failure it reported.
+	certPEM, keyPEM := ca.issue(t, "ptop-server-recovered", true)
+	rewrite(t, cert, certPEM)
+	rewrite(t, key, keyPEM)
+
+	recovered := servedLeaf(t, target, clientTLSConfig(t, ca, nil))
+	if got := recovered.Subject.CommonName; got != "ptop-server-recovered" {
+		t.Errorf("served certificate CN = %q, want the recovered one", got)
+	}
+}
+
+// The client CA bundle rotates too: a subscriber whose CA was not trusted is
+// refused, and accepted once the bundle names its CA — same running server.
+func TestServeMTLSReloadsClientCA(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	ca := newTestCA(t, "ptop-test-ca")
+	next := newTestCA(t, "ptop-next-ca")
+	cert, key, caPath := serverFiles(t, ca, t.TempDir())
+	target := startTCPServer(ctx, t, TLSOptions{CertFile: cert, KeyFile: key, ClientCAFile: caPath})
+
+	err := tlsHandshakeErr(t, target, clientTLSConfig(t, ca, next))
+	if err == nil || !strings.Contains(err.Error(), "unknown certificate authority") {
+		t.Fatalf("error = %v, want the not-yet-trusted client CA to be refused", err)
+	}
+
+	rewrite(t, caPath, next.certPEM)
+
+	ev, err := firstEvent(ctx, target, clientCreds(t, ca, next))
+	if err != nil {
+		t.Fatalf("subscriber refused after its CA was added to the bundle: %v", err)
+	}
+	if ev.GetCategory() != pb.Category_CATEGORY_CPU {
+		t.Fatalf("unexpected first event: %v", ev)
+	}
+}


### PR DESCRIPTION
Closes #97. **Stacked on #96** — base is `feat/serve-mtls`, not `main`. Merge #96 first, then retarget this to `main` (GitHub does that automatically when the base branch merges, but check the diff before merging so it does not carry #96's commits).

#95 read the certificate once, at startup. A headless ptop is a long process — a DaemonSet, on the witness path — and the secret underneath it rotates: cert-manager replaces the contents, the process keeps presenting the old material, and once that expires the stream stops accepting subscribers. Restarting is a poor answer here beyond the downtime: it drops the attached eBPF tracers and the series the consumer was accumulating.

## What this does

`tlsReloader` hooks in as `tls.Config.GetConfigForClient`, which runs per handshake — exactly when a rotation needs noticing.

- **Fingerprint by size + mtime** of cert, key and client CA. Rotation happens on the order of hours; three `stat` calls beat hashing the material on every connection.
- **The client CA bundle reloads too**, so a subscriber whose CA is added to the bundle gets in without restarting the server.
- **A failed reload keeps the last good config** and reports why. Mid-rotation the files can be briefly inconsistent (a key caught half-written, a cert swapped a moment before its key) and dropping every subscriber over a torn write is the worse failure. The stamp is adopted on failure too, so a persistently broken file logs once rather than once per handshake.

## A trap worth naming

A config returned by `GetConfigForClient` replaces the outer one **wholesale**, including the `"h2"` ALPN entry gRPC put there. Without `NextProtos` on the rebuilt config, every gRPC client fails ALPN negotiation. The existing mTLS end-to-end test from #96 is what catches it — worth knowing before anyone touches this function again.

## Verification

Three new tests (rotated cert adopted, broken rotation keeps the last good material *and* recovers on the next good write, client CA rotation flips a refused subscriber to accepted), plus the whole suite green under `-race`.

Against the real binary, same process throughout:

```
### CN served before rotation
subject= /CN=srv-old      serial=E177A159E0B67722
### files rotated in place, process untouched
### CN served after
subject= /CN=srv-new      serial=E177A159E0B67723
[ptop] reloaded TLS material after a change on disk
### then the cert is truncated
subject= /CN=srv-new
[ptop] TLS material changed but does not load (...) — still serving the previous certificate
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)