### PR TITLE
bpf: target a cgroup subtree, not just a pid (#94 groundwork)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,7 +83,8 @@ ptop/
 │   │   │   ├── proc.bpf.c         sched fork/exec/exit → exec lineage subtree (#60)
 │   │   │   └── security.bpf.c     PROT_EXEC mmap/mprotect + SELinux AVC (#59)
 │   │   ├── available.go           runtime feature flag (build-tag based)
-│   │   ├── target.go              pid-namespace target resolver (shared)
+│   │   ├── target.go              target resolver: pid-namespace + cgroup (shared)
+│   │   ├── target_spec.go         bpf.Target + cgroup path/level/id helpers (#94)
 │   │   ├── caps.go                CAP_BPF / CAP_PERFMON detection
 │   │   ├── caps_stub.go           non-Linux stub
 │   │   ├── caps_test.go
@@ -316,16 +317,42 @@ priority-based segment dropping pattern: copy it for any new dynamic strip.
 
 ---
 
-## PID namespaces
+## Target filter (PID namespaces and cgroups)
 
-eBPF programs filter the target process via `bpf_get_ns_current_pid_tgid()`,
-resolving pids inside the target's PID namespace (dev+inode of
-`/proc/<pid>/ns/pid`, written by the Go loader into `struct target_filter`).
-This is required because `bpf_get_current_pid_tgid()` returns root-namespace
-pids — wrong when ptop runs inside a nested namespace (WSL2, Docker, LXC).
-The shared logic lives in `programs/target.bpf.h` and `bpf/target.go`; never
-filter with the bare `bpf_get_current_pid_tgid()` again. Verify with
-`make ebpf-selftest` → `sudo ./bin/ebpf-selftest`.
+Every eBPF program filters through one shared helper, `pid_is_target()` in
+`programs/target.bpf.h`, reading a `struct target_filter` the Go loader wrote
+(`bpf/target.go`). It supports two ways of naming a target — `bpf.Target`,
+built with `TargetPID()` or `TargetCgroup()` (`bpf/target_spec.go`):
+
+**PID mode** resolves pids inside the target's PID namespace via
+`bpf_get_ns_current_pid_tgid()` (dev+inode of `/proc/<pid>/ns/pid`). This is
+required because `bpf_get_current_pid_tgid()` returns root-namespace pids —
+wrong when ptop runs inside a nested namespace (WSL2, Docker, LXC). Never
+filter with the bare `bpf_get_current_pid_tgid()` again.
+
+**Cgroup mode** (#94) targets a whole subtree with
+`bpf_get_current_ancestor_cgroup_id(level)`: every task inside the target
+answers with the target's own cgroup id, forks included, so no pid needs to be
+known in advance. The Go side resolves a path or container id to
+`(cgroup_id, level)` — the id being the cgroup directory's inode, which is what
+the helpers report on kernfs — and refuses level 0, the cgroup root, since that
+would trace the whole host. Cgroup v2 only: the helpers report the default
+hierarchy's id.
+
+Two caveats worth knowing before extending this:
+
+- **The uprobe collectors are pid-bound.** `heap` (#53) and `tls` (#55) attach
+  to a libc/libssl mapped into one process (`resolveLibc`, `resolveLibSSL`,
+  `link.UprobeOptions{PID: pid}`), so they take a pid, not a `Target`, and have
+  no cgroup-wide equivalent.
+- **Cgroup-mode pids are root-namespace pids.** A subtree can span pid
+  namespaces, so there is no single namespace to project into; `pid_target_ns()`
+  fills `out` from `bpf_get_current_pid_tgid()` in that mode.
+
+Verify both modes with `make ebpf-selftest` → `sudo ./bin/ebpf-selftest`: it
+runs one workload and checks the pid filter and the cgroup filter against it
+(the cgroup phase reports SKIP where there is no subtree to target — a cgroup
+v1 host, or a cgroup namespace that shows `/` as its own root).
 
 ## Build tags
 

--- a/cmd/ebpfselftest/main.go
+++ b/cmd/ebpfselftest/main.go
@@ -15,6 +15,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/trentas/ptop/internal/bpf"
@@ -37,17 +38,30 @@ func run() error {
 	pid := os.Getpid()
 	fmt.Printf("ptop eBPF self-test — target = self (pid %d)\n\n", pid)
 
-	cpuT, err := bpf.OpenCPUTracer(pid)
+	cpuT, err := bpf.OpenCPUTracer(bpf.TargetPID(pid))
 	if err != nil {
 		return fmt.Errorf("cpu: OpenCPUTracer: %w", err)
 	}
 	defer cpuT.Close()
 
-	scT, err := bpf.OpenSyscallTracer(pid)
+	scT, err := bpf.OpenSyscallTracer(bpf.TargetPID(pid))
 	if err != nil {
 		return fmt.Errorf("syscalls: OpenSyscallTracer: %w", err)
 	}
 	defer scT.Close()
+
+	// Second targeting mode (#94): the same workload, matched by cgroup subtree
+	// instead of by pid. cgT stays nil when there is no subtree to target.
+	var cgT *bpf.CPUTracer
+	cgroupSpec, cgroupWhy := selfCgroup()
+	if cgroupSpec != "" {
+		cgT, err = bpf.OpenCPUTracer(bpf.TargetCgroup(cgroupSpec))
+		if err != nil {
+			return fmt.Errorf("cgroup: OpenCPUTracer(%s): %w", cgroupSpec, err)
+		}
+		defer cgT.Close()
+		fmt.Printf("      cgroup mode targeting %s\n\n", cgroupSpec)
+	}
 
 	devnull, err := os.OpenFile("/dev/null", os.O_WRONLY, 0)
 	if err != nil {
@@ -89,9 +103,47 @@ func run() error {
 		failed = true
 	}
 
+	switch {
+	case cgT == nil:
+		fmt.Printf("SKIP  cgroup:   %s\n", cgroupWhy)
+	default:
+		if samples, _ := cgT.SampleCount(); samples > 0 {
+			fmt.Printf("PASS  cgroup:   %d on-CPU samples observed via cgroup subtree filter\n", samples)
+		} else {
+			fmt.Fprintln(os.Stderr, "FAIL  cgroup:   0 samples — the cgroup subtree filter did not match this process")
+			failed = true
+		}
+	}
+
 	if failed {
 		return errors.New("eBPF self-test FAILED")
 	}
 	fmt.Println("\neBPF self-test PASSED")
 	return nil
+}
+
+// selfCgroup returns this process's cgroup v2 path, suitable as a --cgroup
+// spec, or "" plus the reason there is nothing to target.
+//
+// Inside a cgroup namespace /proc/self/cgroup reads "0::/" — the process sees
+// its own cgroup as the root — and targeting the root would mean tracing every
+// process on the host, which the resolver refuses. That is a legitimate skip,
+// not a failure.
+func selfCgroup() (spec, why string) {
+	b, err := os.ReadFile("/proc/self/cgroup")
+	if err != nil {
+		return "", fmt.Sprintf("cannot read /proc/self/cgroup (%v)", err)
+	}
+	for _, line := range strings.Split(string(b), "\n") {
+		// The unified hierarchy is the line with an empty controller list.
+		rest, ok := strings.CutPrefix(line, "0::")
+		if !ok {
+			continue
+		}
+		if p := strings.TrimSpace(rest); p != "" && p != "/" {
+			return p, ""
+		}
+		return "", "this process sees its own cgroup as the root (cgroup namespace) — no subtree to target"
+	}
+	return "", "no cgroup v2 (unified) entry in /proc/self/cgroup — cgroup v1 only host"
 }

--- a/internal/bpf/cpu.go
+++ b/internal/bpf/cpu.go
@@ -32,9 +32,9 @@ type CPUTracer struct {
 // `perf record` uses by default — granular enough to detect CPU spikes >10ms.
 const SampleFreq = 100
 
-func OpenCPUTracer(pid int) (*CPUTracer, error) {
-	if pid <= 0 {
-		return nil, errors.New("invalid pid")
+func OpenCPUTracer(target Target) (*CPUTracer, error) {
+	if err := target.validate(); err != nil {
+		return nil, err
 	}
 	if err := rlimit.RemoveMemlock(); err != nil {
 		return nil, fmt.Errorf("rlimit.RemoveMemlock: %w", err)
@@ -56,7 +56,7 @@ func OpenCPUTracer(pid int) (*CPUTracer, error) {
 		t.Close()
 		return nil, errors.New("cpu_target_pid map not found")
 	}
-	tf, err := resolveTarget(pid)
+	tf, err := resolveTarget(target)
 	if err != nil {
 		t.Close()
 		return nil, err

--- a/internal/bpf/cpu_stub.go
+++ b/internal/bpf/cpu_stub.go
@@ -10,7 +10,7 @@ type CPUTracer struct{}
 
 const SampleFreq = 100
 
-func OpenCPUTracer(int) (*CPUTracer, error) { return nil, errCPUStub }
+func OpenCPUTracer(Target) (*CPUTracer, error) { return nil, errCPUStub }
 func (*CPUTracer) SampleCount() (uint64, error) { return 0, errCPUStub }
 func (*CPUTracer) NumCPU() int                  { return 0 }
 func (*CPUTracer) Close() error                 { return nil }

--- a/internal/bpf/futex.go
+++ b/internal/bpf/futex.go
@@ -35,9 +35,9 @@ type FutexTracer struct {
 	smap  *ebpf.Map
 }
 
-func OpenFutexTracer(pid int) (*FutexTracer, error) {
-	if pid <= 0 {
-		return nil, errors.New("invalid pid")
+func OpenFutexTracer(target Target) (*FutexTracer, error) {
+	if err := target.validate(); err != nil {
+		return nil, err
 	}
 	if err := rlimit.RemoveMemlock(); err != nil {
 		return nil, fmt.Errorf("rlimit: %w", err)
@@ -58,7 +58,7 @@ func OpenFutexTracer(pid int) (*FutexTracer, error) {
 		t.Close()
 		return nil, errors.New("futex_target_pid map missing")
 	}
-	tf, err := resolveTarget(pid)
+	tf, err := resolveTarget(target)
 	if err != nil {
 		t.Close()
 		return nil, err

--- a/internal/bpf/futex_stub.go
+++ b/internal/bpf/futex_stub.go
@@ -17,7 +17,7 @@ type FutexStat struct {
 
 type FutexTracer struct{}
 
-func OpenFutexTracer(int) (*FutexTracer, error) { return nil, errFutexStub }
+func OpenFutexTracer(Target) (*FutexTracer, error) { return nil, errFutexStub }
 func (*FutexTracer) Stats() (map[uint64]FutexStat, error) {
 	return nil, errFutexStub
 }

--- a/internal/bpf/heap.go
+++ b/internal/bpf/heap.go
@@ -127,7 +127,7 @@ func OpenHeapTracer(pid int) (*HeapTracer, error) {
 		t.Close()
 		return nil, errors.New("heap_target_pid map missing")
 	}
-	tf, err := resolveTarget(pid)
+	tf, err := resolveTarget(TargetPID(pid))
 	if err != nil {
 		t.Close()
 		return nil, err

--- a/internal/bpf/io.go
+++ b/internal/bpf/io.go
@@ -68,9 +68,9 @@ type IOTracer struct {
 	fsrb  *ringbuf.Reader // #57 — fs_events channel
 }
 
-func OpenIOTracer(pid int) (*IOTracer, error) {
-	if pid <= 0 {
-		return nil, errors.New("invalid pid")
+func OpenIOTracer(target Target) (*IOTracer, error) {
+	if err := target.validate(); err != nil {
+		return nil, err
 	}
 	if err := rlimit.RemoveMemlock(); err != nil {
 		return nil, fmt.Errorf("rlimit: %w", err)
@@ -92,7 +92,7 @@ func OpenIOTracer(pid int) (*IOTracer, error) {
 		t.Close()
 		return nil, errors.New("io_target_pid map missing")
 	}
-	tf, err := resolveTarget(pid)
+	tf, err := resolveTarget(target)
 	if err != nil {
 		t.Close()
 		return nil, err

--- a/internal/bpf/io_stub.go
+++ b/internal/bpf/io_stub.go
@@ -25,6 +25,6 @@ type IOEvent struct {
 
 type IOTracer struct{}
 
-func OpenIOTracer(int) (*IOTracer, error)       { return nil, errIOStub }
+func OpenIOTracer(Target) (*IOTracer, error)       { return nil, errIOStub }
 func (*IOTracer) Next() (IOEvent, error)         { return IOEvent{}, io.EOF }
 func (*IOTracer) Close() error                   { return nil }

--- a/internal/bpf/memory.go
+++ b/internal/bpf/memory.go
@@ -33,9 +33,9 @@ type MemoryTracer struct {
 	cmap  *ebpf.Map
 }
 
-func OpenMemoryTracer(pid int) (*MemoryTracer, error) {
-	if pid <= 0 {
-		return nil, errors.New("invalid pid")
+func OpenMemoryTracer(target Target) (*MemoryTracer, error) {
+	if err := target.validate(); err != nil {
+		return nil, err
 	}
 	if err := rlimit.RemoveMemlock(); err != nil {
 		return nil, fmt.Errorf("rlimit: %w", err)
@@ -56,7 +56,7 @@ func OpenMemoryTracer(pid int) (*MemoryTracer, error) {
 		t.Close()
 		return nil, errors.New("mem_target_pid map missing")
 	}
-	tf, err := resolveTarget(pid)
+	tf, err := resolveTarget(target)
 	if err != nil {
 		t.Close()
 		return nil, err

--- a/internal/bpf/memory_stub.go
+++ b/internal/bpf/memory_stub.go
@@ -15,6 +15,6 @@ type MemCounters struct {
 
 type MemoryTracer struct{}
 
-func OpenMemoryTracer(int) (*MemoryTracer, error)   { return nil, errMemStub }
+func OpenMemoryTracer(Target) (*MemoryTracer, error)   { return nil, errMemStub }
 func (*MemoryTracer) Stats() (MemCounters, error)   { return MemCounters{}, errMemStub }
 func (*MemoryTracer) Close() error                  { return nil }

--- a/internal/bpf/network.go
+++ b/internal/bpf/network.go
@@ -90,9 +90,9 @@ type NetTracer struct {
 	rb    *ringbuf.Reader // #56 — net_error_events channel
 }
 
-func OpenNetTracer(pid int) (*NetTracer, error) {
-	if pid <= 0 {
-		return nil, errors.New("invalid pid")
+func OpenNetTracer(target Target) (*NetTracer, error) {
+	if err := target.validate(); err != nil {
+		return nil, err
 	}
 	if err := rlimit.RemoveMemlock(); err != nil {
 		return nil, fmt.Errorf("rlimit: %w", err)
@@ -113,7 +113,7 @@ func OpenNetTracer(pid int) (*NetTracer, error) {
 		t.Close()
 		return nil, errors.New("net_target_pid map missing")
 	}
-	tf, err := resolveTarget(pid)
+	tf, err := resolveTarget(target)
 	if err != nil {
 		t.Close()
 		return nil, err

--- a/internal/bpf/network_stub.go
+++ b/internal/bpf/network_stub.go
@@ -33,7 +33,7 @@ type NetConnKey struct {
 
 type NetTracer struct{}
 
-func OpenNetTracer(int) (*NetTracer, error)                       { return nil, errNetStub }
+func OpenNetTracer(Target) (*NetTracer, error)                       { return nil, errNetStub }
 func (*NetTracer) Stats() ([]NetSnapshot, error)                   { return nil, errNetStub }
 func (*NetTracer) SeedConnection(NetConnKey, uint32) error         { return errNetStub }
 func (*NetTracer) Close() error                                    { return nil }

--- a/internal/bpf/programs/target.bpf.h
+++ b/internal/bpf/programs/target.bpf.h
@@ -1,14 +1,22 @@
 /* SPDX-License-Identifier: GPL-2.0 */
 /*
- * target.bpf.h — namespace-aware target-process filter shared by every
- * ptop eBPF program.
+ * target.bpf.h — the target filter shared by every ptop eBPF program.
  *
- * bpf_get_current_pid_tgid() returns PIDs in the INITIAL pid namespace.
- * ptop's --pid is a namespace-local PID (what /proc and ps show). Under a
- * nested pid namespace (WSL2, Docker, LXC) the two differ, so the old
- * `tgid == target` comparison never matched. bpf_get_ns_current_pid_tgid()
- * (kernel 5.7+) projects the current task's pid into a specific namespace,
- * identified by the (dev, ino) of /proc/<pid>/ns/pid.
+ * Two ways to name what we are tracing:
+ *
+ * PID mode (PTOP_TARGET_PID). bpf_get_current_pid_tgid() returns PIDs in the
+ * INITIAL pid namespace, while ptop's --pid is a namespace-local PID (what
+ * /proc and ps show). Under a nested pid namespace (WSL2, Docker, LXC) the two
+ * differ, so a plain `tgid == target` comparison never matched.
+ * bpf_get_ns_current_pid_tgid() (kernel 5.7+) projects the current task's pid
+ * into a specific namespace, identified by the (dev, ino) of
+ * /proc/<pid>/ns/pid.
+ *
+ * CGROUP mode (PTOP_TARGET_CGROUP). A cgroup subtree is the target, and no PID
+ * needs to be known in advance — which is what lets ptop attach to a container
+ * or a whole pod (#94). bpf_get_current_ancestor_cgroup_id(level) returns the
+ * id of the current task's ancestor cgroup at that depth, so every task inside
+ * the target's subtree answers with the target's own id, forks included.
  */
 #ifndef PTOP_TARGET_BPF_H
 #define PTOP_TARGET_BPF_H
@@ -16,33 +24,69 @@
 #include <linux/bpf.h>
 #include <bpf/bpf_helpers.h>
 
-/* Written by the Go loader (see internal/bpf/target.go). dev+ino identify
- * the target's PID namespace; pid is the target tgid within that namespace. */
+#define PTOP_TARGET_PID    0
+#define PTOP_TARGET_CGROUP 1
+
+/* Written by the Go loader (see internal/bpf/target.go). In PID mode dev+ino
+ * identify the target's PID namespace and pid is its tgid within that
+ * namespace; in CGROUP mode cgroup_id identifies the target cgroup and
+ * cgroup_level is its depth below the cgroup root. 40 bytes — keep
+ * targetFilter in target.go byte-for-byte identical. */
 struct target_filter {
     __u32 pid;
-    __u32 _pad;
+    __u32 mode;
     __u64 dev;
     __u64 ino;
+    __u64 cgroup_id;
+    __u32 cgroup_level;
+    __u32 _pad;
 };
 
-/* pid_target_ns resolves the current task's pid/tgid inside the target's
- * namespace and writes them into *out. Returns 1 when the current task is
- * the target process, 0 otherwise. target_map is an ARRAY[1] of
- * struct target_filter. */
+/* cgroup_is_target returns 1 when the current task sits anywhere inside the
+ * target cgroup's subtree. Level 0 is the cgroup root, which would match every
+ * process on the host — the Go side refuses to resolve to it, so a filter that
+ * somehow carries it still needs cgroup_id to match. */
+static __always_inline int cgroup_is_target(struct target_filter *tf)
+{
+    if (tf->cgroup_id == 0)
+        return 0;
+    return bpf_get_current_ancestor_cgroup_id(tf->cgroup_level) == tf->cgroup_id;
+}
+
+/* pid_target_ns reports whether the current task is part of the target and
+ * writes its pid/tgid into *out. target_map is an ARRAY[1] of
+ * struct target_filter.
+ *
+ * The pids written in CGROUP mode are the ROOT-namespace ones: a cgroup
+ * subtree can span pid namespaces, so there is no single namespace to project
+ * into. Consumers reading tid/pid off cgroup-targeted events therefore see
+ * host pids, not the container's view of them. */
 static __always_inline int pid_target_ns(void *target_map,
                                           struct bpf_pidns_info *out)
 {
     __u32 key = 0;
     struct target_filter *tf = bpf_map_lookup_elem(target_map, &key);
-    if (!tf || tf->pid == 0)
+    if (!tf)
+        return 0;
+
+    if (tf->mode == PTOP_TARGET_CGROUP) {
+        if (!cgroup_is_target(tf))
+            return 0;
+        __u64 id = bpf_get_current_pid_tgid();
+        out->pid = (__u32)id;
+        out->tgid = (__u32)(id >> 32);
+        return 1;
+    }
+
+    if (tf->pid == 0)
         return 0;
     if (bpf_get_ns_current_pid_tgid(tf->dev, tf->ino, out, sizeof(*out)) != 0)
         return 0;
     return out->tgid == tf->pid;
 }
 
-/* pid_is_target returns 1 when the current task belongs to the target
- * process. Use this anywhere the old is_*_target() helpers were used. */
+/* pid_is_target returns 1 when the current task belongs to the target,
+ * whichever way the target was named. */
 static __always_inline int pid_is_target(void *target_map)
 {
     struct bpf_pidns_info ns = {};

--- a/internal/bpf/security.go
+++ b/internal/bpf/security.go
@@ -52,9 +52,9 @@ type SecurityTracer struct {
 	stacksMap *ebpf.Map
 }
 
-func OpenSecurityTracer(pid int) (*SecurityTracer, error) {
-	if pid <= 0 {
-		return nil, errors.New("invalid pid")
+func OpenSecurityTracer(target Target) (*SecurityTracer, error) {
+	if err := target.validate(); err != nil {
+		return nil, err
 	}
 	if err := rlimit.RemoveMemlock(); err != nil {
 		return nil, fmt.Errorf("rlimit: %w", err)
@@ -75,7 +75,7 @@ func OpenSecurityTracer(pid int) (*SecurityTracer, error) {
 		t.Close()
 		return nil, errors.New("sec_target_pid map missing")
 	}
-	tf, err := resolveTarget(pid)
+	tf, err := resolveTarget(target)
 	if err != nil {
 		t.Close()
 		return nil, err

--- a/internal/bpf/security_stub.go
+++ b/internal/bpf/security_stub.go
@@ -27,7 +27,7 @@ type SecurityRecord struct {
 
 type SecurityTracer struct{}
 
-func OpenSecurityTracer(int) (*SecurityTracer, error) { return nil, errSecurityStub }
+func OpenSecurityTracer(Target) (*SecurityTracer, error) { return nil, errSecurityStub }
 
 func (*SecurityTracer) Next() (SecurityRecord, error) { return SecurityRecord{}, io.EOF }
 

--- a/internal/bpf/syscalls.go
+++ b/internal/bpf/syscalls.go
@@ -31,7 +31,7 @@ type SyscallStat struct {
 // counters map.
 //
 // Lifecycle:
-//   t, err := OpenSyscallTracer(pid)
+//   t, err := OpenSyscallTracer(bpf.TargetPID(pid))
 //   defer t.Close()                  // detaches programs + frees maps
 //   stats, _ := t.Stats()            // snapshot of the syscall_count map
 type SyscallTracer struct {
@@ -41,12 +41,13 @@ type SyscallTracer struct {
 	syscallMap  *ebpf.Map
 }
 
-// OpenSyscallTracer opens the tracer for the target PID. Fails if the kernel
-// doesn't support eBPF tracepoints, if capabilities are missing, or if the
-// BPF object didn't pass kernel verification.
-func OpenSyscallTracer(pid int) (*SyscallTracer, error) {
-	if pid <= 0 {
-		return nil, errors.New("invalid pid")
+// OpenSyscallTracer opens the tracer for target — a pid or a cgroup subtree,
+// see Target. Fails if the kernel doesn't support eBPF tracepoints, if
+// capabilities are missing, or if the BPF object didn't pass kernel
+// verification.
+func OpenSyscallTracer(target Target) (*SyscallTracer, error) {
+	if err := target.validate(); err != nil {
+		return nil, err
 	}
 	// Raises RLIMIT_MEMLOCK so the kernel accepts map allocations.
 	// On 5.11+ kernels with BPF memcg this is a no-op but still safe.
@@ -72,7 +73,7 @@ func OpenSyscallTracer(pid int) (*SyscallTracer, error) {
 		t.Close()
 		return nil, errors.New("target_pid map not found in BPF object")
 	}
-	tf, err := resolveTarget(pid)
+	tf, err := resolveTarget(target)
 	if err != nil {
 		t.Close()
 		return nil, err

--- a/internal/bpf/syscalls_stub.go
+++ b/internal/bpf/syscalls_stub.go
@@ -18,7 +18,7 @@ type SyscallStat struct {
 
 type SyscallTracer struct{}
 
-func OpenSyscallTracer(pid int) (*SyscallTracer, error) {
+func OpenSyscallTracer(Target) (*SyscallTracer, error) {
 	return nil, errSyscallsStub
 }
 

--- a/internal/bpf/target.go
+++ b/internal/bpf/target.go
@@ -4,21 +4,35 @@ package bpf
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/cilium/ebpf"
 	"golang.org/x/sys/unix"
 )
 
 // targetFilter mirrors `struct target_filter` in programs/target.bpf.h
-// byte-for-byte (24 bytes: u32 pid, u32 pad, u64 dev, u64 ino).
+// byte-for-byte (40 bytes: u32 pid, u32 mode, u64 dev, u64 ino, u64 cgroup_id,
+// u32 cgroup_level, u32 pad).
 type targetFilter struct {
-	Pid uint32
-	_   uint32
-	Dev uint64
-	Ino uint64
+	Pid         uint32
+	Mode        uint32
+	Dev         uint64
+	Ino         uint64
+	CgroupID    uint64
+	CgroupLevel uint32
+	_           uint32
 }
 
-// resolveTarget builds the filter for pid: its tgid plus the device and
+// resolveTarget builds the filter the BPF programs read, for either way of
+// naming a target (see Target).
+func resolveTarget(t Target) (targetFilter, error) {
+	if t.IsCgroup() {
+		return resolveCgroupTarget(t.Cgroup)
+	}
+	return resolvePIDTarget(t.PID)
+}
+
+// resolvePIDTarget builds the filter for pid: its tgid plus the device and
 // inode of the PID namespace it lives in (/proc/<pid>/ns/pid).
 //
 // On a native host in the root namespace this resolves to the initial PID
@@ -26,12 +40,54 @@ type targetFilter struct {
 // same values bpf_get_current_pid_tgid() returned before — identical
 // behavior. Inside a nested namespace (WSL2, containers) it resolves to that
 // namespace, which is what makes the filter match.
-func resolveTarget(pid int) (targetFilter, error) {
+func resolvePIDTarget(pid int) (targetFilter, error) {
 	var st unix.Stat_t
 	if err := unix.Stat(fmt.Sprintf("/proc/%d/ns/pid", pid), &st); err != nil {
 		return targetFilter{}, fmt.Errorf("stat pid namespace of %d: %w", pid, err)
 	}
-	return targetFilter{Pid: uint32(pid), Dev: st.Dev, Ino: st.Ino}, nil
+	return targetFilter{Mode: targetModePID, Pid: uint32(pid), Dev: st.Dev, Ino: st.Ino}, nil
+}
+
+// resolveCgroupTarget resolves a cgroup spec (path or container id) to the
+// cgroup's id and its depth below the cgroup root, which is what
+// bpf_get_current_ancestor_cgroup_id() needs to match a whole subtree.
+//
+// The id is the cgroup directory's inode number: since kernel 5.5 kernfs node
+// ids are 64-bit inodes, and that is exactly the value
+// bpf_get_current_cgroup_id() reports.
+func resolveCgroupTarget(spec string) (targetFilter, error) {
+	mi, err := os.ReadFile("/proc/self/mountinfo")
+	if err != nil {
+		return targetFilter{}, fmt.Errorf("read mountinfo: %w", err)
+	}
+	root, err := cgroup2Root(string(mi))
+	if err != nil {
+		return targetFilter{}, err
+	}
+
+	p, err := cgroupPath(os.DirFS(root), root, spec)
+	if err != nil {
+		return targetFilter{}, err
+	}
+
+	level, err := cgroupLevel(root, p)
+	if err != nil {
+		return targetFilter{}, err
+	}
+	if level == 0 {
+		return targetFilter{}, fmt.Errorf(
+			"cgroup %q is the cgroup root — targeting it would trace every process on the host", p)
+	}
+
+	var st unix.Stat_t
+	if err := unix.Stat(p, &st); err != nil {
+		return targetFilter{}, fmt.Errorf("stat cgroup %q: %w", p, err)
+	}
+	if st.Mode&unix.S_IFMT != unix.S_IFDIR {
+		return targetFilter{}, fmt.Errorf("cgroup %q is not a directory", p)
+	}
+
+	return targetFilter{Mode: targetModeCgroup, CgroupID: st.Ino, CgroupLevel: level}, nil
 }
 
 // writeTargetFilter stores the resolved filter at key 0 of an ARRAY[1] map.

--- a/internal/bpf/target_spec.go
+++ b/internal/bpf/target_spec.go
@@ -1,0 +1,188 @@
+package bpf
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"path"
+	"sort"
+	"strings"
+)
+
+// Target modes, mirroring PTOP_TARGET_* in programs/target.bpf.h.
+const (
+	targetModePID    uint32 = 0
+	targetModeCgroup uint32 = 1
+)
+
+// Target names what the eBPF programs should filter on: a single process, or
+// every process in a cgroup subtree.
+//
+// PID mode is resolved inside the target's own PID namespace, so a
+// namespace-local pid (what /proc and ps show) matches even from a nested
+// namespace. Cgroup mode needs no pid at all, which is what lets ptop attach
+// to a container or a whole pod whose processes are not known in advance
+// (#94), and it follows forks into the subtree for free.
+type Target struct {
+	PID int
+
+	// Cgroup is a cgroup path or a container id; non-empty selects cgroup mode.
+	Cgroup string
+}
+
+// TargetPID targets one process by (namespace-local) pid.
+func TargetPID(pid int) Target { return Target{PID: pid} }
+
+// TargetCgroup targets every process in a cgroup subtree. spec is a path —
+// absolute, or relative to the cgroup root as it appears in
+// /proc/<pid>/cgroup — or a container id to look up in the tree.
+func TargetCgroup(spec string) Target { return Target{Cgroup: spec} }
+
+// IsCgroup reports whether t selects a cgroup subtree rather than a pid.
+func (t Target) IsCgroup() bool { return t.Cgroup != "" }
+
+func (t Target) String() string {
+	if t.IsCgroup() {
+		return "cgroup " + t.Cgroup
+	}
+	return fmt.Sprintf("pid %d", t.PID)
+}
+
+// validate rejects a Target that names nothing to trace.
+func (t Target) validate() error {
+	if t.IsCgroup() {
+		return nil
+	}
+	if t.PID <= 0 {
+		return fmt.Errorf("invalid pid %d", t.PID)
+	}
+	return nil
+}
+
+// cgroup2Root returns the mount point of the unified (v2) hierarchy, given the
+// contents of /proc/self/mountinfo.
+//
+// v2 is required: the cgroup id the BPF helpers report is the one from the
+// default hierarchy, so on a cgroup v1-only host there is nothing meaningful
+// to target. On a hybrid host the first cgroup2 mount is the unified one
+// (customarily /sys/fs/cgroup/unified).
+func cgroup2Root(mountinfo string) (string, error) {
+	for _, line := range strings.Split(mountinfo, "\n") {
+		// mountinfo separates the variable-length optional fields from the
+		// fstype with a literal " - ".
+		sep := strings.Index(line, " - ")
+		if sep < 0 {
+			continue
+		}
+		fields := strings.Fields(line[:sep])
+		rest := strings.Fields(line[sep+3:])
+		if len(fields) < 5 || len(rest) < 1 || rest[0] != "cgroup2" {
+			continue
+		}
+		return unescapeMountPath(fields[4]), nil
+	}
+	return "", errors.New("no cgroup2 (unified) hierarchy is mounted — cgroup targeting needs cgroup v2")
+}
+
+// unescapeMountPath undoes the octal escaping the kernel applies to the
+// characters that would otherwise break mountinfo's field separation.
+func unescapeMountPath(p string) string {
+	for from, to := range map[string]string{`\040`: " ", `\011`: "\t", `\012`: "\n", `\134`: `\`} {
+		p = strings.ReplaceAll(p, from, to)
+	}
+	return p
+}
+
+// cgroupLevel returns the depth of target below root, which is what
+// bpf_get_current_ancestor_cgroup_id() needs to identify a subtree. The root
+// itself is level 0.
+func cgroupLevel(root, target string) (uint32, error) {
+	r, t := path.Clean(root), path.Clean(target)
+	if t == r {
+		return 0, nil
+	}
+	if !strings.HasPrefix(t, r+"/") {
+		return 0, fmt.Errorf("cgroup %q is not under the cgroup root %q", target, root)
+	}
+	rel := strings.Trim(strings.TrimPrefix(t, r), "/")
+	return uint32(len(strings.Split(rel, "/"))), nil
+}
+
+// cgroupSearchDepth bounds the container-id walk. Even a deeply nested
+// kubepods hierarchy (kubepods.slice → QoS slice → pod slice → container)
+// stays well inside this, while a cgroup tree with thousands of leaves does
+// not turn a typo into a full-filesystem scan.
+const cgroupSearchDepth = 8
+
+// cgroupPath maps a --cgroup spec to an absolute cgroup path. fsys must be
+// rooted at root (os.DirFS(root)); it is only consulted for a container-id
+// lookup.
+func cgroupPath(fsys fs.FS, root, spec string) (string, error) {
+	if spec == "" {
+		return "", errors.New("empty cgroup spec")
+	}
+	if strings.HasPrefix(spec, "/") {
+		// Either already absolute on the host, or the root-relative form that
+		// /proc/<pid>/cgroup prints.
+		if p := path.Clean(spec); p == path.Clean(root) || strings.HasPrefix(p, path.Clean(root)+"/") {
+			return p, nil
+		}
+		return path.Join(root, spec), nil
+	}
+	rel, err := findCgroup(fsys, spec)
+	if err != nil {
+		return "", err
+	}
+	return path.Join(root, rel), nil
+}
+
+// findCgroup walks fsys — rooted at the cgroup mount — for a directory whose
+// name contains needle, typically a container id. It returns the match
+// relative to fsys.
+//
+// Ambiguity is an error: two containers whose ids share a prefix are a normal
+// thing to hit with a short id, and picking one of them would attach the
+// tracers to the wrong workload silently.
+func findCgroup(fsys fs.FS, needle string) (string, error) {
+	var hits []string
+	err := fs.WalkDir(fsys, ".", func(p string, d fs.DirEntry, err error) error {
+		if err != nil {
+			// A corner of /sys/fs/cgroup this process cannot enter is not
+			// fatal — the target may well be elsewhere in the tree.
+			if d != nil && d.IsDir() {
+				return fs.SkipDir
+			}
+			return nil
+		}
+		if p == "." || !d.IsDir() {
+			return nil
+		}
+		if strings.Count(p, "/")+1 > cgroupSearchDepth {
+			return fs.SkipDir
+		}
+		if strings.Contains(path.Base(p), needle) {
+			// Whatever is below a match belongs to the match.
+			hits = append(hits, p)
+			return fs.SkipDir
+		}
+		return nil
+	})
+	if err != nil {
+		return "", fmt.Errorf("search cgroup tree for %q: %w", needle, err)
+	}
+
+	switch len(hits) {
+	case 0:
+		return "", fmt.Errorf("no cgroup matches %q", needle)
+	case 1:
+		return hits[0], nil
+	default:
+		sort.Strings(hits)
+		shown := hits
+		if len(shown) > 3 {
+			shown = shown[:3]
+		}
+		return "", fmt.Errorf("%q matches %d cgroups (%s...) — pass a full path or a longer id",
+			needle, len(hits), strings.Join(shown, ", "))
+	}
+}

--- a/internal/bpf/target_spec_test.go
+++ b/internal/bpf/target_spec_test.go
@@ -1,0 +1,235 @@
+package bpf
+
+import (
+	"strings"
+	"testing"
+	"testing/fstest"
+)
+
+// Real-shaped mountinfo: a modern unified-only host, a hybrid host where the
+// v2 hierarchy hangs off /sys/fs/cgroup/unified, and a v1-only host.
+const (
+	mountinfoV2 = `23 28 0:22 / /sys rw,nosuid,nodev,noexec,relatime shared:7 - sysfs sysfs rw
+25 23 0:24 / /sys/fs/bpf rw,nosuid,nodev,noexec,relatime shared:8 - bpf bpf rw,mode=700
+30 23 0:26 / /sys/fs/cgroup rw,nosuid,nodev,noexec,relatime shared:9 - cgroup2 cgroup2 rw,nsdelegate,memory_recursiveprot
+`
+	mountinfoHybrid = `30 23 0:26 / /sys/fs/cgroup ro,nosuid,nodev,noexec shared:9 - tmpfs tmpfs ro,mode=755
+31 30 0:27 / /sys/fs/cgroup/unified rw,nosuid,nodev,noexec,relatime shared:10 - cgroup2 cgroup2 rw,nsdelegate
+32 30 0:28 / /sys/fs/cgroup/systemd rw,nosuid,nodev,noexec,relatime shared:11 - cgroup cgroup rw,xattr,name=systemd
+33 30 0:29 / /sys/fs/cgroup/memory rw,nosuid,nodev,noexec,relatime shared:12 - cgroup cgroup rw,memory
+`
+	mountinfoV1 = `30 23 0:26 / /sys/fs/cgroup ro,nosuid,nodev,noexec shared:9 - tmpfs tmpfs ro,mode=755
+32 30 0:28 / /sys/fs/cgroup/systemd rw,nosuid,nodev,noexec,relatime shared:11 - cgroup cgroup rw,xattr,name=systemd
+`
+	// The kernel escapes the characters that would break field separation.
+	mountinfoEscaped = `30 23 0:26 / /mnt/my\040cgroups rw,relatime shared:9 - cgroup2 cgroup2 rw
+`
+)
+
+func TestCgroup2Root(t *testing.T) {
+	cases := []struct {
+		name, mountinfo, want, wantErr string
+	}{
+		{name: "unified only", mountinfo: mountinfoV2, want: "/sys/fs/cgroup"},
+		{name: "hybrid picks the v2 mount", mountinfo: mountinfoHybrid, want: "/sys/fs/cgroup/unified"},
+		{name: "v1 only", mountinfo: mountinfoV1, wantErr: "needs cgroup v2"},
+		{name: "empty", mountinfo: "", wantErr: "needs cgroup v2"},
+		{name: "escaped mount point", mountinfo: mountinfoEscaped, want: "/mnt/my cgroups"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := cgroup2Root(tc.mountinfo)
+			if tc.wantErr != "" {
+				if err == nil {
+					t.Fatalf("cgroup2Root = %q, want error containing %q", got, tc.wantErr)
+				}
+				if !strings.Contains(err.Error(), tc.wantErr) {
+					t.Errorf("error = %q, want it to contain %q", err, tc.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("cgroup2Root: %v", err)
+			}
+			if got != tc.want {
+				t.Errorf("cgroup2Root = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestCgroupLevel(t *testing.T) {
+	const root = "/sys/fs/cgroup"
+	cases := []struct {
+		target  string
+		want    uint32
+		wantErr bool
+	}{
+		{target: "/sys/fs/cgroup", want: 0},
+		{target: "/sys/fs/cgroup/", want: 0},
+		{target: "/sys/fs/cgroup/system.slice", want: 1},
+		{target: "/sys/fs/cgroup/system.slice/docker.service", want: 2},
+		{target: "/sys/fs/cgroup/kubepods.slice/kubepods-burstable.slice/pod.slice/ctr.scope", want: 4},
+		// Not under the root at all.
+		{target: "/sys/fs/cgroup-other/x", wantErr: true},
+		{target: "/etc/passwd", wantErr: true},
+	}
+	for _, tc := range cases {
+		got, err := cgroupLevel(root, tc.target)
+		if tc.wantErr {
+			if err == nil {
+				t.Errorf("cgroupLevel(%q) = %d, want error", tc.target, got)
+			}
+			continue
+		}
+		if err != nil {
+			t.Errorf("cgroupLevel(%q): %v", tc.target, err)
+			continue
+		}
+		if got != tc.want {
+			t.Errorf("cgroupLevel(%q) = %d, want %d", tc.target, got, tc.want)
+		}
+	}
+}
+
+// kubepodsFS is the shape a Kubernetes node's cgroup tree actually has:
+// kubepods.slice → QoS slice → pod slice → one scope per container.
+func kubepodsFS() fstest.MapFS {
+	f := &fstest.MapFile{}
+	return fstest.MapFS{
+		"cgroup.procs": f,
+		"system.slice/containerd.service/cgroup.procs": f,
+		"kubepods.slice/kubepods-burstable.slice/kubepods-burstable-podf00d.slice/cri-containerd-abc123def456789.scope/cgroup.procs":  f,
+		"kubepods.slice/kubepods-burstable.slice/kubepods-burstable-podf00d.slice/cri-containerd-beef987654321.scope/cgroup.procs":    f,
+		"kubepods.slice/kubepods-besteffort.slice/kubepods-besteffort-podcafe.slice/cri-containerd-abc123ffffffff.scope/cgroup.procs": f,
+	}
+}
+
+func TestFindCgroup(t *testing.T) {
+	fsys := kubepodsFS()
+
+	t.Run("unique container id", func(t *testing.T) {
+		got, err := findCgroup(fsys, "abc123def456789")
+		if err != nil {
+			t.Fatalf("findCgroup: %v", err)
+		}
+		const want = "kubepods.slice/kubepods-burstable.slice/kubepods-burstable-podf00d.slice/cri-containerd-abc123def456789.scope"
+		if got != want {
+			t.Errorf("findCgroup = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("pod slice matches its own directory", func(t *testing.T) {
+		got, err := findCgroup(fsys, "podf00d")
+		if err != nil {
+			t.Fatalf("findCgroup: %v", err)
+		}
+		if got != "kubepods.slice/kubepods-burstable.slice/kubepods-burstable-podf00d.slice" {
+			t.Errorf("findCgroup = %q, want the pod slice", got)
+		}
+	})
+
+	t.Run("no match", func(t *testing.T) {
+		if got, err := findCgroup(fsys, "0000000000"); err == nil {
+			t.Errorf("findCgroup = %q, want an error", got)
+		}
+	})
+
+	// A short id shared by two containers must not silently pick one: attaching
+	// the tracers to the wrong workload is worse than refusing.
+	t.Run("ambiguous prefix", func(t *testing.T) {
+		got, err := findCgroup(fsys, "abc123")
+		if err == nil {
+			t.Fatalf("findCgroup = %q, want an ambiguity error", got)
+		}
+		if !strings.Contains(err.Error(), "matches 2 cgroups") {
+			t.Errorf("error = %q, want it to report the ambiguity", err)
+		}
+	})
+
+	t.Run("deeper than the search bound", func(t *testing.T) {
+		deep := fstest.MapFS{
+			"a/b/c/d/e/f/g/h/i/needle-here/cgroup.procs": &fstest.MapFile{},
+		}
+		if got, err := findCgroup(deep, "needle-here"); err == nil {
+			t.Errorf("findCgroup = %q, want the depth bound to stop the walk", got)
+		}
+	})
+}
+
+func TestCgroupPath(t *testing.T) {
+	fsys := kubepodsFS()
+	const root = "/sys/fs/cgroup"
+
+	cases := []struct {
+		name, spec, want, wantErr string
+	}{
+		{
+			name: "absolute host path passes through",
+			spec: "/sys/fs/cgroup/system.slice/containerd.service",
+			want: "/sys/fs/cgroup/system.slice/containerd.service",
+		},
+		{
+			// The form /proc/<pid>/cgroup prints.
+			name: "root-relative path is joined",
+			spec: "/kubepods.slice/kubepods-burstable.slice",
+			want: "/sys/fs/cgroup/kubepods.slice/kubepods-burstable.slice",
+		},
+		{
+			name: "container id is looked up",
+			spec: "beef987654321",
+			want: "/sys/fs/cgroup/kubepods.slice/kubepods-burstable.slice/kubepods-burstable-podf00d.slice/cri-containerd-beef987654321.scope",
+		},
+		{name: "empty spec", spec: "", wantErr: "empty cgroup spec"},
+		{name: "unknown id", spec: "nosuchcontainer", wantErr: "no cgroup matches"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := cgroupPath(fsys, root, tc.spec)
+			if tc.wantErr != "" {
+				if err == nil {
+					t.Fatalf("cgroupPath = %q, want error containing %q", got, tc.wantErr)
+				}
+				if !strings.Contains(err.Error(), tc.wantErr) {
+					t.Errorf("error = %q, want it to contain %q", err, tc.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("cgroupPath: %v", err)
+			}
+			if got != tc.want {
+				t.Errorf("cgroupPath = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestTargetSpec(t *testing.T) {
+	pid := TargetPID(4242)
+	if pid.IsCgroup() {
+		t.Error("TargetPID reports cgroup mode")
+	}
+	if err := pid.validate(); err != nil {
+		t.Errorf("validate: %v", err)
+	}
+	if got := pid.String(); got != "pid 4242" {
+		t.Errorf("String = %q", got)
+	}
+
+	cg := TargetCgroup("/kubepods.slice/x.scope")
+	if !cg.IsCgroup() {
+		t.Error("TargetCgroup does not report cgroup mode")
+	}
+	if err := cg.validate(); err != nil {
+		t.Errorf("validate: %v", err)
+	}
+	if got := cg.String(); got != "cgroup /kubepods.slice/x.scope" {
+		t.Errorf("String = %q", got)
+	}
+
+	// A pid target still has to name a process; a cgroup target never needs one.
+	if err := (Target{}).validate(); err == nil {
+		t.Error("the zero Target validated")
+	}
+}

--- a/internal/bpf/target_test.go
+++ b/internal/bpf/target_test.go
@@ -4,6 +4,7 @@ package bpf
 
 import (
 	"os"
+	"strings"
 	"testing"
 	"unsafe"
 )
@@ -14,21 +15,34 @@ import (
 // struct verbatim.
 func TestTargetFilterLayout(t *testing.T) {
 	var tf targetFilter
-	if got := unsafe.Sizeof(tf); got != 24 {
-		t.Fatalf("sizeof(targetFilter) = %d, want 24", got)
+	if got := unsafe.Sizeof(tf); got != 40 {
+		t.Fatalf("sizeof(targetFilter) = %d, want 40", got)
 	}
-	if got := unsafe.Offsetof(tf.Dev); got != 8 {
-		t.Fatalf("offsetof(targetFilter.Dev) = %d, want 8", got)
+	offsets := []struct {
+		name string
+		got  uintptr
+		want uintptr
+	}{
+		{"Mode", unsafe.Offsetof(tf.Mode), 4},
+		{"Dev", unsafe.Offsetof(tf.Dev), 8},
+		{"Ino", unsafe.Offsetof(tf.Ino), 16},
+		{"CgroupID", unsafe.Offsetof(tf.CgroupID), 24},
+		{"CgroupLevel", unsafe.Offsetof(tf.CgroupLevel), 32},
 	}
-	if got := unsafe.Offsetof(tf.Ino); got != 16 {
-		t.Fatalf("offsetof(targetFilter.Ino) = %d, want 16", got)
+	for _, o := range offsets {
+		if o.got != o.want {
+			t.Errorf("offsetof(targetFilter.%s) = %d, want %d", o.name, o.got, o.want)
+		}
 	}
 }
 
 func TestResolveTargetSelf(t *testing.T) {
-	tf, err := resolveTarget(os.Getpid())
+	tf, err := resolveTarget(TargetPID(os.Getpid()))
 	if err != nil {
 		t.Fatalf("resolveTarget(self): %v", err)
+	}
+	if tf.Mode != targetModePID {
+		t.Errorf("Mode = %d, want PID mode", tf.Mode)
 	}
 	if tf.Pid != uint32(os.Getpid()) {
 		t.Errorf("Pid = %d, want %d", tf.Pid, os.Getpid())
@@ -44,7 +58,58 @@ func TestResolveTargetSelf(t *testing.T) {
 func TestResolveTargetMissingPID(t *testing.T) {
 	// 0x7fffffff exceeds Linux's hard cap on pid_max (PID_MAX_LIMIT = 4194304),
 	// so this PID is guaranteed not to exist on any kernel.
-	if _, err := resolveTarget(0x7fffffff); err == nil {
+	if _, err := resolveTarget(TargetPID(0x7fffffff)); err == nil {
 		t.Error("resolveTarget(nonexistent pid) = nil error, want failure")
+	}
+}
+
+// Cgroup mode against this process's own cgroup: the resolved filter must name
+// a real cgroup below the root. Skipped where there is nothing to resolve — a
+// cgroup v1-only host, or a cgroup namespace that shows "/" as its own root.
+func TestResolveTargetSelfCgroup(t *testing.T) {
+	mi, err := os.ReadFile("/proc/self/mountinfo")
+	if err != nil {
+		t.Skipf("no mountinfo: %v", err)
+	}
+	root, err := cgroup2Root(string(mi))
+	if err != nil {
+		t.Skipf("no cgroup2 hierarchy: %v", err)
+	}
+
+	self, err := os.ReadFile("/proc/self/cgroup")
+	if err != nil {
+		t.Skipf("no /proc/self/cgroup: %v", err)
+	}
+	spec := ""
+	for _, line := range strings.Split(string(self), "\n") {
+		if rest, ok := strings.CutPrefix(line, "0::"); ok {
+			spec = strings.TrimSpace(rest)
+			break
+		}
+	}
+	if spec == "" || spec == "/" {
+		t.Skipf("this process sees its cgroup as %q — nothing below the root to target", spec)
+	}
+
+	tf, err := resolveTarget(TargetCgroup(spec))
+	if err != nil {
+		t.Fatalf("resolveTarget(cgroup %s): %v", spec, err)
+	}
+	if tf.Mode != targetModeCgroup {
+		t.Errorf("Mode = %d, want cgroup mode", tf.Mode)
+	}
+	if tf.CgroupID == 0 {
+		t.Error("CgroupID = 0, want the cgroup directory inode")
+	}
+	if tf.CgroupLevel == 0 {
+		t.Error("CgroupLevel = 0, which is the cgroup root — the resolver should have refused it")
+	}
+	if tf.Pid != 0 || tf.Dev != 0 || tf.Ino != 0 {
+		t.Errorf("pid-mode fields set in a cgroup target: %+v", tf)
+	}
+
+	// The root itself must be refused: it would trace every process on the host.
+	if _, err := resolveTarget(TargetCgroup(root)); err == nil {
+		t.Error("resolveTarget(cgroup root) = nil error, want a refusal")
 	}
 }

--- a/internal/bpf/threads.go
+++ b/internal/bpf/threads.go
@@ -34,9 +34,9 @@ type ThreadsTracer struct {
 	stateMap *ebpf.Map
 }
 
-func OpenThreadsTracer(pid int) (*ThreadsTracer, error) {
-	if pid <= 0 {
-		return nil, errors.New("invalid pid")
+func OpenThreadsTracer(target Target) (*ThreadsTracer, error) {
+	if err := target.validate(); err != nil {
+		return nil, err
 	}
 	if err := rlimit.RemoveMemlock(); err != nil {
 		return nil, fmt.Errorf("rlimit: %w", err)
@@ -57,7 +57,7 @@ func OpenThreadsTracer(pid int) (*ThreadsTracer, error) {
 		t.Close()
 		return nil, errors.New("threads_target_pid map missing")
 	}
-	tf, err := resolveTarget(pid)
+	tf, err := resolveTarget(target)
 	if err != nil {
 		t.Close()
 		return nil, err

--- a/internal/bpf/threads_stub.go
+++ b/internal/bpf/threads_stub.go
@@ -16,7 +16,7 @@ type ThreadState struct {
 
 type ThreadsTracer struct{}
 
-func OpenThreadsTracer(int) (*ThreadsTracer, error)     { return nil, errThreadsStub }
+func OpenThreadsTracer(Target) (*ThreadsTracer, error)     { return nil, errThreadsStub }
 func (*ThreadsTracer) PruneDeadTIDs([]int) error        { return errThreadsStub }
 func (*ThreadsTracer) Stats() (map[uint32]ThreadState, error) {
 	return nil, errThreadsStub

--- a/internal/bpf/tls.go
+++ b/internal/bpf/tls.go
@@ -89,7 +89,7 @@ func OpenTLSTracer(pid, maxBytes int) (*TLSTracer, error) {
 		t.Close()
 		return nil, errors.New("tls_target_pid map missing")
 	}
-	tf, err := resolveTarget(pid)
+	tf, err := resolveTarget(TargetPID(pid))
 	if err != nil {
 		t.Close()
 		return nil, err

--- a/pkg/collector/cpu_ebpf.go
+++ b/pkg/collector/cpu_ebpf.go
@@ -38,7 +38,7 @@ func NewCPUEBPFCollector() *CPUEBPFCollector {
 }
 
 func (c *CPUEBPFCollector) Start(pid int) error {
-	tracer, err := bpf.OpenCPUTracer(pid)
+	tracer, err := bpf.OpenCPUTracer(bpf.TargetPID(pid))
 	if err != nil {
 		return fmt.Errorf("cpu eBPF: %w", err)
 	}

--- a/pkg/collector/futex_ebpf.go
+++ b/pkg/collector/futex_ebpf.go
@@ -42,7 +42,7 @@ func NewFutexEBPFCollector() *FutexEBPFCollector {
 }
 
 func (c *FutexEBPFCollector) Start(pid int) error {
-	tracer, err := bpf.OpenFutexTracer(pid)
+	tracer, err := bpf.OpenFutexTracer(bpf.TargetPID(pid))
 	if err != nil {
 		return fmt.Errorf("futex eBPF: %w", err)
 	}

--- a/pkg/collector/io_ebpf.go
+++ b/pkg/collector/io_ebpf.go
@@ -68,7 +68,7 @@ func NewIOEBPFCollector() *IOEBPFCollector {
 }
 
 func (c *IOEBPFCollector) Start(pid int) error {
-	tracer, err := bpf.OpenIOTracer(pid)
+	tracer, err := bpf.OpenIOTracer(bpf.TargetPID(pid))
 	if err != nil {
 		return fmt.Errorf("io eBPF: %w", err)
 	}

--- a/pkg/collector/mem_ebpf.go
+++ b/pkg/collector/mem_ebpf.go
@@ -43,7 +43,7 @@ func (c *MemEBPFCollector) Start(pid int) error {
 	if _, err := os.Stat(fmt.Sprintf("/proc/%d/statm", pid)); err != nil {
 		return fmt.Errorf("process %d not found: %w", pid, err)
 	}
-	tracer, err := bpf.OpenMemoryTracer(pid)
+	tracer, err := bpf.OpenMemoryTracer(bpf.TargetPID(pid))
 	if err != nil {
 		return fmt.Errorf("memory eBPF: %w", err)
 	}

--- a/pkg/collector/network_ebpf.go
+++ b/pkg/collector/network_ebpf.go
@@ -50,7 +50,7 @@ func NewNetworkEBPFCollector() *NetworkEBPFCollector {
 }
 
 func (c *NetworkEBPFCollector) Start(pid int) error {
-	tracer, err := bpf.OpenNetTracer(pid)
+	tracer, err := bpf.OpenNetTracer(bpf.TargetPID(pid))
 	if err != nil {
 		return fmt.Errorf("network eBPF: %w", err)
 	}

--- a/pkg/collector/security_ebpf.go
+++ b/pkg/collector/security_ebpf.go
@@ -45,7 +45,7 @@ func NewSecurityEBPFCollector() *SecurityEBPFCollector {
 }
 
 func (c *SecurityEBPFCollector) Start(pid int) error {
-	tracer, err := bpf.OpenSecurityTracer(pid)
+	tracer, err := bpf.OpenSecurityTracer(bpf.TargetPID(pid))
 	if err != nil {
 		return fmt.Errorf("security eBPF: %w", err)
 	}

--- a/pkg/collector/syscalls_ebpf.go
+++ b/pkg/collector/syscalls_ebpf.go
@@ -35,7 +35,7 @@ func NewSyscallsEBPFCollector() *SyscallsEBPFCollector {
 }
 
 func (c *SyscallsEBPFCollector) Start(pid int) error {
-	tracer, err := bpf.OpenSyscallTracer(pid)
+	tracer, err := bpf.OpenSyscallTracer(bpf.TargetPID(pid))
 	if err != nil {
 		return fmt.Errorf("syscalls eBPF: %w", err)
 	}

--- a/pkg/collector/threads_ebpf.go
+++ b/pkg/collector/threads_ebpf.go
@@ -57,7 +57,7 @@ func (c *ThreadsEBPFCollector) Start(pid int) error {
 	if _, err := os.Stat(fmt.Sprintf("/proc/%d/task", pid)); err != nil {
 		return fmt.Errorf("process %d not found: %w", pid, err)
 	}
-	tracer, err := bpf.OpenThreadsTracer(pid)
+	tracer, err := bpf.OpenThreadsTracer(bpf.TargetPID(pid))
 	if err != nil {
 		return fmt.Errorf("threads eBPF: %w", err)
 	}


### PR DESCRIPTION
Refs #94 — this is the **first of two**: the targeting primitive. Nothing exposes it yet (no `--cgroup` flag, no collector wiring); that is the follow-up, and it is where the user-visible behavior lands.

Every eBPF program filters through one shared helper, and that helper only knew how to match a single pid inside a single pid namespace. That is the constraint behind #94: you cannot observe a container or a pod without first knowing which pid to name, which rules out attaching to a workload chosen by Kubernetes identity — the case witness is blocked on.

## What changes

`struct target_filter` grows a mode and a cgroup id, and `pid_is_target()` gains a second branch built on `bpf_get_current_ancestor_cgroup_id(level)`: every task inside the target's subtree answers with the target's own cgroup id, so a whole container matches, forks included, with no pid known in advance. All ten programs include `target.bpf.h` and declare their map value as `struct target_filter`, so they inherit both modes from this one header — no per-program edits.

On the Go side a target is named with `bpf.Target` (`TargetPID` / `TargetCgroup`). The eight loaders whose only use of a pid was the filter itself now take one; `heap` and `tls` deliberately keep taking a pid, because their uprobes attach to a libc/libssl mapped into one process and have no cgroup-wide equivalent.

Resolution turns a path or a container id into `(cgroup_id, level)` — the id being the cgroup directory's inode, which is what the helpers report on kernfs since 5.5. Two things are refused rather than guessed:

- **level 0**, the cgroup root, which would quietly trace every process on the host;
- **an ambiguous container id**, since two containers sharing a prefix is ordinary and attaching tracers to the wrong workload is worse than asking for a longer id.

## Verification, and its limits

Being honest about what ran where — I am on macOS:

- The parsing and path math live in a build-tag-free file, so **mountinfo handling (unified / hybrid / v1-only / escaped mount points), level arithmetic and the container-id walk are covered by tests that run on any host** — including the ambiguity and depth-bound cases. Green locally under `-race`.
- The **whole eBPF lane type-checks** here via `GOOS=linux go vet -tags=ebpf ./...`; the C itself only compiles in CI (`make gen`), since Apple clang has no BPF backend. The `targetFilter` layout test (now 40 bytes, with per-field offsets) runs in the ebpf lane and is what catches C/Go drift.
- **The cgroup filter has not run against a live kernel yet.** The self-test is the hook for that: it resolves its own cgroup and checks the subtree filter against the same workload it uses for the pid filter, reporting SKIP where there is nothing below the root to target (cgroup v1 host, or a cgroup namespace showing `/` as its own root). Needs `sudo ./bin/ebpf-selftest` on Linux — worth running before the follow-up builds on it.

## Two caveats now documented in CLAUDE.md

- **The uprobe collectors stay pid-bound** (`heap` #53, `tls` #55).
- **Cgroup-mode pids are root-namespace pids.** A subtree can span pid namespaces, so there is no single namespace to project into.

🤖 Generated with [Claude Code](https://claude.com/claude-code)