### PR TITLE
serve: --cgroup targeting, with a TargetInfo handshake on the stream

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -373,6 +373,7 @@ ptop --pid <PID> --fps 10   render rate (default: 5)
 ptop --pid <PID> --export   save JSON snapshot on exit (also bound to 'e')
 ptop --pid <PID> --no-ebpf  degraded mode: /proc only, no eBPF
 ptop --pid <PID> --serve unix:///run/ptop.sock   headless: stream events over gRPC, no TUI
+ptop --cgroup <path|container-id> --serve <addr>  target a cgroup subtree instead of a PID (#94)
 ptop --pid <PID> --serve tcp://127.0.0.1:50051 --serve-insecure   headless over TCP, cleartext (opt-in)
 ptop --pid <PID> --serve tcp://<ip>:50051 --serve-tls-cert <crt> --serve-tls-key <key>   over TLS
 ptop --pid <PID> ... --serve-tls-client-ca <ca>   also require a client certificate (mTLS)
@@ -397,6 +398,19 @@ count); the actual **plaintext** is captured only with `--tls-bytes N` (default
 0, capped at 4096/call) — it can include credentials/PII, so it's a deliberate
 second opt-in with a stderr warning. The `--serve` privilege boundary (unix
 0600 / TCP loopback-only) guards the resulting plaintext.
+
+`--cgroup <path|container-id>` targets a cgroup subtree instead of one process
+(#94) — see the target-filter section above for the kernel side. It is
+`--serve`-only (the TUI is pid-shaped: header, thread table, fd list) and
+requires eBPF; `checkTargetFlags` in `cmd/ptop/main.go` rejects the rest.
+`bpf.ResolveCgroupSpec` resolves the spec once at startup, so a bad path or an
+ambiguous container id fails before any tracer loads and the log says which
+cgroup an id matched. `Set.startCgroup` starts only the collectors that can
+observe a subtree (syscalls, io, network, futex, cpu, security) — the
+`CgroupTargeter` interface in `types.go` is what marks them, and the ones left
+out are listed there with the reason. Every subscriber gets a `TargetInfo`
+handshake as the first `StreamMeta`, before any event: **the first item on a
+stream is now a meta, not an event** — consumers must handle that.
 
 `--serve <addr>` runs headless (no TUI): it builds the same collector `Set` and
 streams `streampb.Event`s over the `EventStreamService` gRPC service to any number of

--- a/README.md
+++ b/README.md
@@ -135,6 +135,10 @@ sudo ./bin/ptop --pid <PID> --serve tcp://10.1.2.3:50051 \
   --serve-tls-key  /etc/ptop/tls/tls.key \
   --serve-tls-client-ca /etc/ptop/tls/ca.crt
 
+# Target a whole container/pod by cgroup instead of a PID (headless only)
+sudo ./bin/ptop --cgroup /kubepods.slice/.../cri-containerd-<id>.scope --serve unix:///run/ptop.sock
+sudo ./bin/ptop --cgroup <container-id> --serve unix:///run/ptop.sock
+
 # Capture TLS plaintext around libssl (OFF by default; sensitive — see below)
 sudo ./bin/ptop --pid <PID> --tls-bytes 256 --serve unix:///run/ptop.sock --export
 ```
@@ -258,6 +262,38 @@ stderr, because dropping every subscriber is the worse failure.
 > Not to be confused with `--tls`/`--tls-bytes`, which are the opposite
 > direction: those capture the *target's* TLS plaintext. `--serve-tls-*`
 > encrypts *ptop's own* stream.
+
+### Targeting: one PID, or a whole cgroup
+
+`--pid` names one process. `--cgroup` names a **cgroup subtree** — a container
+or a whole pod — and needs no PID at all, so you can attach to a workload
+chosen by Kubernetes identity rather than by looking up what it happens to be
+running as. The spec is a cgroup path (absolute, or the root-relative form
+`/proc/<pid>/cgroup` prints) or a container id, which is resolved by searching
+the tree; an ambiguous id is refused rather than guessed. Forks and execs
+inside the subtree are covered automatically, because the filter matches the
+cgroup, not a process.
+
+Every subscriber is told which mode it is getting, as a `TargetInfo` handshake
+in the first `StreamMeta` of the stream, before any event. That matters because
+the modes aggregate differently: in cgroup mode `Event.pid` is 0 on aggregate
+payloads (there is no single process to name) and any pid inside a payload is a
+**root-namespace** pid, since a subtree can span pid namespaces.
+
+Cgroup mode is `--serve` only (the TUI's header, thread table and fd list are
+all one process's) and needs eBPF, since the filter runs in the kernel. It
+starts a deliberately smaller set of collectors — syscalls, I/O, network,
+locks, CPU and security — and the omissions are structural, not unfinished:
+
+| Not available in cgroup mode | Why |
+|---|---|
+| memory, threads | RSS and thread enumeration come from `/proc/<pid>/statm` and `/proc/<pid>/task` |
+| heap (#53), TLS (#55) | uprobes attach into one process's mapped libc/libssl |
+| signals (#58), exec lineage (#60) | they filter on a global pid of their own |
+
+Two collectors that do run lose a pid-shaped detail: I/O reports no file paths
+(resolving an fd means reading `/proc/<pid>/fd`) and security call sites stay
+in hex (symbolization reads one process's memory map).
 
 Beyond the seven TUI tabs, the stream carries the full process-behavior surface
 (each event tagged by `category`, with `uid`/`gid`/`cgroup_id` stamped on every

--- a/cmd/ptop/main.go
+++ b/cmd/ptop/main.go
@@ -39,6 +39,7 @@ func main() {
 	serveTLSKey := flag.String("serve-tls-key", "", "--serve over TLS: PEM server private key (needs --serve-tls-cert)")
 	serveTLSClientCA := flag.String("serve-tls-client-ca", "", "--serve over mTLS: PEM CA bundle; subscribers must present a certificate signed by it")
 	serveInsecure := flag.Bool("serve-insecure", false, "Allow a PLAINTEXT tcp:// --serve endpoint (unencrypted, unauthenticated) — deliberate opt-in")
+	cgroupSpec := flag.String("cgroup", "", "Target a cgroup subtree instead of one PID — a cgroup path or a container id (requires --serve and eBPF)")
 	tls := flag.Bool("tls", false, "Capture TLS payload metadata (direction/fd/byte count) via libssl uprobes — OFF by default (#55)")
 	tlsBytes := flag.Int("tls-bytes", 0, "Also capture up to N bytes of PLAINTEXT per TLS call (implies --tls; 0=metadata only, max 4096). Sensitive: may include credentials/PII")
 	pprofAddr := flag.String("pprof", "", "Dev: serve net/http/pprof on this addr (e.g. localhost:6060) for profiling ptop itself")
@@ -50,22 +51,23 @@ func main() {
 		os.Exit(0)
 	}
 
-	if *pid <= 0 {
-		if *pid == 0 {
-			fmt.Fprintln(os.Stderr, "error: --pid is required")
-		} else {
-			fmt.Fprintf(os.Stderr, "error: --pid %d is not a valid PID\n", *pid)
-		}
+	// One target, named one of two ways (#94). Everything that cannot hold for a
+	// cgroup subtree is rejected here rather than half-working later.
+	if err := checkTargetFlags(*pid, *cgroupSpec, *serveAddr, *noEBPF); err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
 		fmt.Fprintln(os.Stderr, "usage: ptop --pid <PID> [--fps 5] [--no-ebpf] [--export]")
 		fmt.Fprintln(os.Stderr, "       ptop --pid <PID> --serve unix:///run/ptop.sock")
 		fmt.Fprintln(os.Stderr, "       ptop --pid <PID> --serve tcp://<ip>:50051 --serve-tls-cert <crt> --serve-tls-key <key>")
+		fmt.Fprintln(os.Stderr, "       ptop --cgroup <path|container-id> --serve tcp://127.0.0.1:50051")
 		fmt.Fprintln(os.Stderr, "       ptop --version")
 		os.Exit(1)
 	}
 
-	if err := checkPIDExists(*pid); err != nil {
-		fmt.Fprintf(os.Stderr, "error: %v\n", err)
-		os.Exit(1)
+	if *cgroupSpec == "" {
+		if err := checkPIDExists(*pid); err != nil {
+			fmt.Fprintf(os.Stderr, "error: %v\n", err)
+			os.Exit(1)
+		}
 	}
 
 	// Profiling endpoint (dev tool, opt-in). Serves /debug/pprof for inspecting
@@ -146,11 +148,25 @@ func main() {
 
 	// Headless mode: serve the collector stream over gRPC instead of the TUI.
 	if *serveAddr != "" {
+		target := serve.TargetPID(*pid)
+		if *cgroupSpec != "" {
+			// Resolve once, up front: a bad spec or an ambiguous container id
+			// fails before any tracer loads, and the operator sees which cgroup
+			// an id actually matched.
+			path, id, err := bpf.ResolveCgroupSpec(*cgroupSpec)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "error: --cgroup %s: %v\n", *cgroupSpec, err)
+				os.Exit(1)
+			}
+			fmt.Fprintf(os.Stderr, "[ptop] targeting cgroup %s (id %d)\n", path, id)
+			target = serve.TargetCgroup(path, id)
+		}
+
 		opts := serve.Options{TLS: serveTLS}
 		if *export {
 			opts.JSONLPath = fmt.Sprintf("ptop-events-%s.jsonl", time.Now().Format("20060102-150405"))
 		}
-		runServe(*serveAddr, *pid, *noEBPF, tlsEnabled, tlsCap, opts)
+		runServe(*serveAddr, target, *noEBPF, tlsEnabled, tlsCap, opts)
 		return
 	}
 
@@ -190,6 +206,33 @@ func main() {
 	}
 }
 
+// checkTargetFlags validates how the target was named. --cgroup (#94) is not a
+// drop-in alternative to --pid: the filter runs in the kernel, so it needs
+// eBPF, and it names a set of processes, which the TUI has nowhere to put — its
+// header, thread table and fd list are all one process's. Rejecting those
+// combinations here beats a TUI that renders an empty shell.
+func checkTargetFlags(pid int, cgroupSpec, serveAddr string, noEBPF bool) error {
+	if cgroupSpec == "" {
+		if pid == 0 {
+			return errors.New("--pid is required (or --cgroup with --serve)")
+		}
+		if pid < 0 {
+			return fmt.Errorf("--pid %d is not a valid PID", pid)
+		}
+		return nil
+	}
+
+	switch {
+	case pid != 0:
+		return errors.New("--cgroup and --pid name different targets — pass one")
+	case serveAddr == "":
+		return errors.New("--cgroup requires --serve: a cgroup subtree is a set of processes, and the TUI shows one")
+	case noEBPF:
+		return errors.New("--cgroup needs eBPF (the subtree filter runs in the kernel) — it cannot work with --no-ebpf")
+	}
+	return nil
+}
+
 // checkPIDExists verifies the target process exists before anything starts.
 // Without this, a nonexistent PID silently fails every collector and the TUI
 // falls back to simulated data — plausible-looking numbers for a process that
@@ -218,12 +261,13 @@ func checkPIDExists(pid int) error {
 // so we stop the collectors after it returns. opts carries the transport
 // security and, with --export, the event-level JSONL path (distinct from the
 // TUI's state-snapshot ptop-export-*.jsonl).
-func runServe(addr string, pid int, noEBPF, tlsEnabled bool, tlsBytes int, opts serve.Options) {
+func runServe(addr string, target serve.Target, noEBPF, tlsEnabled bool, tlsBytes int, opts serve.Options) {
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
 
 	set := collector.NewSet(collector.SetConfig{
-		PID: pid, NoEBPF: noEBPF, TLS: tlsEnabled, TLSMaxBytes: tlsBytes,
+		PID: target.PID, Cgroup: target.CgroupPath,
+		NoEBPF: noEBPF, TLS: tlsEnabled, TLSMaxBytes: tlsBytes,
 	})
 	defer set.Stop()
 
@@ -235,7 +279,7 @@ func runServe(addr string, pid int, noEBPF, tlsEnabled bool, tlsBytes int, opts 
 		resolver = set.HeapEBPF
 	}
 
-	if err := serve.Run(ctx, addr, pid, set.Collectors(), resolver, opts); err != nil {
+	if err := serve.Run(ctx, addr, target, set.Collectors(), resolver, opts); err != nil {
 		set.Stop() // os.Exit skips the defer
 		fmt.Fprintf(os.Stderr, "fatal error: %v\n", err)
 		os.Exit(1)

--- a/cmd/ptop/main_test.go
+++ b/cmd/ptop/main_test.go
@@ -36,3 +36,52 @@ func TestCheckPIDExistsGone(t *testing.T) {
 		t.Fatalf("checkPIDExists(%d) = %q, want a 'does not exist' error", cmd.Process.Pid, err)
 	}
 }
+
+func TestCheckTargetFlags(t *testing.T) {
+	const sock = "unix:///run/ptop.sock"
+	cases := []struct {
+		name       string
+		pid        int
+		cgroup     string
+		serveAddr  string
+		noEBPF     bool
+		wantErrHas string // "" = must be accepted
+	}{
+		{name: "pid alone", pid: 42},
+		{name: "pid with serve", pid: 42, serveAddr: sock},
+		{name: "pid with no-ebpf", pid: 42, noEBPF: true},
+		{name: "no target at all", wantErrHas: "--pid is required"},
+		{name: "negative pid", pid: -5, wantErrHas: "not a valid PID"},
+
+		{name: "cgroup with serve", cgroup: "/kubepods.slice/x.scope", serveAddr: sock},
+		{name: "cgroup by container id", cgroup: "abc123def456", serveAddr: sock},
+
+		// A cgroup subtree is a set of processes: the TUI has one header, one
+		// thread table and one fd list, so there is nowhere to put it.
+		{name: "cgroup without serve", cgroup: "/x.scope", wantErrHas: "requires --serve"},
+		// The subtree filter runs in the kernel.
+		{name: "cgroup with no-ebpf", cgroup: "/x.scope", serveAddr: sock, noEBPF: true,
+			wantErrHas: "needs eBPF"},
+		// Two different targets.
+		{name: "cgroup and pid together", pid: 42, cgroup: "/x.scope", serveAddr: sock,
+			wantErrHas: "pass one"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := checkTargetFlags(tc.pid, tc.cgroup, tc.serveAddr, tc.noEBPF)
+			if tc.wantErrHas == "" {
+				if err != nil {
+					t.Fatalf("checkTargetFlags = %v, want accepted", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("checkTargetFlags = nil, want error containing %q", tc.wantErrHas)
+			}
+			if !strings.Contains(err.Error(), tc.wantErrHas) {
+				t.Errorf("error = %q, want it to contain %q", err, tc.wantErrHas)
+			}
+		})
+	}
+}

--- a/internal/bpf/target.go
+++ b/internal/bpf/target.go
@@ -56,38 +56,57 @@ func resolvePIDTarget(pid int) (targetFilter, error) {
 // ids are 64-bit inodes, and that is exactly the value
 // bpf_get_current_cgroup_id() reports.
 func resolveCgroupTarget(spec string) (targetFilter, error) {
+	_, id, level, err := resolveCgroup(spec)
+	if err != nil {
+		return targetFilter{}, err
+	}
+	return targetFilter{Mode: targetModeCgroup, CgroupID: id, CgroupLevel: level}, nil
+}
+
+// ResolveCgroupSpec resolves a cgroup spec to the absolute cgroup path it names
+// and that cgroup's id. Exported so the CLI can resolve once up front — failing
+// before any tracer is loaded, reporting what a container id actually matched,
+// and then handing the unambiguous path to every collector.
+func ResolveCgroupSpec(spec string) (path string, id uint64, err error) {
+	path, id, _, err = resolveCgroup(spec)
+	return path, id, err
+}
+
+// resolveCgroup does the shared work: find the cgroup2 root, map the spec to a
+// path under it, and read the path's id (inode) and depth.
+func resolveCgroup(spec string) (string, uint64, uint32, error) {
 	mi, err := os.ReadFile("/proc/self/mountinfo")
 	if err != nil {
-		return targetFilter{}, fmt.Errorf("read mountinfo: %w", err)
+		return "", 0, 0, fmt.Errorf("read mountinfo: %w", err)
 	}
 	root, err := cgroup2Root(string(mi))
 	if err != nil {
-		return targetFilter{}, err
+		return "", 0, 0, err
 	}
 
 	p, err := cgroupPath(os.DirFS(root), root, spec)
 	if err != nil {
-		return targetFilter{}, err
+		return "", 0, 0, err
 	}
 
 	level, err := cgroupLevel(root, p)
 	if err != nil {
-		return targetFilter{}, err
+		return "", 0, 0, err
 	}
 	if level == 0 {
-		return targetFilter{}, fmt.Errorf(
+		return "", 0, 0, fmt.Errorf(
 			"cgroup %q is the cgroup root — targeting it would trace every process on the host", p)
 	}
 
 	var st unix.Stat_t
 	if err := unix.Stat(p, &st); err != nil {
-		return targetFilter{}, fmt.Errorf("stat cgroup %q: %w", p, err)
+		return "", 0, 0, fmt.Errorf("stat cgroup %q: %w", p, err)
 	}
 	if st.Mode&unix.S_IFMT != unix.S_IFDIR {
-		return targetFilter{}, fmt.Errorf("cgroup %q is not a directory", p)
+		return "", 0, 0, fmt.Errorf("cgroup %q is not a directory", p)
 	}
 
-	return targetFilter{Mode: targetModeCgroup, CgroupID: st.Ino, CgroupLevel: level}, nil
+	return p, st.Ino, level, nil
 }
 
 // writeTargetFilter stores the resolved filter at key 0 of an ARRAY[1] map.

--- a/internal/bpf/target_stub.go
+++ b/internal/bpf/target_stub.go
@@ -1,0 +1,11 @@
+//go:build !linux || !ebpf
+
+package bpf
+
+import "errors"
+
+// ResolveCgroupSpec is unavailable here: cgroup targeting is an eBPF feature
+// (the filter runs in the kernel), so it needs Linux and -tags=ebpf.
+func ResolveCgroupSpec(string) (string, uint64, error) {
+	return "", 0, errors.New("cgroup targeting requires Linux with eBPF support (build -tags=ebpf)")
+}

--- a/internal/serve/hub.go
+++ b/internal/serve/hub.go
@@ -9,11 +9,11 @@ import (
 )
 
 // Hub fans collector events in from many channels and out to many Sinks. One
-// Hub per server instance (one target PID). Sinks are interchangeable consumers
-// of the unified event stream: a gRPC subscriber and a JSONL writer are both
-// just Sinks (see sink.go).
+// Hub per server instance (one target). Sinks are interchangeable consumers of
+// the unified event stream: a gRPC subscriber and a JSONL writer are both just
+// Sinks (see sink.go).
 type Hub struct {
-	pid     int
+	target  Target
 	buildID string // target exec build-id, stamped onto every StackRef (#54)
 	mu      sync.Mutex
 	sinks   map[Sink]struct{}
@@ -26,8 +26,24 @@ type Hub struct {
 	cgroupID uint64
 }
 
-func NewHub(pid int, buildID string) *Hub {
-	return &Hub{pid: pid, buildID: buildID, sinks: make(map[Sink]struct{})}
+func NewHub(target Target, buildID string) *Hub {
+	return &Hub{target: target, buildID: buildID, sinks: make(map[Sink]struct{})}
+}
+
+// targetInfo renders the handshake every subscriber receives before its first
+// event, so a consumer knows the scope of what follows (#94).
+func (h *Hub) targetInfo() *pb.TargetInfo {
+	if h.target.IsCgroup() {
+		return &pb.TargetInfo{
+			Mode:       pb.TargetMode_TARGET_MODE_CGROUP,
+			CgroupPath: h.target.CgroupPath,
+			CgroupId:   h.target.CgroupID,
+		}
+	}
+	return &pb.TargetInfo{
+		Mode: pb.TargetMode_TARGET_MODE_PID,
+		Pid:  int32(h.target.PID),
+	}
 }
 
 // Start launches one fan-in goroutine per collector. Each maps published values
@@ -58,7 +74,7 @@ func (h *Hub) drain(ctx context.Context, ch <-chan interface{}) {
 			if pc, ok := v.(collector.ProcContext); ok {
 				h.setIdent(pc)
 			}
-			if ev := toEvent(h.pid, h.buildID, v); ev != nil {
+			if ev := toEvent(h.target.PID, h.buildID, v); ev != nil {
 				h.stampIdent(ev)
 				h.broadcast(ev)
 			}

--- a/internal/serve/hub_test.go
+++ b/internal/serve/hub_test.go
@@ -24,7 +24,7 @@ func TestHubFanOut(t *testing.T) {
 	defer cancel()
 
 	f := newFake(8)
-	h := NewHub(7, "")
+	h := NewHub(TargetPID(7), "")
 	sub := h.subscribe(nil)
 	h.Start(ctx, []collector.Collector{f})
 
@@ -52,7 +52,7 @@ func TestHubCategoryFilter(t *testing.T) {
 	defer cancel()
 
 	f := newFake(8)
-	h := NewHub(1, "")
+	h := NewHub(TargetPID(1), "")
 	sub := h.subscribe([]pb.Category{pb.Category_CATEGORY_NETWORK})
 	h.Start(ctx, []collector.Collector{f})
 
@@ -84,7 +84,7 @@ func TestHubBackpressureDrops(t *testing.T) {
 
 	// Source channel large enough to hold every emit without blocking the test.
 	f := newFake(subBuffer + 200)
-	h := NewHub(1, "")
+	h := NewHub(TargetPID(1), "")
 	sub := h.subscribe(nil) // never read → its buffer fills, then drops
 	h.Start(ctx, []collector.Collector{f})
 
@@ -107,7 +107,7 @@ func TestHubBackpressureDrops(t *testing.T) {
 }
 
 func TestHubUnsubscribe(t *testing.T) {
-	h := NewHub(1, "")
+	h := NewHub(TargetPID(1), "")
 	sub := h.subscribe(nil)
 	if h.sinkCount() != 1 {
 		t.Fatalf("count = %d, want 1", h.sinkCount())

--- a/internal/serve/serve.go
+++ b/internal/serve/serve.go
@@ -19,7 +19,39 @@ import (
 	pb "github.com/trentas/ptop/pkg/streampb"
 )
 
-// Options tunes a Run beyond the address/PID. The zero value is the plain
+// Target describes what a server observes. It is reported to every subscriber
+// as the stream handshake (TargetInfo, #94), because the two modes aggregate
+// differently: in PID mode every event belongs to one process, while in cgroup
+// mode events come from anywhere in the subtree.
+type Target struct {
+	// PID mode: the target pid. 0 in cgroup mode.
+	PID int
+
+	// Cgroup mode: the resolved absolute cgroup path and its id (the directory
+	// inode). Empty/0 in pid mode.
+	CgroupPath string
+	CgroupID   uint64
+}
+
+// TargetPID names a single process.
+func TargetPID(pid int) Target { return Target{PID: pid} }
+
+// TargetCgroup names a cgroup subtree, already resolved to a path and id.
+func TargetCgroup(path string, id uint64) Target {
+	return Target{CgroupPath: path, CgroupID: id}
+}
+
+// IsCgroup reports whether t names a cgroup subtree rather than a pid.
+func (t Target) IsCgroup() bool { return t.CgroupPath != "" }
+
+func (t Target) String() string {
+	if t.IsCgroup() {
+		return fmt.Sprintf("cgroup %s (id %d)", t.CgroupPath, t.CgroupID)
+	}
+	return fmt.Sprintf("pid %d", t.PID)
+}
+
+// Options tunes a Run beyond the address/target. The zero value is the plain
 // gRPC-only server.
 type Options struct {
 	// JSONLPath, if set, also writes every event as one protojson line to this
@@ -33,7 +65,7 @@ type Options struct {
 }
 
 // Run starts the gRPC server bound to addr, streaming events for the given
-// target pid from cols. It blocks until ctx is cancelled, then stops the server
+// target — a pid or a cgroup subtree — from cols. It blocks until ctx is cancelled, then stops the server
 // and returns. The caller owns the collectors' lifecycle (typically
 // set.Collectors() here and set.Stop() after Run returns). addr is
 // "unix:///path" or "tcp://host:port"; a tcp:// endpoint must carry TLS
@@ -42,7 +74,7 @@ type Options struct {
 // resolver (optional, nil-safe) symbolizes captured stacks: it stamps the
 // per-process build-id onto every StackRef and backs the ResolveStack RPC. Pass
 // set.HeapEBPF when non-nil; nil leaves heap events without stack references.
-func Run(ctx context.Context, addr string, pid int, cols []collector.Collector, resolver StackResolver, opts Options) error {
+func Run(ctx context.Context, addr string, target Target, cols []collector.Collector, resolver StackResolver, opts Options) error {
 	// Resolve transport security first: a missing certificate or a refused
 	// cleartext endpoint should fail before anything is bound.
 	creds, mode, err := serverCredentials(addr, opts.TLS)
@@ -56,18 +88,18 @@ func Run(ctx context.Context, addr string, pid int, cols []collector.Collector, 
 	}
 	defer cleanup()
 
-	return runServer(ctx, lis, creds, mode, pid, cols, resolver, opts)
+	return runServer(ctx, lis, creds, mode, target, cols, resolver, opts)
 }
 
 // runServer owns everything after the listener exists: the hub, the sinks, the
 // gRPC server and the shutdown. Split out of Run so tests can drive a real
 // server on an ephemeral tcp port (listen() picks it, only lis knows it).
-func runServer(ctx context.Context, lis net.Listener, creds credentials.TransportCredentials, mode string, pid int, cols []collector.Collector, resolver StackResolver, opts Options) error {
+func runServer(ctx context.Context, lis net.Listener, creds credentials.TransportCredentials, mode string, target Target, cols []collector.Collector, resolver StackResolver, opts Options) error {
 	var buildID string
 	if resolver != nil {
 		buildID = resolver.ProcessBuildID()
 	}
-	hub := NewHub(pid, buildID)
+	hub := NewHub(target, buildID)
 	hub.Start(ctx, cols)
 
 	// Optional JSONL sink: a non-gRPC consumer of the same event stream.
@@ -97,8 +129,8 @@ func runServer(ctx context.Context, lis net.Listener, creds credentials.Transpor
 		fmt.Fprintln(os.Stderr, "[ptop] ⚠ --serve-insecure: this TCP stream is unencrypted and")
 		fmt.Fprintln(os.Stderr, "       unauthenticated. Anyone who reaches the port reads process internals.")
 	}
-	fmt.Fprintf(os.Stderr, "[ptop] serving events for pid %d on %s://%s (%s)\n",
-		pid, lis.Addr().Network(), lis.Addr().String(), mode)
+	fmt.Fprintf(os.Stderr, "[ptop] serving events for %s on %s://%s (%s)\n",
+		target, lis.Addr().Network(), lis.Addr().String(), mode)
 	if err := srv.Serve(lis); err != nil {
 		return fmt.Errorf("serve: %w", err)
 	}

--- a/internal/serve/serve_test.go
+++ b/internal/serve/serve_test.go
@@ -42,7 +42,7 @@ func TestServeUnixEndToEnd(t *testing.T) {
 	}()
 
 	runErr := make(chan error, 1)
-	go func() { runErr <- Run(ctx, addr, 99, []collector.Collector{f}, nil, Options{}) }()
+	go func() { runErr <- Run(ctx, addr, TargetPID(99), []collector.Collector{f}, nil, Options{}) }()
 
 	// Wait for the listener socket to appear before dialing.
 	waitFor(t, func() bool { _, err := os.Stat(sock); return err == nil })
@@ -68,13 +68,26 @@ func TestServeUnixEndToEnd(t *testing.T) {
 		t.Fatalf("subscribe: %v", err)
 	}
 
+	// The first response is the target handshake (#94), before any event.
+	first, err := stream.Recv()
+	if err != nil {
+		t.Fatalf("recv handshake: %v", err)
+	}
+	ti := first.GetMeta().GetTarget()
+	if ti == nil {
+		t.Fatalf("first response is not a target handshake: %v", first)
+	}
+	if ti.GetMode() != pb.TargetMode_TARGET_MODE_PID || ti.GetPid() != 99 {
+		t.Errorf("handshake = %v, want pid mode for pid 99", ti)
+	}
+
 	resp, err := stream.Recv()
 	if err != nil {
 		t.Fatalf("recv: %v", err)
 	}
 	ev := resp.GetEvent()
 	if ev == nil || ev.GetCategory() != pb.Category_CATEGORY_CPU {
-		t.Fatalf("unexpected first response: %v", resp)
+		t.Fatalf("unexpected first event: %v", resp)
 	}
 	if ev.GetPid() != 99 {
 		t.Errorf("pid = %d, want 99", ev.GetPid())
@@ -108,7 +121,7 @@ func TestServeBackpressureMetaOverGRPC(t *testing.T) {
 
 	f := newFake(8192) // holds the burst without blocking the producer
 	runErr := make(chan error, 1)
-	go func() { runErr <- Run(ctx, addr, 1, []collector.Collector{f}, nil, Options{}) }()
+	go func() { runErr <- Run(ctx, addr, TargetPID(1), []collector.Collector{f}, nil, Options{}) }()
 	waitFor(t, func() bool { _, err := os.Stat(sock); return err == nil })
 
 	conn, err := grpc.NewClient(addr, grpc.WithTransportCredentials(insecure.NewCredentials()))
@@ -176,7 +189,7 @@ func TestServeJSONLExport(t *testing.T) {
 
 	runErr := make(chan error, 1)
 	go func() {
-		runErr <- Run(ctx, "unix://"+sock, 5, []collector.Collector{f}, nil, Options{JSONLPath: jsonl})
+		runErr <- Run(ctx, "unix://"+sock, TargetPID(5), []collector.Collector{f}, nil, Options{JSONLPath: jsonl})
 	}()
 	waitFor(t, func() bool { _, err := os.Stat(sock); return err == nil })
 

--- a/internal/serve/service.go
+++ b/internal/serve/service.go
@@ -42,13 +42,24 @@ func (svc *eventStreamService) ResolveStack(_ context.Context, req *pb.ResolveSt
 	return &pb.ResolveStackResponse{Found: true, Frames: stackFrames(frames)}, nil
 }
 
-// Subscribe registers the client with the hub and streams its queued responses
-// until the client disconnects. Whenever the subscriber's drop counter has
+// Subscribe registers the client with the hub, sends the target handshake, and
+// streams its queued responses until the client disconnects. Whenever the
+// subscriber's drop counter has
 // advanced (backpressure), a StreamMeta is sent ahead of the next event so the
 // consumer learns it missed some.
 func (svc *eventStreamService) Subscribe(req *pb.SubscribeRequest, stream pb.EventStreamService_SubscribeServer) error {
 	sub := svc.hub.subscribe(req.GetCategories())
 	defer svc.hub.unsubscribe(sub)
+
+	// Handshake (#94): the scope of the stream, before anything is streamed. A
+	// consumer needs it to read what follows correctly — notably, cgroup-mode
+	// events carry no single pid.
+	handshake := &pb.SubscribeResponse{
+		Kind: &pb.SubscribeResponse_Meta{Meta: &pb.StreamMeta{Target: svc.hub.targetInfo()}},
+	}
+	if err := stream.Send(handshake); err != nil {
+		return err
+	}
 
 	ctx := stream.Context()
 	var lastDropped uint64

--- a/internal/serve/target_test.go
+++ b/internal/serve/target_test.go
@@ -1,0 +1,133 @@
+package serve
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+
+	"github.com/trentas/ptop/pkg/collector"
+	pb "github.com/trentas/ptop/pkg/streampb"
+)
+
+// handshakeFor starts a server for target and returns the TargetInfo the first
+// response carries.
+func handshakeFor(t *testing.T, target Target) *pb.TargetInfo {
+	t.Helper()
+	sock := shortSock(t)
+	addr := "unix://" + sock
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	f := newFake(4)
+	runErr := make(chan error, 1)
+	go func() { runErr <- Run(ctx, addr, target, []collector.Collector{f}, nil, Options{}) }()
+	waitFor(t, func() bool { _, err := os.Stat(sock); return err == nil })
+
+	conn, err := grpc.NewClient(addr, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer conn.Close()
+
+	recvCtx, recvCancel := context.WithTimeout(ctx, 3*time.Second)
+	defer recvCancel()
+	stream, err := pb.NewEventStreamServiceClient(conn).Subscribe(recvCtx, &pb.SubscribeRequest{})
+	if err != nil {
+		t.Fatalf("subscribe: %v", err)
+	}
+
+	resp, err := stream.Recv()
+	if err != nil {
+		t.Fatalf("recv: %v", err)
+	}
+	ti := resp.GetMeta().GetTarget()
+	if ti == nil {
+		t.Fatalf("first response carries no TargetInfo: %v", resp)
+	}
+
+	cancel()
+	<-runErr
+	return ti
+}
+
+// Every subscriber is told the scope of the stream before it sees an event —
+// in cgroup mode that is the only way to know events are subtree-wide and
+// carry no single pid.
+func TestSubscribeHandshakeDeclaresTarget(t *testing.T) {
+	t.Run("pid mode", func(t *testing.T) {
+		ti := handshakeFor(t, TargetPID(4242))
+		if ti.GetMode() != pb.TargetMode_TARGET_MODE_PID {
+			t.Errorf("mode = %v, want PID", ti.GetMode())
+		}
+		if ti.GetPid() != 4242 {
+			t.Errorf("pid = %d, want 4242", ti.GetPid())
+		}
+		if ti.GetCgroupPath() != "" || ti.GetCgroupId() != 0 {
+			t.Errorf("cgroup fields set in pid mode: %v", ti)
+		}
+	})
+
+	t.Run("cgroup mode", func(t *testing.T) {
+		const path = "/sys/fs/cgroup/kubepods.slice/pod.slice/ctr.scope"
+		ti := handshakeFor(t, TargetCgroup(path, 4026532))
+		if ti.GetMode() != pb.TargetMode_TARGET_MODE_CGROUP {
+			t.Errorf("mode = %v, want CGROUP", ti.GetMode())
+		}
+		if ti.GetCgroupPath() != path {
+			t.Errorf("cgroup_path = %q, want %q", ti.GetCgroupPath(), path)
+		}
+		if ti.GetCgroupId() != 4026532 {
+			t.Errorf("cgroup_id = %d, want 4026532", ti.GetCgroupId())
+		}
+		// No pid to report: the subtree is the target.
+		if ti.GetPid() != 0 {
+			t.Errorf("pid = %d, want 0 in cgroup mode", ti.GetPid())
+		}
+	})
+}
+
+// In cgroup mode the envelope pid stays 0: events come from anywhere in the
+// subtree, so stamping one process's pid on them would be a lie.
+func TestCgroupModeLeavesEnvelopePidUnset(t *testing.T) {
+	h := NewHub(TargetCgroup("/sys/fs/cgroup/x.scope", 7), "")
+	ev := h.targetInfo()
+	if ev.GetPid() != 0 {
+		t.Fatalf("handshake pid = %d, want 0", ev.GetPid())
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	f := newFake(4)
+	sub := h.subscribe(nil)
+	h.Start(ctx, []collector.Collector{f})
+	f.ch <- collector.CpuSample{UsagePct: 5, Timestamp: time.Now()}
+
+	select {
+	case resp := <-sub.ch:
+		if got := resp.GetEvent().GetPid(); got != 0 {
+			t.Errorf("event pid = %d, want 0 in cgroup mode", got)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("no event published")
+	}
+}
+
+func TestTargetString(t *testing.T) {
+	if got := TargetPID(7).String(); got != "pid 7" {
+		t.Errorf("String = %q", got)
+	}
+	if got := TargetCgroup("/a/b", 99).String(); got != "cgroup /a/b (id 99)" {
+		t.Errorf("String = %q", got)
+	}
+	if TargetPID(7).IsCgroup() {
+		t.Error("pid target reports cgroup mode")
+	}
+	if !TargetCgroup("/a", 1).IsCgroup() {
+		t.Error("cgroup target does not report cgroup mode")
+	}
+}

--- a/internal/serve/tls_test.go
+++ b/internal/serve/tls_test.go
@@ -213,7 +213,7 @@ func startTCPServer(ctx context.Context, t *testing.T, opts TLSOptions) string {
 	target := lis.Addr().String()
 	done := make(chan error, 1)
 	go func() {
-		done <- runServer(ctx, lis, creds, "test", 4242, []collector.Collector{f}, nil, Options{})
+		done <- runServer(ctx, lis, creds, "test", TargetPID(4242), []collector.Collector{f}, nil, Options{})
 	}()
 	t.Cleanup(func() {
 		select {
@@ -225,9 +225,13 @@ func startTCPServer(ctx context.Context, t *testing.T, opts TLSOptions) string {
 	return target
 }
 
-// firstEvent subscribes and returns the first event, or the error that stopped
+// firstEvent subscribes and returns the first EVENT, or the error that stopped
 // it. Used both for the success path and for the handshake-refusal paths, where
 // the failure surfaces on Subscribe or on the first Recv depending on timing.
+//
+// It skips StreamMeta responses on the way, which is what any correct consumer
+// does: the stream opens with a TargetInfo handshake meta (#94), and drop
+// notices are interleaved later.
 func firstEvent(ctx context.Context, target string, creds credentials.TransportCredentials) (*pb.Event, error) {
 	conn, err := grpc.NewClient(target, grpc.WithTransportCredentials(creds))
 	if err != nil {
@@ -241,11 +245,15 @@ func firstEvent(ctx context.Context, target string, creds credentials.TransportC
 	if err != nil {
 		return nil, err
 	}
-	resp, err := stream.Recv()
-	if err != nil {
-		return nil, err
+	for {
+		resp, err := stream.Recv()
+		if err != nil {
+			return nil, err
+		}
+		if ev := resp.GetEvent(); ev != nil {
+			return ev, nil
+		}
 	}
-	return resp.GetEvent(), nil
 }
 
 // A subscriber presenting a certificate from the trusted CA streams events

--- a/pkg/collector/cgroup_target_test.go
+++ b/pkg/collector/cgroup_target_test.go
@@ -1,0 +1,58 @@
+package collector
+
+import "testing"
+
+// The collectors that claim cgroup targeting must actually satisfy the
+// interface in every build configuration — including the stub builds, where the
+// method exists to fail cleanly. A compile-time assertion is the whole point:
+// NewSet's cgroup path takes CgroupTargeter, so a missing method is a build
+// error rather than a runtime surprise.
+var (
+	_ CgroupTargeter = (*CPUEBPFCollector)(nil)
+	_ CgroupTargeter = (*SyscallsEBPFCollector)(nil)
+	_ CgroupTargeter = (*IOEBPFCollector)(nil)
+	_ CgroupTargeter = (*NetworkEBPFCollector)(nil)
+	_ CgroupTargeter = (*FutexEBPFCollector)(nil)
+	_ CgroupTargeter = (*SecurityEBPFCollector)(nil)
+)
+
+// NewSet in cgroup mode must never touch the pid-shaped collectors, whatever
+// happens with eBPF. On a host without it (this test's own build, unless it
+// runs with -tags=ebpf as root) every StartCgroup fails and the Set comes back
+// empty — the point being that it comes back at all, with no /proc collector
+// silently started against a pid nobody asked about.
+func TestNewSetCgroupModeStartsNoPIDCollectors(t *testing.T) {
+	s := NewSet(SetConfig{Cgroup: "/sys/fs/cgroup/nonexistent-for-tests.scope"})
+	defer s.Stop()
+
+	if s.FD != nil || s.CPUProc != nil || s.ThreadsProc != nil || s.MemProc != nil ||
+		s.IOWait != nil || s.IOThroughput != nil || s.ProcContext != nil {
+		t.Error("cgroup mode started a /proc collector, which has no pid to read")
+	}
+	if s.HeapEBPF != nil || s.TLSEBPF != nil || s.SignalEBPF != nil || s.ProcLifecycleEBPF != nil {
+		t.Error("cgroup mode started a pid-bound eBPF collector")
+	}
+	if s.MemEBPF != nil || s.ThreadsEBPF != nil {
+		t.Error("cgroup mode started memory/threads, which read /proc/<pid> for their data")
+	}
+}
+
+// A PID <= 0 with a cgroup set is still cgroup mode: the cgroup wins, and the
+// absent pid must not send it down the pid path.
+func TestNewSetCgroupModeIgnoresPID(t *testing.T) {
+	s := NewSet(SetConfig{PID: 0, Cgroup: "/sys/fs/cgroup/nonexistent-for-tests.scope"})
+	defer s.Stop()
+	if s.FD != nil {
+		t.Error("started the fd collector with no pid")
+	}
+}
+
+// --no-ebpf in cgroup mode has nothing to fall back to, and must not quietly
+// start a /proc collector instead.
+func TestNewSetCgroupModeWithNoEBPF(t *testing.T) {
+	s := NewSet(SetConfig{Cgroup: "/sys/fs/cgroup/x.scope", NoEBPF: true})
+	defer s.Stop()
+	if len(s.Collectors()) != 0 {
+		t.Errorf("started %d collectors in --no-ebpf cgroup mode, want none", len(s.Collectors()))
+	}
+}

--- a/pkg/collector/cpu_ebpf.go
+++ b/pkg/collector/cpu_ebpf.go
@@ -37,8 +37,14 @@ func NewCPUEBPFCollector() *CPUEBPFCollector {
 	}
 }
 
-func (c *CPUEBPFCollector) Start(pid int) error {
-	tracer, err := bpf.OpenCPUTracer(bpf.TargetPID(pid))
+func (c *CPUEBPFCollector) Start(pid int) error { return c.start(bpf.TargetPID(pid)) }
+
+// StartCgroup samples every process in a cgroup subtree instead of one pid
+// (#94). Implements CgroupTargeter.
+func (c *CPUEBPFCollector) StartCgroup(spec string) error { return c.start(bpf.TargetCgroup(spec)) }
+
+func (c *CPUEBPFCollector) start(t bpf.Target) error {
+	tracer, err := bpf.OpenCPUTracer(t)
 	if err != nil {
 		return fmt.Errorf("cpu eBPF: %w", err)
 	}

--- a/pkg/collector/cpu_ebpf_stub.go
+++ b/pkg/collector/cpu_ebpf_stub.go
@@ -10,5 +10,10 @@ func NewCPUEBPFCollector() *CPUEBPFCollector { return &CPUEBPFCollector{} }
 func (*CPUEBPFCollector) Start(int) error {
 	return errors.New("eBPF cpu sampler not available in this build")
 }
+
+// StartCgroup mirrors Start: cgroup targeting is an eBPF feature (#94).
+func (*CPUEBPFCollector) StartCgroup(string) error {
+	return errors.New("eBPF cpu sampler not available in this build")
+}
 func (*CPUEBPFCollector) Stop()                          {}
 func (*CPUEBPFCollector) Subscribe() <-chan interface{}  { return nil }

--- a/pkg/collector/futex_ebpf.go
+++ b/pkg/collector/futex_ebpf.go
@@ -41,8 +41,16 @@ func NewFutexEBPFCollector() *FutexEBPFCollector {
 	}
 }
 
-func (c *FutexEBPFCollector) Start(pid int) error {
-	tracer, err := bpf.OpenFutexTracer(bpf.TargetPID(pid))
+func (c *FutexEBPFCollector) Start(pid int) error { return c.start(bpf.TargetPID(pid)) }
+
+// StartCgroup tracks futex contention across a whole cgroup subtree instead of
+// one pid (#94). Implements CgroupTargeter.
+func (c *FutexEBPFCollector) StartCgroup(spec string) error {
+	return c.start(bpf.TargetCgroup(spec))
+}
+
+func (c *FutexEBPFCollector) start(t bpf.Target) error {
+	tracer, err := bpf.OpenFutexTracer(t)
 	if err != nil {
 		return fmt.Errorf("futex eBPF: %w", err)
 	}

--- a/pkg/collector/futex_ebpf_stub.go
+++ b/pkg/collector/futex_ebpf_stub.go
@@ -14,6 +14,11 @@ func (c *FutexEBPFCollector) Start(pid int) error {
 	return errors.New("futex eBPF not available in this build")
 }
 
+// StartCgroup mirrors Start: cgroup targeting is an eBPF feature (#94).
+func (c *FutexEBPFCollector) StartCgroup(string) error {
+	return errors.New("futex eBPF not available in this build")
+}
+
 func (c *FutexEBPFCollector) Stop() {}
 
 func (c *FutexEBPFCollector) Subscribe() <-chan interface{} {

--- a/pkg/collector/io_ebpf.go
+++ b/pkg/collector/io_ebpf.go
@@ -67,8 +67,20 @@ func NewIOEBPFCollector() *IOEBPFCollector {
 	}
 }
 
-func (c *IOEBPFCollector) Start(pid int) error {
-	tracer, err := bpf.OpenIOTracer(bpf.TargetPID(pid))
+func (c *IOEBPFCollector) Start(pid int) error { return c.start(bpf.TargetPID(pid), pid) }
+
+// StartCgroup tracks I/O across a whole cgroup subtree instead of one pid
+// (#94). Implements CgroupTargeter.
+//
+// Byte counters and latency histograms are unaffected, but top-file PATHS come
+// out empty: resolving an fd to a path means reading /proc/<pid>/fd/<n>, and a
+// subtree has no single pid to read it from.
+func (c *IOEBPFCollector) StartCgroup(spec string) error {
+	return c.start(bpf.TargetCgroup(spec), 0)
+}
+
+func (c *IOEBPFCollector) start(t bpf.Target, pid int) error {
+	tracer, err := bpf.OpenIOTracer(t)
 	if err != nil {
 		return fmt.Errorf("io eBPF: %w", err)
 	}

--- a/pkg/collector/io_ebpf_stub.go
+++ b/pkg/collector/io_ebpf_stub.go
@@ -14,5 +14,11 @@ func NewIOEBPFCollector() *IOEBPFCollector { return &IOEBPFCollector{} }
 func (*IOEBPFCollector) Start(int) error {
 	return errors.New("eBPF io collector not available in this build")
 }
+
+// StartCgroup mirrors Start: cgroup targeting is an eBPF feature (#94).
+func (*IOEBPFCollector) StartCgroup(string) error {
+	return errors.New("eBPF io collector not available in this build")
+}
+
 func (*IOEBPFCollector) Stop()                          {}
 func (*IOEBPFCollector) Subscribe() <-chan interface{}  { return nil }

--- a/pkg/collector/network_darwin.go
+++ b/pkg/collector/network_darwin.go
@@ -3,6 +3,7 @@
 package collector
 
 import (
+	"errors"
 	"fmt"
 	"sort"
 	"time"
@@ -49,6 +50,11 @@ func (c *NetworkEBPFCollector) Start(pid int) error {
 	}
 	go c.loop()
 	return nil
+}
+
+// StartCgroup is unavailable on macOS: cgroups are a Linux mechanism (#94).
+func (c *NetworkEBPFCollector) StartCgroup(string) error {
+	return errors.New("cgroup targeting is Linux-only")
 }
 
 func (c *NetworkEBPFCollector) Stop()                          { close(c.stop) }

--- a/pkg/collector/network_ebpf.go
+++ b/pkg/collector/network_ebpf.go
@@ -49,8 +49,20 @@ func NewNetworkEBPFCollector() *NetworkEBPFCollector {
 	}
 }
 
-func (c *NetworkEBPFCollector) Start(pid int) error {
-	tracer, err := bpf.OpenNetTracer(bpf.TargetPID(pid))
+func (c *NetworkEBPFCollector) Start(pid int) error { return c.start(bpf.TargetPID(pid), pid) }
+
+// StartCgroup tracks connections across a whole cgroup subtree instead of one
+// pid (#94). Implements CgroupTargeter.
+//
+// The /proc bootstrap is skipped (it needs a pid), so connections that already
+// existed when ptop attached only appear once they show some activity. New
+// connections are tracked normally.
+func (c *NetworkEBPFCollector) StartCgroup(spec string) error {
+	return c.start(bpf.TargetCgroup(spec), 0)
+}
+
+func (c *NetworkEBPFCollector) start(t bpf.Target, pid int) error {
+	tracer, err := bpf.OpenNetTracer(t)
 	if err != nil {
 		return fmt.Errorf("network eBPF: %w", err)
 	}

--- a/pkg/collector/network_ebpf_stub.go
+++ b/pkg/collector/network_ebpf_stub.go
@@ -17,6 +17,11 @@ func (c *NetworkEBPFCollector) Start(pid int) error {
 	return errors.New("network eBPF not available in this build")
 }
 
+// StartCgroup mirrors Start: cgroup targeting is an eBPF feature (#94).
+func (c *NetworkEBPFCollector) StartCgroup(string) error {
+	return errors.New("network eBPF not available in this build")
+}
+
 func (c *NetworkEBPFCollector) Stop() {}
 
 func (c *NetworkEBPFCollector) Subscribe() <-chan interface{} {

--- a/pkg/collector/security_ebpf.go
+++ b/pkg/collector/security_ebpf.go
@@ -44,15 +44,27 @@ func NewSecurityEBPFCollector() *SecurityEBPFCollector {
 	}
 }
 
-func (c *SecurityEBPFCollector) Start(pid int) error {
-	tracer, err := bpf.OpenSecurityTracer(bpf.TargetPID(pid))
+func (c *SecurityEBPFCollector) Start(pid int) error { return c.start(bpf.TargetPID(pid), pid) }
+
+// StartCgroup watches a whole cgroup subtree instead of one pid (#94).
+// Implements CgroupTargeter. Call sites stay in hex: symbolization reads one
+// process's memory map, and a subtree has no single process to read.
+func (c *SecurityEBPFCollector) StartCgroup(spec string) error {
+	return c.start(bpf.TargetCgroup(spec), 0)
+}
+
+func (c *SecurityEBPFCollector) start(t bpf.Target, pid int) error {
+	tracer, err := bpf.OpenSecurityTracer(t)
 	if err != nil {
 		return fmt.Errorf("security eBPF: %w", err)
 	}
 	c.tracer = tracer
 	// Symbolize call sites best-effort: without /proc maps the sites degrade to
-	// hex — never fail Start over it (same as the heap collector).
-	if sym, err := symbol.NewSymbolizer(pid); err == nil {
+	// hex — never fail Start over it (same as the heap collector). With no pid
+	// (cgroup mode) there is nothing to symbolize against, so skip it quietly.
+	if pid <= 0 {
+		c.sym = nil
+	} else if sym, err := symbol.NewSymbolizer(pid); err == nil {
 		c.sym = sym
 	} else {
 		fmt.Fprintf(os.Stderr, "security: call-site symbolization unavailable for pid %d: %v\n", pid, err)

--- a/pkg/collector/security_ebpf_stub.go
+++ b/pkg/collector/security_ebpf_stub.go
@@ -16,6 +16,11 @@ func (*SecurityEBPFCollector) Start(pid int) error {
 	return errors.New("eBPF security collector not available in this build")
 }
 
+// StartCgroup mirrors Start: cgroup targeting is an eBPF feature (#94).
+func (*SecurityEBPFCollector) StartCgroup(string) error {
+	return errors.New("eBPF security collector not available in this build")
+}
+
 func (*SecurityEBPFCollector) Stop() {}
 
 func (*SecurityEBPFCollector) Subscribe() <-chan interface{} { return nil }

--- a/pkg/collector/set.go
+++ b/pkg/collector/set.go
@@ -12,6 +12,11 @@ type SetConfig struct {
 	PID    int
 	NoEBPF bool // degraded mode: skip eBPF, use /proc (or libproc on macOS) only
 
+	// Cgroup, when set, targets every process in that cgroup subtree instead of
+	// one PID (#94) — a cgroup path or a container id. It takes precedence over
+	// PID and starts a deliberately smaller set of collectors; see NewSet.
+	Cgroup string
+
 	// TLS opts into pre-encryption payload capture via libssl uprobes (#55) —
 	// OFF by default (privacy). TLSMaxBytes caps the plaintext copied per call
 	// (0 = metadata only: direction/fd/byte count, no payload bytes).
@@ -76,6 +81,10 @@ type Set struct {
 // collector that fails to start is left nil.
 func NewSet(cfg SetConfig) *Set {
 	s := &Set{}
+	if cfg.Cgroup != "" {
+		s.startCgroup(cfg)
+		return s
+	}
 	if cfg.PID <= 0 {
 		return s
 	}
@@ -246,6 +255,64 @@ func NewSet(cfg SetConfig) *Set {
 	}
 
 	return s
+}
+
+// startCgroup starts the collectors that can observe a whole cgroup subtree
+// (#94). It is deliberately a smaller set than PID mode, and the omissions are
+// structural rather than unfinished work:
+//
+//   - memory and threads read /proc/<pid>/statm and /proc/<pid>/task for RSS
+//     and thread enumeration — a subtree has no single pid to read;
+//   - heap and TLS attach uprobes into one process's mapped libc/libssl;
+//   - signals and exec lineage filter on a global pid of their own.
+//
+// Of the ones that do start, io loses top-file paths and security loses
+// symbolized call sites (both need /proc/<pid>), and network skips its /proc
+// bootstrap of pre-existing connections. Each StartCgroup documents its own
+// degradation.
+//
+// There is no /proc fallback and nothing is simulated here: cgroup targeting is
+// an in-kernel filter, so without eBPF there is simply nothing to start.
+func (s *Set) startCgroup(cfg SetConfig) {
+	if cfg.NoEBPF {
+		fmt.Fprintln(os.Stderr, "warning: --cgroup targeting needs eBPF; nothing started in --no-ebpf mode")
+		return
+	}
+
+	if c := NewCPUEBPFCollector(); startCgroupCollector("cpu", c, cfg.Cgroup) {
+		s.CPUEBPF = c
+		s.Sources.CPU = "eBPF"
+	}
+	if c := NewSyscallsEBPFCollector(); startCgroupCollector("syscalls", c, cfg.Cgroup) {
+		s.SyscallsEBPF = c
+		s.Sources.Syscalls = "eBPF"
+	}
+	if c := NewIOEBPFCollector(); startCgroupCollector("io", c, cfg.Cgroup) {
+		s.IOEBPF = c
+		s.Sources.IOFiles = "eBPF"
+	}
+	if c := NewNetworkEBPFCollector(); startCgroupCollector("network", c, cfg.Cgroup) {
+		s.NetworkEBPF = c
+		s.Sources.Net = SourceNetworkRich
+	}
+	if c := NewFutexEBPFCollector(); startCgroupCollector("futex", c, cfg.Cgroup) {
+		s.FutexEBPF = c
+		s.Sources.Locks = "eBPF"
+	}
+	if c := NewSecurityEBPFCollector(); startCgroupCollector("security", c, cfg.Cgroup) {
+		s.SecurityEBPF = c
+		s.Sources.Security = "eBPF"
+	}
+}
+
+// startCgroupCollector starts c against a cgroup subtree, reporting a failure
+// the same way PID mode does.
+func startCgroupCollector(name string, c CgroupTargeter, spec string) bool {
+	if err := c.StartCgroup(spec); err != nil {
+		warnEBPFFailure(name, err)
+		return false
+	}
+	return true
 }
 
 // Stop stops every started collector. It is idempotent and safe to call on a

--- a/pkg/collector/syscalls_ebpf.go
+++ b/pkg/collector/syscalls_ebpf.go
@@ -34,8 +34,16 @@ func NewSyscallsEBPFCollector() *SyscallsEBPFCollector {
 	}
 }
 
-func (c *SyscallsEBPFCollector) Start(pid int) error {
-	tracer, err := bpf.OpenSyscallTracer(bpf.TargetPID(pid))
+func (c *SyscallsEBPFCollector) Start(pid int) error { return c.start(bpf.TargetPID(pid)) }
+
+// StartCgroup counts syscalls across a whole cgroup subtree instead of one pid
+// (#94). Implements CgroupTargeter.
+func (c *SyscallsEBPFCollector) StartCgroup(spec string) error {
+	return c.start(bpf.TargetCgroup(spec))
+}
+
+func (c *SyscallsEBPFCollector) start(t bpf.Target) error {
+	tracer, err := bpf.OpenSyscallTracer(t)
 	if err != nil {
 		return fmt.Errorf("syscalls eBPF: %w", err)
 	}

--- a/pkg/collector/syscalls_ebpf_stub.go
+++ b/pkg/collector/syscalls_ebpf_stub.go
@@ -18,6 +18,11 @@ func (*SyscallsEBPFCollector) Start(pid int) error {
 	return errors.New("eBPF syscalls not available in this build")
 }
 
+// StartCgroup mirrors Start: cgroup targeting is an eBPF feature (#94).
+func (*SyscallsEBPFCollector) StartCgroup(string) error {
+	return errors.New("eBPF syscalls not available in this build")
+}
+
 func (*SyscallsEBPFCollector) Stop() {}
 
 func (*SyscallsEBPFCollector) Subscribe() <-chan interface{} {

--- a/pkg/collector/types.go
+++ b/pkg/collector/types.go
@@ -381,3 +381,17 @@ type Collector interface {
 	Stop()
 	Subscribe() <-chan interface{}
 }
+
+// CgroupTargeter is implemented by collectors that can observe every process in
+// a cgroup subtree instead of a single pid (#94) — spec being a cgroup path or
+// a container id. The in-kernel filter matches the subtree, so processes that
+// fork or exec inside it are covered without being named.
+//
+// Not every collector can: anything that reads /proc/<pid>/... for its data
+// (thread enumeration, RSS) or attaches uprobes into one address space (heap,
+// TLS) is bound to a single process, and deliberately does not implement this.
+// Some that do implement it lose a pid-shaped detail — see each StartCgroup.
+type CgroupTargeter interface {
+	Collector
+	StartCgroup(spec string) error
+}

--- a/pkg/streampb/service.pb.go
+++ b/pkg/streampb/service.pb.go
@@ -21,9 +21,63 @@ const (
 	_ = protoimpl.EnforceVersion(protoimpl.MaxVersion - 20)
 )
 
+// TargetMode is how the server was told what to observe (#94).
+type TargetMode int32
+
+const (
+	TargetMode_TARGET_MODE_UNSPECIFIED TargetMode = 0
+	// One process, matched by pid inside its own pid namespace.
+	TargetMode_TARGET_MODE_PID TargetMode = 1
+	// Every process in a cgroup subtree, matched by cgroup id. No pid is
+	// involved, so the subtree's forks are included automatically.
+	TargetMode_TARGET_MODE_CGROUP TargetMode = 2
+)
+
+// Enum value maps for TargetMode.
+var (
+	TargetMode_name = map[int32]string{
+		0: "TARGET_MODE_UNSPECIFIED",
+		1: "TARGET_MODE_PID",
+		2: "TARGET_MODE_CGROUP",
+	}
+	TargetMode_value = map[string]int32{
+		"TARGET_MODE_UNSPECIFIED": 0,
+		"TARGET_MODE_PID":         1,
+		"TARGET_MODE_CGROUP":      2,
+	}
+)
+
+func (x TargetMode) Enum() *TargetMode {
+	p := new(TargetMode)
+	*p = x
+	return p
+}
+
+func (x TargetMode) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (TargetMode) Descriptor() protoreflect.EnumDescriptor {
+	return file_service_proto_enumTypes[0].Descriptor()
+}
+
+func (TargetMode) Type() protoreflect.EnumType {
+	return &file_service_proto_enumTypes[0]
+}
+
+func (x TargetMode) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use TargetMode.Descriptor instead.
+func (TargetMode) EnumDescriptor() ([]byte, []int) {
+	return file_service_proto_rawDescGZIP(), []int{0}
+}
+
 // SubscribeRequest opens a stream. categories filters which Event categories
-// the server sends; empty means all. The target PID is fixed per server
-// instance (set via `ptop --serve --pid`), so it is not part of the request.
+// the server sends; empty means all. The target is fixed per server instance
+// (set via `ptop --serve --pid` or `--cgroup`), so it is not part of the
+// request — see TargetInfo, which the server reports on the stream.
 type SubscribeRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Categories    []Category             `protobuf:"varint,1,rep,packed,name=categories,proto3,enum=ptop.v1.Category" json:"categories,omitempty"`
@@ -68,20 +122,102 @@ func (x *SubscribeRequest) GetCategories() []Category {
 	return nil
 }
 
-// StreamMeta is an out-of-band signal interleaved in the stream. It reports
+// TargetInfo describes the SCOPE of everything on this stream. The server sends
+// it once, in the first StreamMeta of a subscription, before any event.
+//
+// It matters because the two modes aggregate differently. In PID mode every
+// Event.pid is the target. In CGROUP mode events come from any process in the
+// subtree, so Event.pid is 0 on the aggregate payloads (there is no single
+// process to name) and any pid inside a payload is a ROOT-namespace pid — a
+// subtree can span pid namespaces, so there is no namespace to project into.
+type TargetInfo struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	Mode  TargetMode             `protobuf:"varint,1,opt,name=mode,proto3,enum=ptop.v1.TargetMode" json:"mode,omitempty"`
+	// PID mode: the target pid. 0 in cgroup mode.
+	Pid int32 `protobuf:"varint,2,opt,name=pid,proto3" json:"pid,omitempty"`
+	// CGROUP mode: the resolved absolute cgroup path, and the cgroup id it
+	// resolved to (the directory inode). Empty/0 in pid mode.
+	CgroupPath    string `protobuf:"bytes,3,opt,name=cgroup_path,json=cgroupPath,proto3" json:"cgroup_path,omitempty"`
+	CgroupId      uint64 `protobuf:"varint,4,opt,name=cgroup_id,json=cgroupId,proto3" json:"cgroup_id,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *TargetInfo) Reset() {
+	*x = TargetInfo{}
+	mi := &file_service_proto_msgTypes[1]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *TargetInfo) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*TargetInfo) ProtoMessage() {}
+
+func (x *TargetInfo) ProtoReflect() protoreflect.Message {
+	mi := &file_service_proto_msgTypes[1]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use TargetInfo.ProtoReflect.Descriptor instead.
+func (*TargetInfo) Descriptor() ([]byte, []int) {
+	return file_service_proto_rawDescGZIP(), []int{1}
+}
+
+func (x *TargetInfo) GetMode() TargetMode {
+	if x != nil {
+		return x.Mode
+	}
+	return TargetMode_TARGET_MODE_UNSPECIFIED
+}
+
+func (x *TargetInfo) GetPid() int32 {
+	if x != nil {
+		return x.Pid
+	}
+	return 0
+}
+
+func (x *TargetInfo) GetCgroupPath() string {
+	if x != nil {
+		return x.CgroupPath
+	}
+	return ""
+}
+
+func (x *TargetInfo) GetCgroupId() uint64 {
+	if x != nil {
+		return x.CgroupId
+	}
+	return 0
+}
+
+// StreamMeta is an out-of-band signal interleaved in the stream. It carries the
+// subscription handshake (target, sent once before any event) and reports
 // backpressure: how many events the server dropped for this subscriber because
 // it could not keep up (cumulative). The collector is never blocked by a slow
 // consumer — events are dropped and counted instead.
 type StreamMeta struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Dropped       uint64                 `protobuf:"varint,1,opt,name=dropped,proto3" json:"dropped,omitempty"`
+	state   protoimpl.MessageState `protogen:"open.v1"`
+	Dropped uint64                 `protobuf:"varint,1,opt,name=dropped,proto3" json:"dropped,omitempty"`
+	// Set on the handshake meta only; nil on backpressure notices.
+	Target        *TargetInfo `protobuf:"bytes,2,opt,name=target,proto3" json:"target,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
 
 func (x *StreamMeta) Reset() {
 	*x = StreamMeta{}
-	mi := &file_service_proto_msgTypes[1]
+	mi := &file_service_proto_msgTypes[2]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -93,7 +229,7 @@ func (x *StreamMeta) String() string {
 func (*StreamMeta) ProtoMessage() {}
 
 func (x *StreamMeta) ProtoReflect() protoreflect.Message {
-	mi := &file_service_proto_msgTypes[1]
+	mi := &file_service_proto_msgTypes[2]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -106,7 +242,7 @@ func (x *StreamMeta) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use StreamMeta.ProtoReflect.Descriptor instead.
 func (*StreamMeta) Descriptor() ([]byte, []int) {
-	return file_service_proto_rawDescGZIP(), []int{1}
+	return file_service_proto_rawDescGZIP(), []int{2}
 }
 
 func (x *StreamMeta) GetDropped() uint64 {
@@ -114,6 +250,13 @@ func (x *StreamMeta) GetDropped() uint64 {
 		return x.Dropped
 	}
 	return 0
+}
+
+func (x *StreamMeta) GetTarget() *TargetInfo {
+	if x != nil {
+		return x.Target
+	}
+	return nil
 }
 
 // SubscribeResponse is one item in the stream: either a captured Event or a
@@ -131,7 +274,7 @@ type SubscribeResponse struct {
 
 func (x *SubscribeResponse) Reset() {
 	*x = SubscribeResponse{}
-	mi := &file_service_proto_msgTypes[2]
+	mi := &file_service_proto_msgTypes[3]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -143,7 +286,7 @@ func (x *SubscribeResponse) String() string {
 func (*SubscribeResponse) ProtoMessage() {}
 
 func (x *SubscribeResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_service_proto_msgTypes[2]
+	mi := &file_service_proto_msgTypes[3]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -156,7 +299,7 @@ func (x *SubscribeResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SubscribeResponse.ProtoReflect.Descriptor instead.
 func (*SubscribeResponse) Descriptor() ([]byte, []int) {
-	return file_service_proto_rawDescGZIP(), []int{2}
+	return file_service_proto_rawDescGZIP(), []int{3}
 }
 
 func (x *SubscribeResponse) GetKind() isSubscribeResponse_Kind {
@@ -212,7 +355,7 @@ type ResolveStackRequest struct {
 
 func (x *ResolveStackRequest) Reset() {
 	*x = ResolveStackRequest{}
-	mi := &file_service_proto_msgTypes[3]
+	mi := &file_service_proto_msgTypes[4]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -224,7 +367,7 @@ func (x *ResolveStackRequest) String() string {
 func (*ResolveStackRequest) ProtoMessage() {}
 
 func (x *ResolveStackRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_service_proto_msgTypes[3]
+	mi := &file_service_proto_msgTypes[4]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -237,7 +380,7 @@ func (x *ResolveStackRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ResolveStackRequest.ProtoReflect.Descriptor instead.
 func (*ResolveStackRequest) Descriptor() ([]byte, []int) {
-	return file_service_proto_rawDescGZIP(), []int{3}
+	return file_service_proto_rawDescGZIP(), []int{4}
 }
 
 func (x *ResolveStackRequest) GetStackId() uint64 {
@@ -260,7 +403,7 @@ type ResolveStackResponse struct {
 
 func (x *ResolveStackResponse) Reset() {
 	*x = ResolveStackResponse{}
-	mi := &file_service_proto_msgTypes[4]
+	mi := &file_service_proto_msgTypes[5]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -272,7 +415,7 @@ func (x *ResolveStackResponse) String() string {
 func (*ResolveStackResponse) ProtoMessage() {}
 
 func (x *ResolveStackResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_service_proto_msgTypes[4]
+	mi := &file_service_proto_msgTypes[5]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -285,7 +428,7 @@ func (x *ResolveStackResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ResolveStackResponse.ProtoReflect.Descriptor instead.
 func (*ResolveStackResponse) Descriptor() ([]byte, []int) {
-	return file_service_proto_rawDescGZIP(), []int{4}
+	return file_service_proto_rawDescGZIP(), []int{5}
 }
 
 func (x *ResolveStackResponse) GetFrames() []*StackFrame {
@@ -310,10 +453,18 @@ const file_service_proto_rawDesc = "" +
 	"\x10SubscribeRequest\x121\n" +
 	"\n" +
 	"categories\x18\x01 \x03(\x0e2\x11.ptop.v1.CategoryR\n" +
-	"categories\"&\n" +
+	"categories\"\x85\x01\n" +
+	"\n" +
+	"TargetInfo\x12'\n" +
+	"\x04mode\x18\x01 \x01(\x0e2\x13.ptop.v1.TargetModeR\x04mode\x12\x10\n" +
+	"\x03pid\x18\x02 \x01(\x05R\x03pid\x12\x1f\n" +
+	"\vcgroup_path\x18\x03 \x01(\tR\n" +
+	"cgroupPath\x12\x1b\n" +
+	"\tcgroup_id\x18\x04 \x01(\x04R\bcgroupId\"S\n" +
 	"\n" +
 	"StreamMeta\x12\x18\n" +
-	"\adropped\x18\x01 \x01(\x04R\adropped\"n\n" +
+	"\adropped\x18\x01 \x01(\x04R\adropped\x12+\n" +
+	"\x06target\x18\x02 \x01(\v2\x13.ptop.v1.TargetInfoR\x06target\"n\n" +
 	"\x11SubscribeResponse\x12&\n" +
 	"\x05event\x18\x01 \x01(\v2\x0e.ptop.v1.EventH\x00R\x05event\x12)\n" +
 	"\x04meta\x18\x02 \x01(\v2\x13.ptop.v1.StreamMetaH\x00R\x04metaB\x06\n" +
@@ -322,7 +473,12 @@ const file_service_proto_rawDesc = "" +
 	"\bstack_id\x18\x01 \x01(\x04R\astackId\"Y\n" +
 	"\x14ResolveStackResponse\x12+\n" +
 	"\x06frames\x18\x01 \x03(\v2\x13.ptop.v1.StackFrameR\x06frames\x12\x14\n" +
-	"\x05found\x18\x02 \x01(\bR\x05found2\xa7\x01\n" +
+	"\x05found\x18\x02 \x01(\bR\x05found*V\n" +
+	"\n" +
+	"TargetMode\x12\x1b\n" +
+	"\x17TARGET_MODE_UNSPECIFIED\x10\x00\x12\x13\n" +
+	"\x0fTARGET_MODE_PID\x10\x01\x12\x16\n" +
+	"\x12TARGET_MODE_CGROUP\x10\x022\xa7\x01\n" +
 	"\x12EventStreamService\x12D\n" +
 	"\tSubscribe\x12\x19.ptop.v1.SubscribeRequest\x1a\x1a.ptop.v1.SubscribeResponse0\x01\x12K\n" +
 	"\fResolveStack\x12\x1c.ptop.v1.ResolveStackRequest\x1a\x1d.ptop.v1.ResolveStackResponseB\x87\x01\n" +
@@ -340,31 +496,36 @@ func file_service_proto_rawDescGZIP() []byte {
 	return file_service_proto_rawDescData
 }
 
-var file_service_proto_msgTypes = make([]protoimpl.MessageInfo, 5)
+var file_service_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
+var file_service_proto_msgTypes = make([]protoimpl.MessageInfo, 6)
 var file_service_proto_goTypes = []any{
-	(*SubscribeRequest)(nil),     // 0: ptop.v1.SubscribeRequest
-	(*StreamMeta)(nil),           // 1: ptop.v1.StreamMeta
-	(*SubscribeResponse)(nil),    // 2: ptop.v1.SubscribeResponse
-	(*ResolveStackRequest)(nil),  // 3: ptop.v1.ResolveStackRequest
-	(*ResolveStackResponse)(nil), // 4: ptop.v1.ResolveStackResponse
-	(Category)(0),                // 5: ptop.v1.Category
-	(*Event)(nil),                // 6: ptop.v1.Event
-	(*StackFrame)(nil),           // 7: ptop.v1.StackFrame
+	(TargetMode)(0),              // 0: ptop.v1.TargetMode
+	(*SubscribeRequest)(nil),     // 1: ptop.v1.SubscribeRequest
+	(*TargetInfo)(nil),           // 2: ptop.v1.TargetInfo
+	(*StreamMeta)(nil),           // 3: ptop.v1.StreamMeta
+	(*SubscribeResponse)(nil),    // 4: ptop.v1.SubscribeResponse
+	(*ResolveStackRequest)(nil),  // 5: ptop.v1.ResolveStackRequest
+	(*ResolveStackResponse)(nil), // 6: ptop.v1.ResolveStackResponse
+	(Category)(0),                // 7: ptop.v1.Category
+	(*Event)(nil),                // 8: ptop.v1.Event
+	(*StackFrame)(nil),           // 9: ptop.v1.StackFrame
 }
 var file_service_proto_depIdxs = []int32{
-	5, // 0: ptop.v1.SubscribeRequest.categories:type_name -> ptop.v1.Category
-	6, // 1: ptop.v1.SubscribeResponse.event:type_name -> ptop.v1.Event
-	1, // 2: ptop.v1.SubscribeResponse.meta:type_name -> ptop.v1.StreamMeta
-	7, // 3: ptop.v1.ResolveStackResponse.frames:type_name -> ptop.v1.StackFrame
-	0, // 4: ptop.v1.EventStreamService.Subscribe:input_type -> ptop.v1.SubscribeRequest
-	3, // 5: ptop.v1.EventStreamService.ResolveStack:input_type -> ptop.v1.ResolveStackRequest
-	2, // 6: ptop.v1.EventStreamService.Subscribe:output_type -> ptop.v1.SubscribeResponse
-	4, // 7: ptop.v1.EventStreamService.ResolveStack:output_type -> ptop.v1.ResolveStackResponse
-	6, // [6:8] is the sub-list for method output_type
-	4, // [4:6] is the sub-list for method input_type
-	4, // [4:4] is the sub-list for extension type_name
-	4, // [4:4] is the sub-list for extension extendee
-	0, // [0:4] is the sub-list for field type_name
+	7, // 0: ptop.v1.SubscribeRequest.categories:type_name -> ptop.v1.Category
+	0, // 1: ptop.v1.TargetInfo.mode:type_name -> ptop.v1.TargetMode
+	2, // 2: ptop.v1.StreamMeta.target:type_name -> ptop.v1.TargetInfo
+	8, // 3: ptop.v1.SubscribeResponse.event:type_name -> ptop.v1.Event
+	3, // 4: ptop.v1.SubscribeResponse.meta:type_name -> ptop.v1.StreamMeta
+	9, // 5: ptop.v1.ResolveStackResponse.frames:type_name -> ptop.v1.StackFrame
+	1, // 6: ptop.v1.EventStreamService.Subscribe:input_type -> ptop.v1.SubscribeRequest
+	5, // 7: ptop.v1.EventStreamService.ResolveStack:input_type -> ptop.v1.ResolveStackRequest
+	4, // 8: ptop.v1.EventStreamService.Subscribe:output_type -> ptop.v1.SubscribeResponse
+	6, // 9: ptop.v1.EventStreamService.ResolveStack:output_type -> ptop.v1.ResolveStackResponse
+	8, // [8:10] is the sub-list for method output_type
+	6, // [6:8] is the sub-list for method input_type
+	6, // [6:6] is the sub-list for extension type_name
+	6, // [6:6] is the sub-list for extension extendee
+	0, // [0:6] is the sub-list for field type_name
 }
 
 func init() { file_service_proto_init() }
@@ -373,7 +534,7 @@ func file_service_proto_init() {
 		return
 	}
 	file_event_proto_init()
-	file_service_proto_msgTypes[2].OneofWrappers = []any{
+	file_service_proto_msgTypes[3].OneofWrappers = []any{
 		(*SubscribeResponse_Event)(nil),
 		(*SubscribeResponse_Meta)(nil),
 	}
@@ -382,13 +543,14 @@ func file_service_proto_init() {
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_service_proto_rawDesc), len(file_service_proto_rawDesc)),
-			NumEnums:      0,
-			NumMessages:   5,
+			NumEnums:      1,
+			NumMessages:   6,
 			NumExtensions: 0,
 			NumServices:   1,
 		},
 		GoTypes:           file_service_proto_goTypes,
 		DependencyIndexes: file_service_proto_depIdxs,
+		EnumInfos:         file_service_proto_enumTypes,
 		MessageInfos:      file_service_proto_msgTypes,
 	}.Build()
 	File_service_proto = out.File

--- a/pkg/streampb/service_grpc.pb.go
+++ b/pkg/streampb/service_grpc.pb.go
@@ -30,8 +30,10 @@ const (
 // EventStreamService is ptop's headless collection surface. ptop runs with the
 // elevated capabilities (CAP_BPF/CAP_PERFMON); subscribers connect with none.
 type EventStreamServiceClient interface {
-	// Subscribe streams collector events for the server's target PID until the
-	// client disconnects. Multiple subscribers fan out from one collector.
+	// Subscribe streams collector events for the server's target until the client
+	// disconnects. The first response is always a StreamMeta carrying TargetInfo,
+	// so a consumer knows the scope of what follows. Multiple subscribers fan out
+	// from one collector.
 	Subscribe(ctx context.Context, in *SubscribeRequest, opts ...grpc.CallOption) (grpc.ServerStreamingClient[SubscribeResponse], error)
 	// ResolveStack symbolizes a stack id seen on the stream into its leaf-first
 	// frames — an out-of-band lookup so high-rate events stay small (they carry
@@ -83,8 +85,10 @@ func (c *eventStreamServiceClient) ResolveStack(ctx context.Context, in *Resolve
 // EventStreamService is ptop's headless collection surface. ptop runs with the
 // elevated capabilities (CAP_BPF/CAP_PERFMON); subscribers connect with none.
 type EventStreamServiceServer interface {
-	// Subscribe streams collector events for the server's target PID until the
-	// client disconnects. Multiple subscribers fan out from one collector.
+	// Subscribe streams collector events for the server's target until the client
+	// disconnects. The first response is always a StreamMeta carrying TargetInfo,
+	// so a consumer knows the scope of what follows. Multiple subscribers fan out
+	// from one collector.
 	Subscribe(*SubscribeRequest, grpc.ServerStreamingServer[SubscribeResponse]) error
 	// ResolveStack symbolizes a stack id seen on the stream into its leaf-first
 	// frames — an out-of-band lookup so high-rate events stay small (they carry

--- a/proto/service.proto
+++ b/proto/service.proto
@@ -7,18 +7,50 @@ import "event.proto";
 option go_package = "github.com/trentas/ptop/pkg/streampb;streampb";
 
 // SubscribeRequest opens a stream. categories filters which Event categories
-// the server sends; empty means all. The target PID is fixed per server
-// instance (set via `ptop --serve --pid`), so it is not part of the request.
+// the server sends; empty means all. The target is fixed per server instance
+// (set via `ptop --serve --pid` or `--cgroup`), so it is not part of the
+// request — see TargetInfo, which the server reports on the stream.
 message SubscribeRequest {
   repeated Category categories = 1;
 }
 
-// StreamMeta is an out-of-band signal interleaved in the stream. It reports
+// TargetMode is how the server was told what to observe (#94).
+enum TargetMode {
+  TARGET_MODE_UNSPECIFIED = 0;
+  // One process, matched by pid inside its own pid namespace.
+  TARGET_MODE_PID = 1;
+  // Every process in a cgroup subtree, matched by cgroup id. No pid is
+  // involved, so the subtree's forks are included automatically.
+  TARGET_MODE_CGROUP = 2;
+}
+
+// TargetInfo describes the SCOPE of everything on this stream. The server sends
+// it once, in the first StreamMeta of a subscription, before any event.
+//
+// It matters because the two modes aggregate differently. In PID mode every
+// Event.pid is the target. In CGROUP mode events come from any process in the
+// subtree, so Event.pid is 0 on the aggregate payloads (there is no single
+// process to name) and any pid inside a payload is a ROOT-namespace pid — a
+// subtree can span pid namespaces, so there is no namespace to project into.
+message TargetInfo {
+  TargetMode mode = 1;
+  // PID mode: the target pid. 0 in cgroup mode.
+  int32 pid = 2;
+  // CGROUP mode: the resolved absolute cgroup path, and the cgroup id it
+  // resolved to (the directory inode). Empty/0 in pid mode.
+  string cgroup_path = 3;
+  uint64 cgroup_id = 4;
+}
+
+// StreamMeta is an out-of-band signal interleaved in the stream. It carries the
+// subscription handshake (target, sent once before any event) and reports
 // backpressure: how many events the server dropped for this subscriber because
 // it could not keep up (cumulative). The collector is never blocked by a slow
 // consumer — events are dropped and counted instead.
 message StreamMeta {
   uint64 dropped = 1;
+  // Set on the handshake meta only; nil on backpressure notices.
+  TargetInfo target = 2;
 }
 
 // SubscribeResponse is one item in the stream: either a captured Event or a
@@ -48,8 +80,10 @@ message ResolveStackResponse {
 // EventStreamService is ptop's headless collection surface. ptop runs with the
 // elevated capabilities (CAP_BPF/CAP_PERFMON); subscribers connect with none.
 service EventStreamService {
-  // Subscribe streams collector events for the server's target PID until the
-  // client disconnects. Multiple subscribers fan out from one collector.
+  // Subscribe streams collector events for the server's target until the client
+  // disconnects. The first response is always a StreamMeta carrying TargetInfo,
+  // so a consumer knows the scope of what follows. Multiple subscribers fan out
+  // from one collector.
   rpc Subscribe(SubscribeRequest) returns (stream SubscribeResponse);
 
   // ResolveStack symbolizes a stack id seen on the stream into its leaf-first


### PR DESCRIPTION
Closes #94. **Stacked on #99** — base is `feat/cgroup-target`. Merge #99 first, then check this diff before merging so it does not carry #99's commits.

#99 taught the kernel-side filter to match a cgroup subtree. This is the surface: `ptop --cgroup <path|container-id> --serve <addr>` observes a container or a whole pod without knowing any pid — a consumer can attach to a workload chosen by Kubernetes identity instead of by looking up what it currently runs as.

## Resolution and refusals

The spec resolves once, at startup, via `bpf.ResolveCgroupSpec`: a bad path or an ambiguous container id fails before a single tracer loads, and the log reports which cgroup an id actually matched. `checkTargetFlags` rejects what cannot hold:

| Combination | Refused because |
|---|---|
| `--cgroup` + `--pid` | two different targets |
| `--cgroup` without `--serve` | the TUI's header, thread table and fd list are all one process's |
| `--cgroup` + `--no-ebpf` | the subtree filter runs in the kernel |

## A smaller collector set, on purpose

Cgroup mode starts syscalls, I/O, network, locks, CPU and security. The omissions are structural:

| Not started | Why |
|---|---|
| memory, threads | RSS and thread enumeration come from `/proc/<pid>/statm` and `/proc/<pid>/task` |
| heap (#53), TLS (#55) | uprobes attach into one process's mapped libc/libssl |
| signals (#58), lineage (#60) | they filter on a global pid of their own |

Two that do start degrade, and say so in their own doc comments: I/O reports no file paths (an fd becomes a path through `/proc/<pid>/fd`) and security call sites stay in hex (symbolization reads one process's memory map). The new `CgroupTargeter` interface is what marks a collector as capable, so this is a compile-time distinction rather than a runtime disappointment — `pkg/collector/cgroup_target_test.go` asserts both the interface satisfaction and that cgroup mode starts no pid-shaped collector.

## ⚠️ The stream shape changes

Consumers cannot be left guessing which mode they are receiving, because the modes aggregate differently: in cgroup mode there is no single pid to stamp, so `Event.pid` is 0. `TargetInfo` (new, in `StreamMeta`) now rides the **first response of every subscription, before any event**.

So **the first item on a stream is a meta, not an event**. `SubscribeResponse` always allowed it — a correct consumer type-switches on the oneof — but anything that assumed event-first needs a look. Worth checking witness before this merges.

## Verification

- New tests, all running here on macOS: the handshake in both modes end-to-end over real gRPC, the envelope pid staying 0 in cgroup mode, `checkTargetFlags` as a 10-case table, and the `Set` cgroup path starting nothing pid-shaped. Whole suite green under `-race`, plus `GOOS=linux go vet -tags=ebpf ./...`.
- Real binary: all four refusal paths exit 1 with an actionable message, and on this non-eBPF build `--cgroup` fails with `cgroup targeting requires Linux with eBPF support`.
- **Still not verified against a live kernel** — same caveat as #99. `sudo ./bin/ebpf-selftest` on Linux is the check for the filter itself; a real `--cgroup` run against a container is the check for this layer.

## Note for whoever merges

This branch is cut from `main` via #99, so it does not contain the TLS work in #96/#98. Both touch `internal/serve/serve.go` (that chain wraps `Run` in a `runServer` split; this one changes `Run`'s signature to take a `Target`), so **whichever chain lands second needs a rebase** — the conflict is small but real.

🤖 Generated with [Claude Code](https://claude.com/claude-code)