### PR TITLE
serve: open the JSONL export with the target header

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -421,7 +421,10 @@ collector→`streampb` mapping + server live in `internal/serve`.
 
 The gRPC subscriber and the JSONL writer are interchangeable `Sink`s
 (`internal/serve/sink.go`) fed by the hub. `--serve --export` adds the JSONL
-sink: it writes one protojson `Event` per line to `ptop-events-<ts>.jsonl`
+sink: its first line is a protojson `StreamMeta` carrying `TargetInfo` (the same
+handshake a gRPC subscriber gets — without it an export is unattributable, since
+cgroup-mode events have `pid` 0 and several payloads carry no pid), and every
+line after it is one protojson `Event`, in `ptop-events-<ts>.jsonl`
 (event-level — distinct from the TUI's state-snapshot `ptop-export-<ts>.jsonl`).
 
 Stack symbolization (#54) rides this surface: heap events carry a

--- a/README.md
+++ b/README.md
@@ -232,7 +232,8 @@ eBPF programs in `internal/bpf/programs/`:
 The TUI is one consumer of a richer event model. `ptop --pid <PID> --serve
 <addr>` runs headless and streams every observation as a typed protobuf `Event`
 over gRPC (package `ptop.v1`) to any number of unprivileged subscribers — and,
-with `--export`, also as one protojson line per event to a JSONL file. ptop
+with `--export`, also to a JSONL file: a `StreamMeta` header line naming the
+target, then one protojson line per event. ptop
 holds `CAP_BPF`/`CAP_PERFMON`; subscribers connect with none.
 
 ### Transport security

--- a/internal/serve/serve.go
+++ b/internal/serve/serve.go
@@ -104,7 +104,7 @@ func runServer(ctx context.Context, lis net.Listener, creds credentials.Transpor
 
 	// Optional JSONL sink: a non-gRPC consumer of the same event stream.
 	if opts.JSONLPath != "" {
-		js, err := newJSONLSink(opts.JSONLPath)
+		js, err := newJSONLSink(opts.JSONLPath, hub.targetInfo())
 		if err != nil {
 			return fmt.Errorf("serve: jsonl export: %w", err)
 		}

--- a/internal/serve/serve_test.go
+++ b/internal/serve/serve_test.go
@@ -204,8 +204,22 @@ func TestServeJSONLExport(t *testing.T) {
 		t.Fatalf("open jsonl: %v", err)
 	}
 	defer f2.Close()
-	var lines int
 	sc := bufio.NewScanner(f2)
+
+	// The export opens with the same target handshake a gRPC subscriber gets,
+	// so the file says what it observed. Events follow.
+	if !sc.Scan() {
+		t.Fatal("empty export: no target header")
+	}
+	var meta pb.StreamMeta
+	if err := protojson.Unmarshal(sc.Bytes(), &meta); err != nil {
+		t.Fatalf("first line is not a StreamMeta: %v", err)
+	}
+	if meta.GetTarget().GetPid() != 5 {
+		t.Errorf("header target = %v, want pid 5", meta.GetTarget())
+	}
+
+	var lines int
 	for sc.Scan() {
 		var ev pb.Event
 		if err := protojson.Unmarshal(sc.Bytes(), &ev); err != nil {

--- a/internal/serve/sink.go
+++ b/internal/serve/sink.go
@@ -63,9 +63,16 @@ func (s *grpcSink) Emit(ev *pb.Event) {
 
 func (s *grpcSink) Close() error { return nil }
 
-// jsonlSink writes every event as one protojson line to a file. A bounded
-// channel + writer goroutine keep disk I/O off the hub's broadcast path; on
-// overflow events are dropped and counted (reported on Close).
+// jsonlSink writes a target header followed by every event as one protojson
+// line to a file. A bounded channel + writer goroutine keep disk I/O off the
+// hub's broadcast path; on overflow events are dropped and counted (reported on
+// Close).
+//
+// The FIRST line is a StreamMeta carrying TargetInfo, mirroring the handshake a
+// gRPC subscriber receives; every line after it is an Event. Without it an
+// export is unattributable after the fact — nothing in a file of cgroup-mode
+// events says which cgroup produced them, since the envelope pid is 0 there and
+// several payloads carry no pid of their own.
 type jsonlSink struct {
 	w       io.WriteCloser
 	ch      chan *pb.Event
@@ -73,20 +80,42 @@ type jsonlSink struct {
 	dropped uint64
 }
 
-func newJSONLSink(path string) (*jsonlSink, error) {
+func newJSONLSink(path string, target *pb.TargetInfo) (*jsonlSink, error) {
 	f, err := os.OpenFile(path, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0o644)
 	if err != nil {
 		return nil, err
 	}
-	return newJSONLSinkWriter(f), nil
+	s, err := newJSONLSinkWriter(f, target)
+	if err != nil {
+		_ = f.Close()
+		return nil, err
+	}
+	return s, nil
 }
 
 // newJSONLSinkWriter is the testable core: it writes to any WriteCloser.
-func newJSONLSinkWriter(w io.WriteCloser) *jsonlSink {
+//
+// The header is written synchronously, before the writer goroutine starts, so
+// it is line 1 whatever the scheduler does — and a file that cannot even take
+// its header fails here, at startup, instead of producing a headerless export.
+func newJSONLSinkWriter(w io.WriteCloser, target *pb.TargetInfo) (*jsonlSink, error) {
+	if target != nil {
+		b, err := jsonlMarshal.Marshal(&pb.StreamMeta{Target: target})
+		if err != nil {
+			return nil, fmt.Errorf("serve: jsonl target header: %w", err)
+		}
+		if _, err := w.Write(append(b, '\n')); err != nil {
+			return nil, fmt.Errorf("serve: jsonl target header: %w", err)
+		}
+	}
 	s := &jsonlSink{w: w, ch: make(chan *pb.Event, subBuffer), done: make(chan struct{})}
 	go s.run()
-	return s
+	return s, nil
 }
+
+// jsonlMarshal keeps the header and the events on identical marshalling terms:
+// compact, one object per line.
+var jsonlMarshal = protojson.MarshalOptions{}
 
 func (s *jsonlSink) Emit(ev *pb.Event) {
 	select {
@@ -98,9 +127,8 @@ func (s *jsonlSink) Emit(ev *pb.Event) {
 
 func (s *jsonlSink) run() {
 	defer close(s.done)
-	opts := protojson.MarshalOptions{} // compact, one object per line
 	for ev := range s.ch {
-		b, err := opts.Marshal(ev)
+		b, err := jsonlMarshal.Marshal(ev)
 		if err != nil {
 			continue
 		}

--- a/internal/serve/sink_test.go
+++ b/internal/serve/sink_test.go
@@ -2,8 +2,10 @@ package serve
 
 import (
 	"bufio"
+	"errors"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -14,11 +16,14 @@ import (
 	pb "github.com/trentas/ptop/pkg/streampb"
 )
 
-// jsonlSink writes one parseable protojson Event per line, and Close flushes
-// what's queued.
+// jsonlSink opens with a target header, then writes one parseable protojson
+// Event per line, and Close flushes what's queued.
 func TestJSONLSinkRoundTrip(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "events.jsonl")
-	s, err := newJSONLSink(path)
+	s, err := newJSONLSink(path, &pb.TargetInfo{
+		Mode: pb.TargetMode_TARGET_MODE_PID,
+		Pid:  7,
+	})
 	if err != nil {
 		t.Fatalf("newJSONLSink: %v", err)
 	}
@@ -41,8 +46,21 @@ func TestJSONLSinkRoundTrip(t *testing.T) {
 	}
 	defer f.Close()
 
-	var lines int
 	sc := bufio.NewScanner(f)
+
+	// Line 1 is the header, not an event.
+	if !sc.Scan() {
+		t.Fatal("empty export: no target header")
+	}
+	var meta pb.StreamMeta
+	if err := protojson.Unmarshal(sc.Bytes(), &meta); err != nil {
+		t.Fatalf("first line is not a StreamMeta: %v", err)
+	}
+	if meta.GetTarget().GetPid() != 7 || meta.GetTarget().GetMode() != pb.TargetMode_TARGET_MODE_PID {
+		t.Errorf("header target = %v, want pid mode for pid 7", meta.GetTarget())
+	}
+
+	var lines int
 	for sc.Scan() {
 		var ev pb.Event
 		if err := protojson.Unmarshal(sc.Bytes(), &ev); err != nil {
@@ -54,9 +72,63 @@ func TestJSONLSinkRoundTrip(t *testing.T) {
 		lines++
 	}
 	if lines != n {
-		t.Errorf("got %d lines, want %d", lines, n)
+		t.Errorf("got %d event lines, want %d", lines, n)
 	}
 }
+
+// A cgroup-mode export must be attributable: the events carry no pid at all, so
+// the header is the only thing that says what was observed.
+func TestJSONLSinkHeaderCarriesCgroupTarget(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "events.jsonl")
+	const cg = "/sys/fs/cgroup/kubepods.slice/pod.slice/ctr.scope"
+	s, err := newJSONLSink(path, &pb.TargetInfo{
+		Mode:       pb.TargetMode_TARGET_MODE_CGROUP,
+		CgroupPath: cg,
+		CgroupId:   23156,
+	})
+	if err != nil {
+		t.Fatalf("newJSONLSink: %v", err)
+	}
+	s.Emit(&pb.Event{Category: pb.Category_CATEGORY_CPU,
+		Payload: &pb.Event_Cpu{Cpu: &pb.CpuSample{UsagePct: 1}}})
+	if err := s.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	first := strings.SplitN(string(b), "\n", 2)[0]
+	var meta pb.StreamMeta
+	if err := protojson.Unmarshal([]byte(first), &meta); err != nil {
+		t.Fatalf("first line is not a StreamMeta: %v", err)
+	}
+	ti := meta.GetTarget()
+	if ti.GetMode() != pb.TargetMode_TARGET_MODE_CGROUP {
+		t.Errorf("mode = %v, want CGROUP", ti.GetMode())
+	}
+	if ti.GetCgroupPath() != cg || ti.GetCgroupId() != 23156 {
+		t.Errorf("header target = %v, want %s (id 23156)", ti, cg)
+	}
+}
+
+// Header write failures surface at construction: better to refuse than to leave
+// an export nobody can attribute.
+func TestJSONLSinkHeaderWriteFailure(t *testing.T) {
+	_, err := newJSONLSinkWriter(failingWriter{}, &pb.TargetInfo{Pid: 1})
+	if err == nil {
+		t.Fatal("newJSONLSinkWriter = nil error, want the header failure")
+	}
+	if !strings.Contains(err.Error(), "target header") {
+		t.Errorf("error = %q, want it to name the header", err)
+	}
+}
+
+type failingWriter struct{}
+
+func (failingWriter) Write([]byte) (int, error) { return 0, errors.New("disk gone") }
+func (failingWriter) Close() error              { return nil }
 
 // blockingWriter blocks every Write until release is closed, so the sink's
 // writer goroutine stalls and the bounded channel overflows.
@@ -78,7 +150,12 @@ func (w *blockingWriter) Close() error { return nil }
 // A stalled writer must cause drops (counted), never block the Emit caller.
 func TestJSONLSinkDropsWhenWriterBlocked(t *testing.T) {
 	bw := &blockingWriter{release: make(chan struct{})}
-	s := newJSONLSinkWriter(bw)
+	// No header here: it is written synchronously, so it would block in the
+	// constructor on this deliberately stalled writer.
+	s, err := newJSONLSinkWriter(bw, nil)
+	if err != nil {
+		t.Fatalf("newJSONLSinkWriter: %v", err)
+	}
 
 	// Emit far more than the buffer while the writer is blocked. Emit must never
 	// block, so this returns promptly.


### PR DESCRIPTION
Found while verifying #94 against a live kernel (thanks to the run that produced 7143 events from a cgroup target): **nothing in the exported file said which cgroup produced them.**

The `TargetInfo` handshake from #100 lives in `service.Subscribe`, so it reaches gRPC subscribers and never the JSONL sink. In PID mode you could at least infer the target from `Event.pid`; in cgroup mode there is nothing — the envelope pid is 0 because a subtree has no single process, and payloads like `SecurityEvent` carry no pid of their own.

## What changes

The sink now opens with the same `StreamMeta` a subscriber receives; every line after it is an `Event`, as before.

```jsonl
{"target":{"mode":"TARGET_MODE_CGROUP","cgroupPath":"/sys/fs/cgroup/ptop-empty","cgroupId":"23156"}}
{"tsUnixNano":"…","category":"CATEGORY_CPU","cpu":{"usagePct":1.5}}
```

The header is written **synchronously, before the writer goroutine starts**, so it is line 1 regardless of scheduling — and a writer that cannot take even its header fails at construction instead of producing a headerless export. A nil target skips the header, which is what the backpressure test needs: its writer blocks every write by design and would stall the constructor.

## ⚠️ It changes the file's shape

A reader that parses every line as an `Event` now fails on line 1. It fails **loudly** — protojson rejects the unknown field — which is the better failure mode, and it is exactly how the existing `TestServeJSONLExport` caught it. `jq`-based workflows are unaffected (the header just answers `null` to `.category`).

The alternative I considered was wrapping every line in `SubscribeResponse`, making the file schema-identical to the gRPC stream — one parser for both surfaces, and drop notices could be recorded too. That is cleaner but changes *every* line instead of adding one, so it stays on the table rather than in this PR.

## Verification

Three new tests plus one updated: the header in pid mode and in cgroup mode, a construction failure when the header cannot be written, and `TestServeJSONLExport` now asserting the header end-to-end through `serve.Run`. Whole suite green under `-race`, plus `GOOS=linux go vet -tags=ebpf ./...`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)