### PR TITLE
serve: one SubscribeResponse per JSONL line, with drops recorded in the file

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -421,10 +421,12 @@ collector→`streampb` mapping + server live in `internal/serve`.
 
 The gRPC subscriber and the JSONL writer are interchangeable `Sink`s
 (`internal/serve/sink.go`) fed by the hub. `--serve --export` adds the JSONL
-sink: its first line is a protojson `StreamMeta` carrying `TargetInfo` (the same
-handshake a gRPC subscriber gets — without it an export is unattributable, since
-cgroup-mode events have `pid` 0 and several payloads carry no pid), and every
-line after it is one protojson `Event`, in `ptop-events-<ts>.jsonl`
+sink: `ptop-events-<ts>.jsonl` holds one protojson **`SubscribeResponse` per
+line** — the same message a gRPC subscriber receives, in the same order, so one
+parser reads either surface. The first line is a meta carrying `TargetInfo`
+(without it an export is unattributable: cgroup-mode events have `pid` 0 and
+several payloads carry no pid), a meta with `dropped` records a gap where it
+happened, and everything else is an `event`
 (event-level — distinct from the TUI's state-snapshot `ptop-export-<ts>.jsonl`).
 
 Stack symbolization (#54) rides this surface: heap events carry a

--- a/README.md
+++ b/README.md
@@ -232,8 +232,8 @@ eBPF programs in `internal/bpf/programs/`:
 The TUI is one consumer of a richer event model. `ptop --pid <PID> --serve
 <addr>` runs headless and streams every observation as a typed protobuf `Event`
 over gRPC (package `ptop.v1`) to any number of unprivileged subscribers — and,
-with `--export`, also to a JSONL file: a `StreamMeta` header line naming the
-target, then one protojson line per event. ptop
+with `--export`, also to a JSONL file: one protojson `SubscribeResponse` per
+line — the same messages, so a file and a live stream parse identically. ptop
 holds `CAP_BPF`/`CAP_PERFMON`; subscribers connect with none.
 
 ### Transport security
@@ -313,6 +313,10 @@ envelope):
 
 High-rate events reference a captured stack by id; the `ResolveStack` RPC
 symbolizes it on demand (`addr → func (file:line)`, build-id keyed).
+
+Some `Event` payloads, shown unwrapped for readability — on the wire and in the
+JSONL each one arrives inside a `SubscribeResponse` (`{"event":{…}}`), which is
+also where the target handshake and the drop notices live:
 
 ```jsonl
 {"tsUnixNano":"…","pid":4242,"category":"CATEGORY_PROCESS","uid":1000,"gid":1000,"cgroupId":"2817","procContext":{"pidNs":"4026532630","cgroup":"/docker/3127f7e31dab…","container":"docker:3127f7e31dab"}}

--- a/internal/serve/serve_test.go
+++ b/internal/serve/serve_test.go
@@ -10,7 +10,6 @@ import (
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
-	"google.golang.org/protobuf/encoding/protojson"
 
 	"github.com/trentas/ptop/pkg/collector"
 	pb "github.com/trentas/ptop/pkg/streampb"
@@ -206,24 +205,20 @@ func TestServeJSONLExport(t *testing.T) {
 	defer f2.Close()
 	sc := bufio.NewScanner(f2)
 
-	// The export opens with the same target handshake a gRPC subscriber gets,
-	// so the file says what it observed. Events follow.
+	// Every line is a SubscribeResponse, the same message a gRPC subscriber
+	// receives — starting with the target handshake, so the file says what it
+	// observed.
 	if !sc.Scan() {
 		t.Fatal("empty export: no target header")
 	}
-	var meta pb.StreamMeta
-	if err := protojson.Unmarshal(sc.Bytes(), &meta); err != nil {
-		t.Fatalf("first line is not a StreamMeta: %v", err)
-	}
-	if meta.GetTarget().GetPid() != 5 {
-		t.Errorf("header target = %v, want pid 5", meta.GetTarget())
+	if ti := unmarshalResponse(t, sc.Bytes()).GetMeta().GetTarget(); ti.GetPid() != 5 {
+		t.Errorf("header target = %v, want pid 5", ti)
 	}
 
 	var lines int
 	for sc.Scan() {
-		var ev pb.Event
-		if err := protojson.Unmarshal(sc.Bytes(), &ev); err != nil {
-			t.Fatalf("line %d not valid Event: %v", lines, err)
+		if unmarshalResponse(t, sc.Bytes()).GetEvent() == nil {
+			continue // a drop notice is legitimate here
 		}
 		lines++
 	}

--- a/internal/serve/sink.go
+++ b/internal/serve/sink.go
@@ -63,16 +63,23 @@ func (s *grpcSink) Emit(ev *pb.Event) {
 
 func (s *grpcSink) Close() error { return nil }
 
-// jsonlSink writes a target header followed by every event as one protojson
-// line to a file. A bounded channel + writer goroutine keep disk I/O off the
-// hub's broadcast path; on overflow events are dropped and counted (reported on
-// Close).
+// jsonlSink writes the event stream to a file as one protojson
+// SubscribeResponse per line — the same message a gRPC subscriber receives, in
+// the same order. A bounded channel + writer goroutine keep disk I/O off the
+// hub's broadcast path.
 //
-// The FIRST line is a StreamMeta carrying TargetInfo, mirroring the handshake a
-// gRPC subscriber receives; every line after it is an Event. Without it an
-// export is unattributable after the fact — nothing in a file of cgroup-mode
-// events says which cgroup produced them, since the envelope pid is 0 there and
-// several payloads carry no pid of their own.
+// Being the same message type is the point: one parser reads either surface,
+// and everything the stream says gets said in the file too.
+//
+//   - The first line is a meta carrying TargetInfo, mirroring the subscriber
+//     handshake. Without it an export is unattributable after the fact —
+//     nothing in a file of cgroup-mode events says which cgroup produced them,
+//     since the envelope pid is 0 there and several payloads carry no pid.
+//   - A meta with dropped>0 is written whenever the counter advances, exactly
+//     as the gRPC path does. A slow disk used to hole the file silently, with
+//     only a stderr line at Close to say so — and an unrecorded gap in an
+//     export read months later is worse than a recorded one, because a
+//     deploy-vs-deploy comparison reads the hole as a behavior change.
 type jsonlSink struct {
 	w       io.WriteCloser
 	ch      chan *pb.Event
@@ -100,11 +107,7 @@ func newJSONLSink(path string, target *pb.TargetInfo) (*jsonlSink, error) {
 // its header fails here, at startup, instead of producing a headerless export.
 func newJSONLSinkWriter(w io.WriteCloser, target *pb.TargetInfo) (*jsonlSink, error) {
 	if target != nil {
-		b, err := jsonlMarshal.Marshal(&pb.StreamMeta{Target: target})
-		if err != nil {
-			return nil, fmt.Errorf("serve: jsonl target header: %w", err)
-		}
-		if _, err := w.Write(append(b, '\n')); err != nil {
+		if err := writeJSONLLine(w, metaResponse(&pb.StreamMeta{Target: target})); err != nil {
 			return nil, fmt.Errorf("serve: jsonl target header: %w", err)
 		}
 	}
@@ -113,9 +116,26 @@ func newJSONLSinkWriter(w io.WriteCloser, target *pb.TargetInfo) (*jsonlSink, er
 	return s, nil
 }
 
-// jsonlMarshal keeps the header and the events on identical marshalling terms:
-// compact, one object per line.
+// jsonlMarshal keeps every line on identical marshalling terms: compact, one
+// object per line.
 var jsonlMarshal = protojson.MarshalOptions{}
+
+func metaResponse(m *pb.StreamMeta) *pb.SubscribeResponse {
+	return &pb.SubscribeResponse{Kind: &pb.SubscribeResponse_Meta{Meta: m}}
+}
+
+func eventResponse(ev *pb.Event) *pb.SubscribeResponse {
+	return &pb.SubscribeResponse{Kind: &pb.SubscribeResponse_Event{Event: ev}}
+}
+
+func writeJSONLLine(w io.Writer, resp *pb.SubscribeResponse) error {
+	b, err := jsonlMarshal.Marshal(resp)
+	if err != nil {
+		return err
+	}
+	_, err = w.Write(append(b, '\n'))
+	return err
+}
 
 func (s *jsonlSink) Emit(ev *pb.Event) {
 	select {
@@ -127,16 +147,42 @@ func (s *jsonlSink) Emit(ev *pb.Event) {
 
 func (s *jsonlSink) run() {
 	defer close(s.done)
+
+	var reported uint64
 	for ev := range s.ch {
-		b, err := jsonlMarshal.Marshal(ev)
-		if err != nil {
-			continue
+		// Same policy as the gRPC path (see service.Subscribe): when the drop
+		// counter has advanced, a meta goes out ahead of the next event, so the
+		// gap is recorded where it happened.
+		if cur := atomic.LoadUint64(&s.dropped); cur != reported {
+			reported = cur
+			if !s.writeLine(metaResponse(&pb.StreamMeta{Dropped: cur})) {
+				return
+			}
 		}
-		if _, err := s.w.Write(append(b, '\n')); err != nil {
-			fmt.Fprintf(os.Stderr, "warning: jsonl export write: %v\n", err)
+		if !s.writeLine(eventResponse(ev)) {
 			return
 		}
 	}
+
+	// Drops after the last event still belong in the file.
+	if cur := atomic.LoadUint64(&s.dropped); cur != reported {
+		s.writeLine(metaResponse(&pb.StreamMeta{Dropped: cur}))
+	}
+}
+
+// writeLine reports whether the writer is still usable: a value that cannot be
+// marshalled is skipped, while a failed write ends the goroutine, since every
+// line after it would fail the same way.
+func (s *jsonlSink) writeLine(resp *pb.SubscribeResponse) bool {
+	b, err := jsonlMarshal.Marshal(resp)
+	if err != nil {
+		return true
+	}
+	if _, err := s.w.Write(append(b, '\n')); err != nil {
+		fmt.Fprintf(os.Stderr, "warning: jsonl export write: %v\n", err)
+		return false
+	}
+	return true
 }
 
 // Close flushes the queued events and closes the writer. The caller must

--- a/internal/serve/sink_test.go
+++ b/internal/serve/sink_test.go
@@ -2,6 +2,7 @@ package serve
 
 import (
 	"bufio"
+	"bytes"
 	"errors"
 	"os"
 	"path/filepath"
@@ -16,8 +17,8 @@ import (
 	pb "github.com/trentas/ptop/pkg/streampb"
 )
 
-// jsonlSink opens with a target header, then writes one parseable protojson
-// Event per line, and Close flushes what's queued.
+// jsonlSink writes one parseable protojson SubscribeResponse per line — a meta
+// header first, then events — and Close flushes what's queued.
 func TestJSONLSinkRoundTrip(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "events.jsonl")
 	s, err := newJSONLSink(path, &pb.TargetInfo{
@@ -48,32 +49,41 @@ func TestJSONLSinkRoundTrip(t *testing.T) {
 
 	sc := bufio.NewScanner(f)
 
-	// Line 1 is the header, not an event.
+	// Line 1 is the target handshake, not an event.
 	if !sc.Scan() {
 		t.Fatal("empty export: no target header")
 	}
-	var meta pb.StreamMeta
-	if err := protojson.Unmarshal(sc.Bytes(), &meta); err != nil {
-		t.Fatalf("first line is not a StreamMeta: %v", err)
-	}
-	if meta.GetTarget().GetPid() != 7 || meta.GetTarget().GetMode() != pb.TargetMode_TARGET_MODE_PID {
-		t.Errorf("header target = %v, want pid mode for pid 7", meta.GetTarget())
+	first := unmarshalResponse(t, sc.Bytes())
+	if ti := first.GetMeta().GetTarget(); ti.GetPid() != 7 || ti.GetMode() != pb.TargetMode_TARGET_MODE_PID {
+		t.Errorf("header target = %v, want pid mode for pid 7", ti)
 	}
 
 	var lines int
 	for sc.Scan() {
-		var ev pb.Event
-		if err := protojson.Unmarshal(sc.Bytes(), &ev); err != nil {
-			t.Fatalf("line %d not valid protojson Event: %v", lines, err)
+		resp := unmarshalResponse(t, sc.Bytes())
+		ev := resp.GetEvent()
+		if ev == nil {
+			t.Fatalf("line %d is not an event: %v", lines, resp)
 		}
 		if ev.GetPid() != 7 || ev.GetCategory() != pb.Category_CATEGORY_CPU {
-			t.Errorf("line %d: unexpected event %v", lines, &ev)
+			t.Errorf("line %d: unexpected event %v", lines, ev)
 		}
 		lines++
 	}
 	if lines != n {
 		t.Errorf("got %d event lines, want %d", lines, n)
 	}
+}
+
+// unmarshalResponse parses one JSONL line, which is a SubscribeResponse exactly
+// like the one a gRPC subscriber receives.
+func unmarshalResponse(t *testing.T, line []byte) *pb.SubscribeResponse {
+	t.Helper()
+	var resp pb.SubscribeResponse
+	if err := protojson.Unmarshal(line, &resp); err != nil {
+		t.Fatalf("line is not a SubscribeResponse: %v (%s)", err, line)
+	}
+	return &resp
 }
 
 // A cgroup-mode export must be attributable: the events carry no pid at all, so
@@ -100,11 +110,7 @@ func TestJSONLSinkHeaderCarriesCgroupTarget(t *testing.T) {
 		t.Fatalf("read: %v", err)
 	}
 	first := strings.SplitN(string(b), "\n", 2)[0]
-	var meta pb.StreamMeta
-	if err := protojson.Unmarshal([]byte(first), &meta); err != nil {
-		t.Fatalf("first line is not a StreamMeta: %v", err)
-	}
-	ti := meta.GetTarget()
+	ti := unmarshalResponse(t, []byte(first)).GetMeta().GetTarget()
 	if ti.GetMode() != pb.TargetMode_TARGET_MODE_CGROUP {
 		t.Errorf("mode = %v, want CGROUP", ti.GetMode())
 	}
@@ -136,16 +142,24 @@ type blockingWriter struct {
 	release chan struct{}
 	mu      sync.Mutex
 	written int
+	buf     bytes.Buffer
 }
 
 func (w *blockingWriter) Write(p []byte) (int, error) {
 	<-w.release
 	w.mu.Lock()
 	w.written += len(p)
+	w.buf.Write(p)
 	w.mu.Unlock()
 	return len(p), nil
 }
 func (w *blockingWriter) Close() error { return nil }
+
+func (w *blockingWriter) contents() string {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.buf.String()
+}
 
 // A stalled writer must cause drops (counted), never block the Emit caller.
 func TestJSONLSinkDropsWhenWriterBlocked(t *testing.T) {
@@ -188,5 +202,65 @@ func TestJSONLSinkDropsWhenWriterBlocked(t *testing.T) {
 	close(bw.release) // unblock so Close can drain and return
 	if err := s.Close(); err != nil {
 		t.Fatalf("close: %v", err)
+	}
+}
+
+// A gap in the export must be recorded IN the export. The stderr summary at
+// Close is for whoever is watching the terminal; a file read later has to carry
+// its own holes, or a deploy-vs-deploy comparison reads a dropped burst as a
+// change in behavior.
+func TestJSONLSinkRecordsDropsInBand(t *testing.T) {
+	bw := &blockingWriter{release: make(chan struct{})}
+	s, err := newJSONLSinkWriter(bw, nil) // header would block on this writer
+	if err != nil {
+		t.Fatalf("newJSONLSinkWriter: %v", err)
+	}
+
+	// Overflow the bounded channel while the writer is stalled, so events are
+	// dropped and counted.
+	for i := 0; i < subBuffer+200; i++ {
+		s.Emit(&pb.Event{Pid: 1, Category: pb.Category_CATEGORY_CPU,
+			Payload: &pb.Event_Cpu{Cpu: &pb.CpuSample{UsagePct: float64(i)}}})
+	}
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) && atomic.LoadUint64(&s.dropped) == 0 {
+		time.Sleep(5 * time.Millisecond)
+	}
+	if atomic.LoadUint64(&s.dropped) == 0 {
+		t.Fatal("expected drops while the writer was stalled")
+	}
+
+	close(bw.release) // let the queue drain
+	if err := s.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	var dropMetas, events int
+	var lastDropped uint64
+	for _, line := range strings.Split(strings.TrimSpace(bw.contents()), "\n") {
+		if line == "" {
+			continue
+		}
+		resp := unmarshalResponse(t, []byte(line))
+		if m := resp.GetMeta(); m != nil {
+			dropMetas++
+			lastDropped = m.GetDropped()
+			continue
+		}
+		events++
+	}
+
+	if dropMetas == 0 {
+		t.Error("no drop meta in the export: the gap went unrecorded")
+	}
+	if lastDropped == 0 {
+		t.Errorf("drop meta reports %d dropped, want the real count", lastDropped)
+	}
+	if events == 0 {
+		t.Error("no events survived to be written")
+	}
+	// The file must account for everything the sink saw.
+	if total := uint64(events) + lastDropped; total < subBuffer {
+		t.Errorf("export accounts for %d of the %d emitted events", total, subBuffer+200)
 	}
 }


### PR DESCRIPTION
**Stacked on #101** — base is `feat/jsonl-target-header`. This is the change #101 named and left on the table, taken deliberately in the same release: the export's shape changes once, not twice.

## Two shapes for one event model

The stream wraps everything in `SubscribeResponse`; the file wrote bare `Event`s. That meant two parsers for the same data, and a file that could not say anything the wrapper carries.

That second part had teeth. `jsonlSink` counts the events it sheds when the disk falls behind, but the only report was a stderr line at `Close` — so **a file holed by a slow disk looked complete**. Read a month later, comparing one deploy against the next, a dropped burst reads as a change in behavior. That is exactly the workload this export exists for.

## What it looks like now

```jsonl
{"meta":{"target":{"mode":"TARGET_MODE_PID","pid":41705}}}
{"event":{"tsUnixNano":"1787374925051101000","pid":41705,"category":"CATEGORY_IO","ioWait":{}}}
```

(real output, not hand-written)

- One protojson `SubscribeResponse` per line, same message and same order a subscriber gets — one parser for both surfaces.
- A `meta` with `dropped` is written whenever the counter advances, the same policy `service.Subscribe` already used, plus a trailing one for drops after the last event. The file accounts for what it lost.

## Cost, stated plainly

`jq` expressions move down one level: `.category` → `.event.category`, `.security.kind` → `.event.security.kind`. Filtering events becomes `jq 'select(.event) | .event'`. Each line also carries ~11 bytes of envelope.

## Verification

New test drives the real drop path: stall the writer, overflow the bounded channel, release it, then parse the output and require a `dropped` meta plus enough events that the file accounts for the emitted total. The round-trip, cgroup-header and end-to-end `serve.Run` tests all parse `SubscribeResponse` now. Whole suite green under `-race`, plus `GOOS=linux go vet -tags=ebpf ./...`; the sample above is from the built binary.

Also updated the README's event-payload block, which showed unwrapped payloads — it now says so explicitly instead of implying that is the file format.

🤖 Generated with [Claude Code](https://claude.com/claude-code)