### PR TITLE
LockEntry: name a contended lock by its symbolized call site (#89)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,7 +77,7 @@ ptop/
 │   │   │   ├── threads.bpf.c      sched_switch
 │   │   │   ├── memory.bpf.c       mmap/brk/page-fault
 │   │   │   ├── heap.bpf.c         libc malloc/free uprobes → lifetime + leak
-│   │   │   ├── futex.bpf.c        futex wait/wake → lock graph
+│   │   │   ├── futex.bpf.c        futex wait/wake → lock graph + acquire site
 │   │   │   ├── signal.bpf.c       signal_generate → signals with origin (#58)
 │   │   │   ├── tls.bpf.c          libssl SSL_write/read uprobes → plaintext (#55)
 │   │   │   ├── proc.bpf.c         sched fork/exec/exit → exec lineage subtree (#60)
@@ -96,7 +96,7 @@ ptop/
 │   │   ├── heap.go                libc allocator uprobe loader (#53)
 │   │   ├── tls.go                 libssl uprobe loader → TLS plaintext (#55)
 │   │   ├── threads.go             sched_switch loader
-│   │   ├── futex.go               futex wait/wake loader
+│   │   ├── futex.go               futex wait/wake loader + contention stacks
 │   │   ├── signal.go              signal_generate loader (#58)
 │   │   ├── proc.go                sched fork/exec/exit loader → exec lineage (#60)
 │   │   ├── security.go            PROT_EXEC + SELinux AVC loader + stack (#59)
@@ -106,6 +106,7 @@ ptop/
 │   │   ├── tls.go                 transport security: TLS/mTLS policy + hot reload (#95)
 │   │   ├── hub.go                 fan-in collectors → fan-out to sinks
 │   │   ├── sink.go                Sink iface: gRPC subscriber + JSONL writer
+│   │   ├── stackid.go             wire stack-id namespace + combined resolver (#89)
 │   │   ├── service.go             EventStream gRPC service impl
 │   │   └── mapper.go              collector value → streampb.Event
 │   └── tui/                       Bubbletea + Lipgloss
@@ -152,7 +153,7 @@ ptop/
 │       ├── io_ebpf.go             top files + per-op latency
 │       ├── network_ebpf.go        connections + RTT + bytes
 │       ├── syscalls_ebpf.go       per-syscall counts + latency
-│       ├── futex_ebpf.go          lock graph from futex tracking
+│       ├── futex_ebpf.go          lock graph from futex tracking (#89 call site)
 │       ├── proccontext_linux.go   /proc ns + cgroup + uid/gid context (#60)
 │       ├── proccontext.go         container-id / cgroup / ns-inode parsers (build-tag-free)
 │       ├── proclifecycle_ebpf.go  sched fork/exec/exit → exec lineage subtree (#60)
@@ -438,6 +439,25 @@ the optional `StackResolver`; a nil resolver simply omits stack refs and reports
 `found=false`. `build_id` is the target executable's GNU build-id, a stable
 per-process cache key (the same `stack_id` denotes a different stack once the
 binary changes).
+
+`LockEntry` rides it too (#89): `uaddr` names a lock only inside the live
+process — ASLR and arena reuse move it every run — so each entry also carries
+the symbolized `call_site` (`StackFrame`) plus a `stack_id`. That makes
+cross-run/deploy lock comparison possible: key on `module+offset` or
+`func/file:line`, never on `uaddr`. The kernel counts waits per
+`(uaddr, stack_id)` and the collector names the lock by the **dominant** site
+of the window, so a mutex taken from many places reports the one actually
+serializing it.
+
+**Wire stack ids are namespaced by source** (`internal/serve/stackid.go`): each
+tracer captures into its own `STACK_TRACE` map, and their ids are independent
+counters, so the wire id is `source<<32 | kernel_id` — heap is source 0 (ids
+unchanged from before #89), futex is 1, and `0` means "no stack". Pass the id
+back verbatim; `CombineStackResolvers` routes it to the tracer that captured
+it. Two consequences worth knowing: a new stack-capturing collector must claim
+a source constant, and both symbolization paths are **pid-mode only** — in
+cgroup mode there is no single memory map to resolve against, so sites stay
+unresolved.
 
 Version metadata is injected via `-ldflags` at release time
 (`main.version`, `main.commit`, `main.buildDate`). In dev they stay as

--- a/cmd/ptop/main.go
+++ b/cmd/ptop/main.go
@@ -271,13 +271,19 @@ func runServe(addr string, target serve.Target, noEBPF, tlsEnabled bool, tlsByte
 	})
 	defer set.Stop()
 
-	// The heap collector owns the stack tracer + symbolizer, so it backs stack
-	// references + the ResolveStack RPC. Pass an untyped nil when it never
-	// started (avoid a non-nil interface wrapping a nil pointer).
-	var resolver serve.StackResolver
+	// The heap (#54) and futex (#89) collectors each own a stack tracer +
+	// symbolizer, so they back the stack references and the ResolveStack RPC.
+	// Wire ids are namespaced by source, so one combined resolver serves both.
+	// Only register a collector that actually started — a nil pointer stored in
+	// the map would still read as a non-nil interface.
+	resolvers := make(map[serve.StackSource]serve.StackResolver, 2)
 	if set.HeapEBPF != nil {
-		resolver = set.HeapEBPF
+		resolvers[serve.StackSourceHeap] = set.HeapEBPF
 	}
+	if set.FutexEBPF != nil {
+		resolvers[serve.StackSourceFutex] = set.FutexEBPF
+	}
+	resolver := serve.CombineStackResolvers(resolvers)
 
 	if err := serve.Run(ctx, addr, target, set.Collectors(), resolver, opts); err != nil {
 		set.Stop() // os.Exit skips the defer

--- a/internal/bpf/futex.go
+++ b/internal/bpf/futex.go
@@ -16,6 +16,21 @@ import (
 //go:embed programs/futex.bpf.o
 var futexBPFObj []byte
 
+// futexStackDepth mirrors FUTEX_STACK_DEPTH in programs/futex.bpf.c — the user
+// stack depth captured at a contention site.
+const futexStackDepth = 32
+
+// FutexKey mirrors `struct futex_key`: the futex word plus the user stack
+// captured where a thread blocked on it (#89). Waits are counted per
+// (lock, contention site) so a lock keeps an identity that survives ASLR —
+// uaddr alone does not. StackID is -1 on wake-class calls (no stack is walked)
+// and on a failed walk.
+type FutexKey struct {
+	UAddr   uint64
+	StackID int32
+	_       uint32 // struct futex_key's explicit pad; part of the hash key
+}
+
 // FutexStat mirrors `struct futex_stat` in programs/futex.bpf.c 1:1.
 // 40 bytes (4 × u64 + 2 × u32).
 type FutexStat struct {
@@ -28,11 +43,13 @@ type FutexStat struct {
 }
 
 // FutexTracer loads futex.bpf.o, attaches sys_enter/exit_futex and exposes
-// Stats() to read the futex_stats map keyed by uaddr.
+// Stats() to read the futex_stats map keyed by (uaddr, contention site), plus
+// ResolveStack() for that site's frames.
 type FutexTracer struct {
-	coll  *ebpf.Collection
-	links []link.Link
-	smap  *ebpf.Map
+	coll      *ebpf.Collection
+	links     []link.Link
+	smap      *ebpf.Map
+	stacksMap *ebpf.Map
 }
 
 func OpenFutexTracer(target Target) (*FutexTracer, error) {
@@ -69,9 +86,10 @@ func OpenFutexTracer(target Target) (*FutexTracer, error) {
 	}
 
 	t.smap = coll.Maps["futex_stats"]
-	if t.smap == nil {
+	t.stacksMap = coll.Maps["futex_stacks"]
+	if t.smap == nil || t.stacksMap == nil {
 		t.Close()
-		return nil, errors.New("futex_stats map missing")
+		return nil, errors.New("futex maps missing")
 	}
 
 	tracepoints := []struct{ group, name, prog string }{
@@ -95,13 +113,14 @@ func OpenFutexTracer(target Target) (*FutexTracer, error) {
 	return t, nil
 }
 
-// Stats returns a complete snapshot of the futex_stats map: uaddr → stat.
-func (t *FutexTracer) Stats() (map[uint64]FutexStat, error) {
+// Stats returns a complete snapshot of the futex_stats map:
+// (uaddr, contention site) → stat.
+func (t *FutexTracer) Stats() (map[FutexKey]FutexStat, error) {
 	if t == nil || t.smap == nil {
 		return nil, errors.New("tracer not initialized")
 	}
-	out := make(map[uint64]FutexStat, 64)
-	var k uint64
+	out := make(map[FutexKey]FutexStat, 64)
+	var k FutexKey
 	var v FutexStat
 	iter := t.smap.Iterate()
 	for iter.Next(&k, &v) {
@@ -111,6 +130,27 @@ func (t *FutexTracer) Stats() (map[uint64]FutexStat, error) {
 		return out, err
 	}
 	return out, nil
+}
+
+// ResolveStack returns the user-stack frames captured for stackID (leaf first),
+// trailing zero slots trimmed. A negative id (wake op, or a failed walk) yields
+// nil. Mirrors HeapTracer.ResolveStack.
+func (t *FutexTracer) ResolveStack(stackID int32) ([]uint64, error) {
+	if stackID < 0 {
+		return nil, nil
+	}
+	if t == nil || t.stacksMap == nil {
+		return nil, errors.New("tracer not initialized")
+	}
+	var frames [futexStackDepth]uint64
+	if err := t.stacksMap.Lookup(uint32(stackID), &frames); err != nil {
+		return nil, err
+	}
+	n := len(frames)
+	for n > 0 && frames[n-1] == 0 {
+		n--
+	}
+	return frames[:n], nil
 }
 
 func (t *FutexTracer) Close() error {
@@ -125,6 +165,7 @@ func (t *FutexTracer) Close() error {
 		t.coll.Close()
 		t.coll = nil
 		t.smap = nil
+		t.stacksMap = nil
 	}
 	return nil
 }

--- a/internal/bpf/futex_stub.go
+++ b/internal/bpf/futex_stub.go
@@ -6,6 +6,14 @@ import "errors"
 
 var errFutexStub = errors.New("eBPF futex tracer not available in this build")
 
+// FutexKey mirrors `struct futex_key`: the futex word plus the contention-site
+// stack id (#89). See the linux+ebpf lane for the semantics.
+type FutexKey struct {
+	UAddr   uint64
+	StackID int32
+	_       uint32
+}
+
 type FutexStat struct {
 	WaitCount   uint64
 	WakeCount   uint64
@@ -18,7 +26,8 @@ type FutexStat struct {
 type FutexTracer struct{}
 
 func OpenFutexTracer(Target) (*FutexTracer, error) { return nil, errFutexStub }
-func (*FutexTracer) Stats() (map[uint64]FutexStat, error) {
+func (*FutexTracer) Stats() (map[FutexKey]FutexStat, error) {
 	return nil, errFutexStub
 }
-func (*FutexTracer) Close() error { return nil }
+func (*FutexTracer) ResolveStack(int32) ([]uint64, error) { return nil, errFutexStub }
+func (*FutexTracer) Close() error                         { return nil }

--- a/internal/bpf/programs/futex.bpf.c
+++ b/internal/bpf/programs/futex.bpf.c
@@ -11,12 +11,23 @@
 //
 // Maps:
 //   futex_target_pid    ARRAY[1]  struct target_filter (written by the Go loader)
-//   futex_inflight      HASH      tgid_pid → {uaddr, op, ts_ns}
+//   futex_inflight      HASH      tgid_pid → {uaddr, op, ts_ns, stack_id}
 //                                 correlates enter→exit to compute
-//                                 per-call latency
-//   futex_stats         HASH      uaddr → {wait_count, wake_count,
+//                                 per-call latency, and carries the stack
+//                                 captured at enter to the exit that accounts it
+//   futex_stats         HASH      {uaddr, stack_id} → {wait_count, wake_count,
 //                                 lat_sum_ns, lat_count, last_wait_tid,
 //                                 last_wake_tid}
+//   futex_stacks        STACK_TRACE  user stacks captured at the WAIT call site
+//
+// Why the key carries a stack id (#89):
+//   uaddr alone identifies a lock only inside the live process — ASLR and
+//   arena reuse give the same logical lock a different address on the next
+//   run. The stack captured where a thread blocks is the address-independent
+//   identity (module+offset survives ASLR), so waits are counted per
+//   (uaddr, contention site) and userspace picks the dominant site as the
+//   lock's name. Wake-class calls get stack_id = -1: they never name a lock,
+//   and skipping the walk keeps the cheap path cheap.
 //
 // Op filtering:
 //   FUTEX_CMD_MASK = 0x7F strips FUTEX_PRIVATE_FLAG (0x80) and
@@ -30,6 +41,11 @@
 char LICENSE[] SEC("license") = "GPL";
 
 #define FUTEX_CMD_MASK 0x7F
+
+// User-stack depth captured per contention site — enough to step over libc's
+// pthread/futex wrappers and reach the application caller. Mirrors
+// heap.bpf.c's HEAP_STACK_DEPTH; futexStackDepth in internal/bpf/futex.go.
+#define FUTEX_STACK_DEPTH 32
 
 // Wait-class ops (thread sleeps on the uaddr)
 #define FUTEX_WAIT             0
@@ -68,6 +84,15 @@ struct futex_inflight {
     __u64 uaddr;
     __u64 ts_ns;
     __u32 op;
+    __s32 stack_id; // wait-site user stack (<0 → unknown, or a wake op)
+};
+
+// futex_stats key. A hash key is compared byte-wise, so _pad must be zeroed on
+// every lookup/update — always build it as `struct futex_key k = {};`.
+// Mirrored by FutexKey in internal/bpf/futex.go.
+struct futex_key {
+    __u64 uaddr;
+    __s32 stack_id;
     __u32 _pad;
 };
 
@@ -96,10 +121,17 @@ struct {
 
 struct {
     __uint(type, BPF_MAP_TYPE_HASH);
-    __type(key, __u64);
+    __type(key, struct futex_key);
     __type(value, struct futex_stat);
-    __uint(max_entries, 4096);
+    __uint(max_entries, 8192); // (lock × contention site) pairs, not locks
 } futex_stats SEC(".maps");
+
+struct {
+    __uint(type, BPF_MAP_TYPE_STACK_TRACE);
+    __uint(key_size, sizeof(__u32));
+    __uint(value_size, FUTEX_STACK_DEPTH * sizeof(__u64));
+    __uint(max_entries, 4096);
+} futex_stacks SEC(".maps");
 
 static __always_inline int is_futex_target(void)
 {
@@ -131,9 +163,14 @@ int handle_enter_futex(struct sys_enter_futex_args *ctx)
 
     __u64 pid_tgid = bpf_get_current_pid_tgid();
     struct futex_inflight inf = {
-        .uaddr = ctx->uaddr,
-        .ts_ns = bpf_ktime_get_ns(),
-        .op    = base_op,
+        .uaddr    = ctx->uaddr,
+        .ts_ns    = bpf_ktime_get_ns(),
+        .op       = base_op,
+        // Only a WAIT names a lock (the caller is blocking ON it); a WAKE is
+        // the release path and would only add noise plus a stack walk.
+        .stack_id = is_wait_op(base_op)
+                        ? (__s32)bpf_get_stackid(ctx, &futex_stacks, BPF_F_USER_STACK)
+                        : -1,
     };
     bpf_map_update_elem(&futex_inflight, &pid_tgid, &inf, BPF_ANY);
     return 0;
@@ -148,12 +185,14 @@ int handle_exit_futex(struct sys_exit_args *ctx)
         return 0;
 
     __u64 lat_ns = bpf_ktime_get_ns() - inf->ts_ns;
-    __u64 uaddr = inf->uaddr;
     __u32 op = inf->op;
     __u32 tid = (__u32)pid_tgid;
+    struct futex_key key = {}; // zero-init: the padding is part of the hash key
+    key.uaddr = inf->uaddr;
+    key.stack_id = inf->stack_id;
     bpf_map_delete_elem(&futex_inflight, &pid_tgid);
 
-    struct futex_stat *s = bpf_map_lookup_elem(&futex_stats, &uaddr);
+    struct futex_stat *s = bpf_map_lookup_elem(&futex_stats, &key);
     if (!s) {
         struct futex_stat ns = {};
         if (is_wait_op(op)) {
@@ -165,7 +204,7 @@ int handle_exit_futex(struct sys_exit_args *ctx)
         }
         ns.lat_sum_ns = lat_ns;
         ns.lat_count = 1;
-        bpf_map_update_elem(&futex_stats, &uaddr, &ns, BPF_ANY);
+        bpf_map_update_elem(&futex_stats, &key, &ns, BPF_ANY);
         return 0;
     }
     if (is_wait_op(op)) {

--- a/internal/serve/mapper.go
+++ b/internal/serve/mapper.go
@@ -157,6 +157,10 @@ func toEvent(pid int, buildID string, v interface{}) *pb.Event {
 				Uaddr: l.UAddr, Waiters: l.Waiters, Wakers: l.Wakers,
 				WaitDelta: l.WaitDelta, LatencyMs: l.LatencyMs,
 				LastWaitTid: int32(l.LastWaitTID), LastWakeTid: int32(l.LastWakeTID),
+				// The lock's cross-run identity (#89); absent when the stack
+				// walk failed, so consumers never key on a made-up site.
+				CallSite: lockCallSite(l),
+				StackId:  taggedStackID(StackSourceFutex, l.StackID),
 			}
 		}
 		ev.Payload = &pb.Event_Locks{Locks: &pb.LockSnapshot{Locks: locks}}
@@ -223,7 +227,7 @@ func heapCallSites(in []collector.HeapCallSite) []*pb.HeapCallSite {
 			CallSite: s.CallSite, AddrHex: s.AddrHex, LiveBytes: s.LiveBytes,
 			AllocCount: s.AllocCount, AvgLifetimeMs: s.AvgLifetimeMs, Suspected: s.Suspected,
 			Func: s.Func, File: s.File, Line: int32(s.Line), Module: s.Module, Offset: s.Offset,
-			StackId: stackID(s.StackID),
+			StackId: taggedStackID(StackSourceHeap, s.StackID),
 		}
 	}
 	return out
@@ -231,22 +235,28 @@ func heapCallSites(in []collector.HeapCallSite) []*pb.HeapCallSite {
 
 // stackRef builds the envelope StackRef for a stack-bearing event, or nil when
 // the stack walk failed (negative kernel sentinel) so consumers don't chase a
-// dead id.
+// dead id. Heap events are the only stack-bearing ones today (#54).
 func stackRef(stackID int32, buildID string) *pb.StackRef {
 	if stackID < 0 {
 		return nil
 	}
-	return &pb.StackRef{StackId: uint64(stackID), BuildId: buildID}
+	return &pb.StackRef{
+		StackId: taggedStackID(StackSourceHeap, stackID),
+		BuildId: buildID,
+	}
 }
 
-// stackID widens a kernel stack id for the wire. A negative sentinel (walk
-// failed) becomes 0 — ResolveStack(0) reports not-found, the same as any id the
-// kernel has since evicted.
-func stackID(id int32) uint64 {
-	if id < 0 {
-		return 0
+// lockCallSite is the symbolized frame that blocked on a lock (#89), or nil
+// when nothing was resolved — an unresolved site is reported as absent rather
+// than as a frame of zeros.
+func lockCallSite(l collector.LockEntry) *pb.StackFrame {
+	if l.Func == "" && l.Module == "" && l.Offset == 0 {
+		return nil
 	}
-	return uint64(id)
+	return &pb.StackFrame{
+		Func: l.Func, File: l.File, Line: int32(l.Line),
+		Module: l.Module, Offset: l.Offset,
+	}
 }
 
 // stackFrames maps resolved symbol frames onto the wire form for ResolveStack.

--- a/internal/serve/mapper_test.go
+++ b/internal/serve/mapper_test.go
@@ -75,10 +75,20 @@ func TestToEventCategoriesAndPayloads(t *testing.T) {
 			}},
 		{"fd_event", collector.FDEvent{Message: "openat /etc/hosts", Timestamp: time.Unix(4, 0)},
 			pb.Category_CATEGORY_FD, func(e *pb.Event) bool { return e.GetFdEvent().GetMessage() == "openat /etc/hosts" }},
-		{"locks", []collector.LockEntry{{UAddr: 0xdead, Waiters: 2, LastWaitTID: 9}},
+		{"locks", []collector.LockEntry{{UAddr: 0xdead, Waiters: 2, LastWaitTID: 9,
+			CallSite: 0xabc, Func: "pool.acquire", File: "/build/db.go", Line: 42,
+			Module: "app", Offset: 0x1a3, StackID: 7}},
 			pb.Category_CATEGORY_LOCK, func(e *pb.Event) bool {
 				l := e.GetLocks().GetLocks()
-				return len(l) == 1 && l[0].GetUaddr() == 0xdead && l[0].GetLastWaitTid() == 9
+				if len(l) != 1 || l[0].GetUaddr() != 0xdead || l[0].GetLastWaitTid() != 9 {
+					return false
+				}
+				cs := l[0].GetCallSite()
+				return cs.GetFunc() == "pool.acquire" && cs.GetFile() == "/build/db.go" &&
+					cs.GetLine() == 42 && cs.GetModule() == "app" && cs.GetOffset() == 0x1a3 &&
+					// tagged with its source so ResolveStack reaches the futex
+					// tracer, not the heap one
+					l[0].GetStackId() == taggedStackID(StackSourceFutex, 7)
 			}},
 		{"timeline_lock", collector.TimelineEvent{Category: "lock", Message: "futex", Timestamp: time.Unix(5, 0)},
 			pb.Category_CATEGORY_LOCK, func(e *pb.Event) bool { return e.GetTimeline().GetMessage() == "futex" }},
@@ -130,6 +140,22 @@ func TestToEventNegativeStackID(t *testing.T) {
 	})
 	if id := ev.GetHeap().GetTopCallSites()[0].GetStackId(); id != 0 {
 		t.Errorf("StackId = %d, want 0 for a failed stack walk", id)
+	}
+}
+
+// A lock whose contention stack couldn't be walked reports no call site and no
+// stack id, rather than a frame of zeros pointing at a dead id.
+func TestToEventLockWithoutCallSite(t *testing.T) {
+	ev := toEvent(1, "bid", []collector.LockEntry{{UAddr: 0xdead, Waiters: 2, StackID: -1}})
+	l := ev.GetLocks().GetLocks()[0]
+	if l.GetCallSite() != nil {
+		t.Errorf("CallSite = %v, want nil for a failed stack walk", l.GetCallSite())
+	}
+	if l.GetStackId() != 0 {
+		t.Errorf("StackId = %d, want 0 for a failed stack walk", l.GetStackId())
+	}
+	if l.GetUaddr() != 0xdead {
+		t.Errorf("Uaddr = %#x, want 0xdead — the live-process identity still ships", l.GetUaddr())
 	}
 }
 

--- a/internal/serve/serve.go
+++ b/internal/serve/serve.go
@@ -72,8 +72,9 @@ type Options struct {
 // material or an explicit opt-in to cleartext (see serverCredentials).
 //
 // resolver (optional, nil-safe) symbolizes captured stacks: it stamps the
-// per-process build-id onto every StackRef and backs the ResolveStack RPC. Pass
-// set.HeapEBPF when non-nil; nil leaves heap events without stack references.
+// per-process build-id onto every StackRef and backs the ResolveStack RPC.
+// Build it with CombineStackResolvers over the collectors that captured stacks
+// (heap, futex); nil leaves events without stack references.
 func Run(ctx context.Context, addr string, target Target, cols []collector.Collector, resolver StackResolver, opts Options) error {
 	// Resolve transport security first: a missing certificate or a refused
 	// cleartext endpoint should fail before anything is bound.

--- a/internal/serve/stackid.go
+++ b/internal/serve/stackid.go
@@ -1,0 +1,82 @@
+package serve
+
+import "github.com/trentas/ptop/pkg/symbol"
+
+// Stack ids on the wire are namespaced by their source (#89). Several tracers
+// capture stacks, each into its own kernel BPF_MAP_TYPE_STACK_TRACE map, and
+// their ids are independent counters — id 7 in the heap map and id 7 in the
+// futex map are different stacks. A bare kernel id on the wire would therefore
+// be ambiguous, and ResolveStack would happily answer with the wrong stack.
+//
+// So a wire stack id carries its source in the high 32 bits and the kernel id
+// in the low 32:
+//
+//	stack_id = source<<32 | uint32(kernel_id)
+//
+// Heap is source 0, which keeps every id emitted before #89 byte-identical.
+// 0 is reserved for "no stack" — a walk that failed, or an event with none —
+// so it never resolves.
+type StackSource uint32
+
+const (
+	StackSourceHeap  StackSource = 0 // heap_stacks (#53/#54)
+	StackSourceFutex StackSource = 1 // futex_stacks (#89)
+)
+
+// taggedStackID widens a kernel stack id for the wire, stamping its source. A
+// negative sentinel (the walk failed) becomes 0, which ResolveStack reports as
+// not-found — the same as any id the kernel has since evicted.
+func taggedStackID(src StackSource, id int32) uint64 {
+	if id < 0 {
+		return 0
+	}
+	return uint64(src)<<32 | uint64(uint32(id))
+}
+
+// combinedResolver routes a wire stack id back to the tracer that captured it.
+type combinedResolver struct {
+	order    []StackSource // build-id lookup order; deterministic
+	bySource map[StackSource]StackResolver
+}
+
+// CombineStackResolvers returns one StackResolver over several capturing
+// tracers, dispatching each id to the source encoded in it. Sources with a nil
+// resolver are dropped; the result is nil when nothing is left, so a caller can
+// pass it straight to Run (a nil resolver disables stack references).
+func CombineStackResolvers(bySource map[StackSource]StackResolver) StackResolver {
+	c := &combinedResolver{bySource: make(map[StackSource]StackResolver, len(bySource))}
+	// Fixed order (not map order) so ProcessBuildID is stable across runs.
+	for _, src := range []StackSource{StackSourceHeap, StackSourceFutex} {
+		if r := bySource[src]; r != nil {
+			c.order = append(c.order, src)
+			c.bySource[src] = r
+		}
+	}
+	if len(c.order) == 0 {
+		return nil
+	}
+	return c
+}
+
+// ProcessBuildID is the target executable's build-id. Every source symbolizes
+// the same target, so the first non-empty answer is the answer.
+func (c *combinedResolver) ProcessBuildID() string {
+	for _, src := range c.order {
+		if id := c.bySource[src].ProcessBuildID(); id != "" {
+			return id
+		}
+	}
+	return ""
+}
+
+// ResolveStack strips the source tag and asks that tracer for the frames.
+func (c *combinedResolver) ResolveStack(stackID uint64) ([]symbol.Frame, bool) {
+	if stackID == 0 {
+		return nil, false // reserved: no stack was captured
+	}
+	r := c.bySource[StackSource(stackID>>32)]
+	if r == nil {
+		return nil, false
+	}
+	return r.ResolveStack(stackID & 0xFFFFFFFF)
+}

--- a/internal/serve/stackid_test.go
+++ b/internal/serve/stackid_test.go
@@ -1,0 +1,98 @@
+package serve
+
+import (
+	"testing"
+
+	"github.com/trentas/ptop/pkg/symbol"
+)
+
+// tagResolver answers with a frame naming itself, so a test can tell which
+// source a dispatched id actually reached.
+type tagResolver struct {
+	tag     string
+	buildID string
+	seen    uint64 // last id it was asked for (after the tag was stripped)
+}
+
+func (r *tagResolver) ProcessBuildID() string { return r.buildID }
+
+func (r *tagResolver) ResolveStack(id uint64) ([]symbol.Frame, bool) {
+	r.seen = id
+	return []symbol.Frame{{Func: r.tag}}, true
+}
+
+// An id emitted before #89 (heap, source 0) must keep its exact wire value.
+func TestTaggedStackIDHeapUnchanged(t *testing.T) {
+	if got := taggedStackID(StackSourceHeap, 42); got != 42 {
+		t.Errorf("heap id = %d, want 42 (source 0 is the identity tag)", got)
+	}
+	if got := taggedStackID(StackSourceFutex, 42); got != 1<<32|42 {
+		t.Errorf("futex id = %#x, want %#x", got, uint64(1)<<32|42)
+	}
+	for _, src := range []StackSource{StackSourceHeap, StackSourceFutex} {
+		if got := taggedStackID(src, -1); got != 0 {
+			t.Errorf("source %d: failed walk = %d, want 0", src, got)
+		}
+	}
+}
+
+// Two tracers, two independent id spaces: the same kernel id must reach the
+// tracer that captured it, never the other one.
+func TestCombinedResolverRoutesBySource(t *testing.T) {
+	heap := &tagResolver{tag: "heap"}
+	futex := &tagResolver{tag: "futex", buildID: "bid"}
+	r := CombineStackResolvers(map[StackSource]StackResolver{
+		StackSourceHeap:  heap,
+		StackSourceFutex: futex,
+	})
+
+	frames, ok := r.ResolveStack(taggedStackID(StackSourceFutex, 7))
+	if !ok || len(frames) != 1 || frames[0].Func != "futex" {
+		t.Fatalf("futex id resolved to %v (ok=%v), want the futex tracer", frames, ok)
+	}
+	if futex.seen != 7 {
+		t.Errorf("futex tracer got id %d, want the bare kernel id 7", futex.seen)
+	}
+
+	frames, ok = r.ResolveStack(taggedStackID(StackSourceHeap, 7))
+	if !ok || frames[0].Func != "heap" {
+		t.Fatalf("heap id resolved to %v (ok=%v), want the heap tracer", frames, ok)
+	}
+}
+
+func TestCombinedResolverUnknownIDs(t *testing.T) {
+	r := CombineStackResolvers(map[StackSource]StackResolver{
+		StackSourceHeap: &tagResolver{tag: "heap"},
+	})
+	if _, ok := r.ResolveStack(0); ok {
+		t.Error("id 0 resolved; it is reserved for 'no stack captured'")
+	}
+	// A futex id with no futex collector running (Go target, no libc): not
+	// found, never silently answered by the heap tracer.
+	if _, ok := r.ResolveStack(taggedStackID(StackSourceFutex, 3)); ok {
+		t.Error("id of an absent source resolved; want not-found")
+	}
+}
+
+// The build-id is the target executable's, so any source can supply it — but
+// only a source that has one.
+func TestCombinedResolverBuildID(t *testing.T) {
+	r := CombineStackResolvers(map[StackSource]StackResolver{
+		StackSourceHeap:  &tagResolver{tag: "heap"}, // cgroup mode: no build-id
+		StackSourceFutex: &tagResolver{tag: "futex", buildID: "bid"},
+	})
+	if got := r.ProcessBuildID(); got != "bid" {
+		t.Errorf("ProcessBuildID = %q, want %q", got, "bid")
+	}
+}
+
+// With nothing capturing stacks, Run must receive a genuinely nil resolver —
+// not a wrapper that reports found=false forever.
+func TestCombineStackResolversEmpty(t *testing.T) {
+	if r := CombineStackResolvers(nil); r != nil {
+		t.Errorf("CombineStackResolvers(nil) = %v, want nil", r)
+	}
+	if r := CombineStackResolvers(map[StackSource]StackResolver{}); r != nil {
+		t.Errorf("CombineStackResolvers(empty) = %v, want nil", r)
+	}
+}

--- a/internal/tui/lock_view_test.go
+++ b/internal/tui/lock_view_test.go
@@ -1,0 +1,74 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/lipgloss"
+
+	"github.com/trentas/ptop/pkg/collector"
+)
+
+// TestLockSiteLabel covers the lock-naming fallback chain (#89): a lock is
+// named by the call site contending on it, and only falls back to the futex
+// word address when nothing resolved.
+func TestLockSiteLabel(t *testing.T) {
+	cases := []struct {
+		name string
+		e    collector.LockEntry
+		want string
+	}{
+		{"go func+line", collector.LockEntry{
+			UAddr: 0x7f00, Func: "db.(*Pool).acquire", File: "/build/app/pool.go",
+			Line: 42, Module: "app"}, "db.(*Pool).acquire (pool.go:42)"},
+		{"c func only", collector.LockEntry{
+			UAddr: 0x7f00, Func: "worker_run", Module: "libworker.so"}, "worker_run"},
+		{"stripped module+offset", collector.LockEntry{
+			UAddr: 0x7f00, Module: "libfoo.so", Offset: 0x1500}, "libfoo.so+0x1500"},
+		{"no site at all", collector.LockEntry{UAddr: 0x7f00}, "futex@0x7f00"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := lockSiteLabel(c.e); got != c.want {
+				t.Errorf("lockSiteLabel = %q, want %q", got, c.want)
+			}
+		})
+	}
+}
+
+// A long symbol must be truncated into the panel, not pushed past its width —
+// an overflowing row wraps and shears the whole layout (see "Width discipline").
+func TestRenderLockLineFitsWidth(t *testing.T) {
+	e := collector.LockEntry{
+		UAddr: 0x7f00, WaitDelta: 42, LatencyMs: 3.2, LastWaitTID: 1247,
+		Func: strings.Repeat("verylongsymbolname.", 8),
+	}
+	for _, w := range []int{40, 60, 100} {
+		if got := lipgloss.Width(renderLockLine(e, w)); got > w {
+			t.Errorf("width %d: rendered %d columns", w, got)
+		}
+	}
+}
+
+// The contended lock's F4 row shows its call site and drops nothing else.
+func TestRenderLockGraphShowsCallSite(t *testing.T) {
+	if locksUnavailable {
+		t.Skip("lock graph has no source on this platform")
+	}
+	m := NewModel(Config{PID: 1, FPS: 5, NoEBPF: true})
+	m.Width, m.Height = 180, 50
+	m.LockGraph = []collector.LockEntry{{
+		UAddr: 0x7f00, WaitDelta: 42, Waiters: 120, LatencyMs: 3.2, LastWaitTID: 1247,
+		Func: "acquireSlot", File: "/build/pool.go", Line: 42, Module: "app", StackID: 7,
+	}}
+
+	out := renderLockGraph(m, 60)
+	for _, want := range []string{"acquireSlot", "↑42", "3.2ms", "tid=1247"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("lock graph missing %q:\n%s", want, out)
+		}
+	}
+	if strings.Contains(out, "futex@0x7f00") {
+		t.Errorf("lock graph fell back to the address despite a resolved site:\n%s", out)
+	}
+}

--- a/internal/tui/view_threads.go
+++ b/internal/tui/view_threads.go
@@ -2,6 +2,7 @@ package tui
 
 import (
 	"fmt"
+	"path/filepath"
 	"strings"
 
 	"github.com/charmbracelet/lipgloss"
@@ -59,11 +60,12 @@ func renderLockGraph(m Model, w int) string {
 	return strings.Join(lines, "\n")
 }
 
-// renderLockLine: "futex@0xADDR  ↑42 waits  avg 3.2ms  last tid 1247"
+// renderLockLine: "pool.acquire (db.go:42) · ↑42 · 3.2ms · tid=1247".
+// The lock is named by the call site contending on it (#89) and falls back to
+// the futex word address — see lockSiteLabel. The name absorbs whatever width
+// the fixed-size right-hand fields leave, so a long symbol can't overflow the
+// panel.
 func renderLockLine(e collector.LockEntry, w int) string {
-	addrStyle := lipgloss.NewStyle().Foreground(ColorAmber).Background(ColorPanel)
-	addr := addrStyle.Render(fmt.Sprintf("futex@0x%x", e.UAddr))
-
 	deltaColor := ColorMuted
 	switch {
 	case e.WaitDelta >= 100:
@@ -76,13 +78,42 @@ func renderLockLine(e collector.LockEntry, w int) string {
 	delta := lipgloss.NewStyle().Foreground(deltaColor).Background(ColorPanel).
 		Render(fmt.Sprintf("↑%d", e.WaitDelta))
 
-	lat := MutedStyle.Render(fmt.Sprintf("%.1fms", e.LatencyMs))
-
-	tid := ""
+	parts := []string{delta, MutedStyle.Render(fmt.Sprintf("%.1fms", e.LatencyMs))}
 	if e.LastWaitTID != 0 {
-		tid = MutedStyle.Render(fmt.Sprintf("tid=%d", e.LastWaitTID))
+		parts = append(parts, MutedStyle.Render(fmt.Sprintf("tid=%d", e.LastWaitTID)))
 	}
+	sep := MutedStyle.Render(" · ")
+	tail := strings.Join(parts, sep)
 
-	parts := []string{addr, delta, lat, tid}
-	return strings.Join(parts, MutedStyle.Render(" · "))
+	avail := w - lipgloss.Width(tail) - lipgloss.Width(sep)
+	if avail < 8 {
+		avail = 8 // never squeeze the name to nothing; the row may wrap instead
+	}
+	name := lipgloss.NewStyle().Foreground(ColorAmber).Background(ColorPanel).
+		Render(truncate(lockSiteLabel(e), avail))
+
+	return name + sep + tail
+}
+
+// lockSiteLabel names a lock by the most specific form available, mirroring
+// heapSiteLabel:
+//
+//	func (file:line)  — contention site resolved with a line table (Go)
+//	func              — resolved by symbol name only (C; no DWARF line info)
+//	module+0xoffset   — stripped module, located by load offset
+//	futex@0xADDR      — no site: stack walk failed, /proc mode, or cgroup mode
+//
+// The first three survive ASLR; the address does not (it is this run's futex
+// word), which is why it is the last resort.
+func lockSiteLabel(e collector.LockEntry) string {
+	if e.Func != "" {
+		if e.File != "" && e.Line > 0 {
+			return fmt.Sprintf("%s (%s:%d)", e.Func, filepath.Base(e.File), e.Line)
+		}
+		return e.Func
+	}
+	if e.Module != "" {
+		return fmt.Sprintf("%s+0x%x", e.Module, e.Offset)
+	}
+	return fmt.Sprintf("futex@0x%x", e.UAddr)
 }

--- a/pkg/collector/futex_agg.go
+++ b/pkg/collector/futex_agg.go
@@ -1,0 +1,157 @@
+package collector
+
+import (
+	"fmt"
+	"sort"
+)
+
+// Pure aggregation helpers for the futex collector (#89), kept free of any
+// kernel/eBPF dependency so they unit-test on every platform. The real
+// collector (futex_ebpf.go) feeds these from the BPF maps and symbolizes the
+// call site each lock ends up named by.
+
+// lockSample is one row of the kernel's futex_stats map: everything a single
+// (futex word, contention site) pair accumulated since the tracer started.
+// StackID < 0 means no site was captured — every wake-class call lands there,
+// and so does a wait whose stack walk failed (no frame pointers).
+type lockSample struct {
+	UAddr       uint64
+	StackID     int32
+	WaitCount   uint64
+	WakeCount   uint64
+	LatSumNs    uint64
+	LatCount    uint64
+	LastWaitTID int
+	LastWakeTID int
+}
+
+// lockAcc accumulates one lock's rows while aggregateLocks folds them.
+type lockAcc struct {
+	entry     LockEntry
+	latSum    uint64
+	latCount  uint64
+	bestWaits uint64 // waits of the dominant (named) site so far
+	maxWaits  uint64 // waits of the row LastWaitTID came from
+	maxWakes  uint64 // wakes of the row LastWakeTID came from
+}
+
+// aggregateLocks folds the per-(lock, site) rows into one entry per lock and
+// names each lock by its DOMINANT contention site — the one accounting for most
+// of its waits. A lock taken from several places therefore reports the site
+// that is actually serializing it, and reports it stably: the same site wins
+// again next window unless the contention itself moves.
+//
+// WaitDelta is measured against prevWaits (per-lock cumulative wait totals from
+// the previous window); the returned map replaces it. A lock whose total went
+// backwards (its rows fell out of the map) reports a delta of 0 rather than
+// wrapping around.
+//
+// Call sites come out as StackID only — symbolizing one needs the tracer, so
+// that belongs to the collector.
+func aggregateLocks(samples []lockSample, prevWaits map[uint64]uint64) ([]LockEntry, map[uint64]uint64) {
+	// Fold in a fixed order so a tie between two equally-hot sites always
+	// resolves the same way (map iteration in the caller does not).
+	rows := make([]lockSample, len(samples))
+	copy(rows, samples)
+	sort.Slice(rows, func(i, j int) bool {
+		if rows[i].UAddr != rows[j].UAddr {
+			return rows[i].UAddr < rows[j].UAddr
+		}
+		return rows[i].StackID < rows[j].StackID
+	})
+
+	accs := make(map[uint64]*lockAcc, len(rows))
+	order := make([]uint64, 0, len(rows))
+	for _, r := range rows {
+		a := accs[r.UAddr]
+		if a == nil {
+			a = &lockAcc{entry: LockEntry{UAddr: r.UAddr, StackID: -1}}
+			accs[r.UAddr] = a
+			order = append(order, r.UAddr)
+		}
+		a.entry.Waiters += r.WaitCount
+		a.entry.Wakers += r.WakeCount
+		a.latSum += r.LatSumNs
+		a.latCount += r.LatCount
+
+		// The dominant site names the lock. Only a real captured stack can:
+		// the StackID < 0 row is the wake path and the failed walks.
+		if r.StackID >= 0 && r.WaitCount > a.bestWaits {
+			a.bestWaits = r.WaitCount
+			a.entry.StackID = r.StackID
+		}
+		// Last waiter/waker: keep the one from the busiest row, so a single
+		// stray call can't overwrite the tid of the site doing the blocking.
+		if r.LastWaitTID != 0 && r.WaitCount >= a.maxWaits {
+			a.maxWaits = r.WaitCount
+			a.entry.LastWaitTID = r.LastWaitTID
+		}
+		if r.LastWakeTID != 0 && r.WakeCount >= a.maxWakes {
+			a.maxWakes = r.WakeCount
+			a.entry.LastWakeTID = r.LastWakeTID
+		}
+	}
+
+	out := make([]LockEntry, 0, len(order))
+	curWaits := make(map[uint64]uint64, len(order))
+	for _, uaddr := range order {
+		a := accs[uaddr]
+		e := a.entry
+		if a.latCount > 0 {
+			e.LatencyMs = float64(a.latSum) / float64(a.latCount) / 1e6
+		}
+		if prev := prevWaits[uaddr]; e.Waiters > prev {
+			e.WaitDelta = e.Waiters - prev
+		}
+		curWaits[uaddr] = e.Waiters
+		out = append(out, e)
+	}
+	return out, curWaits
+}
+
+// rankLocks orders locks by contention in the current window (WaitDelta),
+// falling back to the cumulative total and then the address so the order is
+// deterministic. n < 0 keeps all.
+func rankLocks(entries []LockEntry, n int) []LockEntry {
+	out := make([]LockEntry, len(entries))
+	copy(out, entries)
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].WaitDelta != out[j].WaitDelta {
+			return out[i].WaitDelta > out[j].WaitDelta
+		}
+		if out[i].Waiters != out[j].Waiters {
+			return out[i].Waiters > out[j].Waiters
+		}
+		return out[i].UAddr < out[j].UAddr
+	})
+	if n >= 0 && len(out) > n {
+		out = out[:n]
+	}
+	return out
+}
+
+// countHot returns how many of the ranked locks passed the contention
+// threshold for this window. rankLocks sorts by WaitDelta first, so those are
+// exactly the first countHot entries.
+func countHot(ranked []LockEntry, threshold uint64) int {
+	for i, e := range ranked {
+		if e.WaitDelta < threshold {
+			return i
+		}
+	}
+	return len(ranked)
+}
+
+// lockName is the shortest honest name for a lock in a one-line message: its
+// contention site when symbolized, the module it sits in when only that
+// resolved, else the futex word in hex (all we had before #89).
+func lockName(e LockEntry) string {
+	switch {
+	case e.Func != "":
+		return e.Func
+	case e.Module != "":
+		return fmt.Sprintf("%s+0x%x", e.Module, e.Offset)
+	default:
+		return fmt.Sprintf("futex@0x%x", e.UAddr)
+	}
+}

--- a/pkg/collector/futex_agg_test.go
+++ b/pkg/collector/futex_agg_test.go
@@ -1,0 +1,146 @@
+package collector
+
+import "testing"
+
+// A lock taken from several places is named by the site doing most of the
+// blocking, and its totals still cover every site — including the wake rows,
+// which carry no stack at all.
+func TestAggregateLocksNamesDominantSite(t *testing.T) {
+	samples := []lockSample{
+		{UAddr: 0x1000, StackID: 9, WaitCount: 10, LatSumNs: 10_000_000, LatCount: 10, LastWaitTID: 22},
+		{UAddr: 0x1000, StackID: 7, WaitCount: 100, LatSumNs: 200_000_000, LatCount: 100, LastWaitTID: 33},
+		{UAddr: 0x1000, StackID: -1, WakeCount: 50, LatSumNs: 5_000_000, LatCount: 50, LastWakeTID: 44},
+	}
+
+	got, cur := aggregateLocks(samples, map[uint64]uint64{0x1000: 60})
+	if len(got) != 1 {
+		t.Fatalf("len(entries) = %d, want 1 (rows fold per lock)", len(got))
+	}
+	e := got[0]
+	if e.StackID != 7 {
+		t.Errorf("StackID = %d, want 7 (the site with most waits)", e.StackID)
+	}
+	if e.Waiters != 110 || e.Wakers != 50 {
+		t.Errorf("Waiters/Wakers = %d/%d, want 110/50", e.Waiters, e.Wakers)
+	}
+	if e.WaitDelta != 50 {
+		t.Errorf("WaitDelta = %d, want 50 (110 − 60)", e.WaitDelta)
+	}
+	// (10 + 200 + 5)ms over 160 calls.
+	if want := 215.0 / 160.0; e.LatencyMs < want-0.001 || e.LatencyMs > want+0.001 {
+		t.Errorf("LatencyMs = %v, want ~%v", e.LatencyMs, want)
+	}
+	if e.LastWaitTID != 33 || e.LastWakeTID != 44 {
+		t.Errorf("last tids = %d/%d, want 33/44 (from the busiest rows)", e.LastWaitTID, e.LastWakeTID)
+	}
+	if cur[0x1000] != 110 {
+		t.Errorf("carried total = %d, want 110", cur[0x1000])
+	}
+}
+
+// The dominant site must not depend on the order rows come out of the kernel
+// map (Go randomizes map iteration), and a tie resolves the same way every time.
+func TestAggregateLocksDeterministicOnTies(t *testing.T) {
+	forward := []lockSample{
+		{UAddr: 0x2000, StackID: 4, WaitCount: 7},
+		{UAddr: 0x2000, StackID: 2, WaitCount: 7},
+	}
+	reversed := []lockSample{forward[1], forward[0]}
+
+	a, _ := aggregateLocks(forward, nil)
+	b, _ := aggregateLocks(reversed, nil)
+	if a[0].StackID != b[0].StackID {
+		t.Fatalf("tie broke differently by input order: %d vs %d", a[0].StackID, b[0].StackID)
+	}
+	if a[0].StackID != 2 {
+		t.Errorf("StackID = %d, want 2 (lowest id wins a tie)", a[0].StackID)
+	}
+}
+
+// A wait whose stack walk failed still counts — it just leaves the lock unnamed
+// rather than borrowing the wake path's sentinel as a site.
+func TestAggregateLocksUnwalkedStaysUnnamed(t *testing.T) {
+	got, _ := aggregateLocks([]lockSample{
+		{UAddr: 0x3000, StackID: -1, WaitCount: 5, LastWaitTID: 12},
+	}, nil)
+	if len(got) != 1 {
+		t.Fatalf("len(entries) = %d, want 1", len(got))
+	}
+	if got[0].StackID != -1 {
+		t.Errorf("StackID = %d, want -1 (no site captured)", got[0].StackID)
+	}
+	if got[0].Waiters != 5 || got[0].LastWaitTID != 12 {
+		t.Errorf("waits/tid = %d/%d, want 5/12", got[0].Waiters, got[0].LastWaitTID)
+	}
+}
+
+// Totals only ever grow; if the kernel map lost the rows, report no contention
+// for the window instead of an unsigned wrap-around.
+func TestAggregateLocksNoUnderflow(t *testing.T) {
+	got, _ := aggregateLocks([]lockSample{
+		{UAddr: 0x4000, StackID: 1, WaitCount: 3},
+	}, map[uint64]uint64{0x4000: 900})
+	if got[0].WaitDelta != 0 {
+		t.Errorf("WaitDelta = %d, want 0", got[0].WaitDelta)
+	}
+}
+
+func TestRankLocks(t *testing.T) {
+	in := []LockEntry{
+		{UAddr: 0x30, WaitDelta: 5, Waiters: 100},
+		{UAddr: 0x10, WaitDelta: 5, Waiters: 900},
+		{UAddr: 0x20, WaitDelta: 40, Waiters: 40},
+		{UAddr: 0x05, WaitDelta: 5, Waiters: 100},
+	}
+	got := rankLocks(in, -1)
+	want := []uint64{0x20, 0x10, 0x05, 0x30} // delta desc, then waiters desc, then addr
+	for i, w := range want {
+		if got[i].UAddr != w {
+			t.Fatalf("rank[%d] = 0x%x, want 0x%x (order: %v)", i, got[i].UAddr, w, addrsOf(got))
+		}
+	}
+	if n := len(rankLocks(in, 2)); n != 2 {
+		t.Errorf("len(rankLocks(.., 2)) = %d, want 2", n)
+	}
+	if in[0].UAddr != 0x30 {
+		t.Error("rankLocks mutated its input")
+	}
+}
+
+func TestCountHot(t *testing.T) {
+	ranked := []LockEntry{{WaitDelta: 90}, {WaitDelta: 20}, {WaitDelta: 19}, {WaitDelta: 0}}
+	if got := countHot(ranked, 20); got != 2 {
+		t.Errorf("countHot = %d, want 2", got)
+	}
+	if got := countHot(ranked, 0); got != len(ranked) {
+		t.Errorf("countHot(threshold 0) = %d, want %d", got, len(ranked))
+	}
+	if got := countHot(nil, 20); got != 0 {
+		t.Errorf("countHot(nil) = %d, want 0", got)
+	}
+}
+
+func TestLockName(t *testing.T) {
+	cases := []struct {
+		name string
+		in   LockEntry
+		want string
+	}{
+		{"symbolized", LockEntry{UAddr: 0xabc, Func: "pool.acquire", Module: "app"}, "pool.acquire"},
+		{"module only", LockEntry{UAddr: 0xabc, Module: "libfoo.so", Offset: 0x1f}, "libfoo.so+0x1f"},
+		{"unresolved", LockEntry{UAddr: 0xabc}, "futex@0xabc"},
+	}
+	for _, tc := range cases {
+		if got := lockName(tc.in); got != tc.want {
+			t.Errorf("%s: lockName = %q, want %q", tc.name, got, tc.want)
+		}
+	}
+}
+
+func addrsOf(entries []LockEntry) []uint64 {
+	out := make([]uint64, len(entries))
+	for i, e := range entries {
+		out[i] = e.UAddr
+	}
+	return out
+}

--- a/pkg/collector/futex_ebpf.go
+++ b/pkg/collector/futex_ebpf.go
@@ -4,24 +4,42 @@ package collector
 
 import (
 	"fmt"
-	"sort"
+	"os"
 	"sync"
 	"time"
 
 	"github.com/trentas/ptop/internal/bpf"
+	"github.com/trentas/ptop/pkg/symbol"
 )
 
 // FutexEBPFCollector consumes the futex_stats map periodically and publishes
 // a []LockEntry ranked by contention in the current window (delta of
 // waits in the last interval). Emits TimelineEvent category="lock" when
-// some uaddr passes the contention threshold for the interval.
+// some lock passes the contention threshold for the interval.
+//
+// The kernel counts waits per (futex word, contention site), so each lock is
+// named by the call site doing most of the blocking (#89) — an identity that
+// survives ASLR, unlike the futex word address. Symbolization needs one
+// process's memory map, so in cgroup mode (a subtree of processes) the sites
+// stay unresolved and only the address is reported.
 type FutexEBPFCollector struct {
 	tracer *bpf.FutexTracer
+	sym    *symbol.Symbolizer // nil in cgroup mode, or if /proc maps failed
 	ch     chan interface{}
 	stop   chan struct{}
 
-	mu   sync.Mutex
-	prev map[uint64]bpf.FutexStat
+	mu         sync.Mutex
+	prev       map[uint64]uint64        // uaddr → cumulative waits last window
+	siteCache  map[int32]lockSite       // stack_id → resolved contention site
+	stackCache map[int32][]symbol.Frame // stack_id → full leaf-first frames
+}
+
+// lockSite is the resolved contention site for a stack_id: the raw frame
+// address plus its symbolization. Cached because stacks are stable for the
+// process lifetime and symbolizing re-reads ELF modules.
+type lockSite struct {
+	addr  uint64
+	frame symbol.Frame
 }
 
 // contentionThreshold defines how many new waits in the interval (1s) are
@@ -35,26 +53,39 @@ const topLockEntries = 8
 
 func NewFutexEBPFCollector() *FutexEBPFCollector {
 	return &FutexEBPFCollector{
-		ch:   make(chan interface{}, 8),
-		stop: make(chan struct{}),
-		prev: make(map[uint64]bpf.FutexStat),
+		ch:         make(chan interface{}, 8),
+		stop:       make(chan struct{}),
+		prev:       make(map[uint64]uint64),
+		siteCache:  make(map[int32]lockSite),
+		stackCache: make(map[int32][]symbol.Frame),
 	}
 }
 
-func (c *FutexEBPFCollector) Start(pid int) error { return c.start(bpf.TargetPID(pid)) }
+func (c *FutexEBPFCollector) Start(pid int) error { return c.start(bpf.TargetPID(pid), pid) }
 
 // StartCgroup tracks futex contention across a whole cgroup subtree instead of
-// one pid (#94). Implements CgroupTargeter.
+// one pid (#94). Implements CgroupTargeter. Contention sites stay unresolved:
+// symbolization reads one process's memory map, and a subtree has no single
+// process to read.
 func (c *FutexEBPFCollector) StartCgroup(spec string) error {
-	return c.start(bpf.TargetCgroup(spec))
+	return c.start(bpf.TargetCgroup(spec), 0)
 }
 
-func (c *FutexEBPFCollector) start(t bpf.Target) error {
+func (c *FutexEBPFCollector) start(t bpf.Target, pid int) error {
 	tracer, err := bpf.OpenFutexTracer(t)
 	if err != nil {
 		return fmt.Errorf("futex eBPF: %w", err)
 	}
 	c.tracer = tracer
+	// Symbolize best-effort: without /proc maps the sites degrade to the bare
+	// address, exactly as before #89 — never fail Start over it.
+	if pid <= 0 {
+		c.sym = nil
+	} else if sym, err := symbol.NewSymbolizer(pid); err == nil {
+		c.sym = sym
+	} else {
+		fmt.Fprintf(os.Stderr, "futex: call-site symbolization unavailable for pid %d: %v\n", pid, err)
+	}
 	go c.loop()
 	return nil
 }
@@ -65,10 +96,61 @@ func (c *FutexEBPFCollector) Stop() {
 		_ = c.tracer.Close()
 		c.tracer = nil
 	}
+	if c.sym != nil {
+		_ = c.sym.Close()
+		c.sym = nil
+	}
 }
 
 func (c *FutexEBPFCollector) Subscribe() <-chan interface{} {
 	return c.ch
+}
+
+// ResolveStack returns the full leaf-first symbolized frames of a captured
+// contention stack, or ok=false when the id is unknown (wake-path sentinel,
+// evicted from the kernel map, or empty). Results are cached (stacks are
+// immutable for the process lifetime). Safe for concurrent use — the headless
+// server calls it from gRPC handlers while the publish loop runs. Backs the
+// EventStreamService.ResolveStack RPC for LockEntry.stack_id (#54/#89).
+func (c *FutexEBPFCollector) ResolveStack(stackID uint64) ([]symbol.Frame, bool) {
+	if c.tracer == nil || int32(stackID) < 0 {
+		return nil, false
+	}
+	sid := int32(stackID)
+	c.mu.Lock()
+	if fr, ok := c.stackCache[sid]; ok {
+		c.mu.Unlock()
+		return fr, true
+	}
+	c.mu.Unlock()
+
+	addrs, err := c.tracer.ResolveStack(sid)
+	if err != nil || len(addrs) == 0 {
+		return nil, false
+	}
+	frames := make([]symbol.Frame, len(addrs))
+	for i, a := range addrs {
+		if c.sym != nil {
+			frames[i] = c.sym.Symbolize(a)
+		} else {
+			frames[i] = symbol.Frame{Offset: a}
+		}
+	}
+
+	c.mu.Lock()
+	c.stackCache[sid] = frames
+	c.mu.Unlock()
+	return frames, true
+}
+
+// ProcessBuildID returns the target executable's GNU build-id — the stable
+// per-process key for the stack ids this collector hands out. "" in cgroup mode
+// or when the target has no build-id.
+func (c *FutexEBPFCollector) ProcessBuildID() string {
+	if c.sym == nil {
+		return ""
+	}
+	return c.sym.ProcessBuildID()
 }
 
 func (c *FutexEBPFCollector) loop() {
@@ -84,7 +166,7 @@ func (c *FutexEBPFCollector) loop() {
 			case c.ch <- snap:
 			default:
 			}
-			// Timeline events: one per "hot" uaddr in the interval.
+			// Timeline events: one per "hot" lock in the interval.
 			// Cap at 3 per tick to avoid flooding.
 			emitted := 0
 			for _, e := range hot {
@@ -96,8 +178,8 @@ func (c *FutexEBPFCollector) loop() {
 					Timestamp: time.Now(),
 					Category:  "lock",
 					Message: fmt.Sprintf(
-						"futex@0x%x ↑ %d waits (avg %.1fms, last tid %d)",
-						e.UAddr, e.WaitDelta, e.LatencyMs, e.LastWaitTID,
+						"%s ↑ %d waits (avg %.1fms, last tid %d)",
+						lockName(e), e.WaitDelta, e.LatencyMs, e.LastWaitTID,
 					),
 				}:
 					emitted++
@@ -108,9 +190,10 @@ func (c *FutexEBPFCollector) loop() {
 	}
 }
 
-// snapshot reads futex_stats, computes delta vs prev, returns the top-N
-// by window contention and the "hot" list (those past the threshold for
-// emitting timeline events).
+// snapshot reads futex_stats, folds the per-site rows into one entry per lock,
+// computes the window delta vs the previous read and returns the top-N by
+// contention plus the "hot" list (those past the threshold for a timeline
+// event). Only the entries actually published get their call site symbolized.
 func (c *FutexEBPFCollector) snapshot() (snap []LockEntry, hot []LockEntry) {
 	if c.tracer == nil {
 		return nil, nil
@@ -120,46 +203,101 @@ func (c *FutexEBPFCollector) snapshot() (snap []LockEntry, hot []LockEntry) {
 		return nil, nil
 	}
 
-	c.mu.Lock()
-	defer c.mu.Unlock()
-
-	all := make([]LockEntry, 0, len(stats))
-	for uaddr, s := range stats {
-		p := c.prev[uaddr]
-		waitDelta := s.WaitCount - p.WaitCount
-		latMs := 0.0
-		if s.LatCount > 0 {
-			latMs = float64(s.LatSumNs) / float64(s.LatCount) / 1e6
-		}
-		entry := LockEntry{
-			UAddr:       uaddr,
-			Waiters:     s.WaitCount,
-			Wakers:      s.WakeCount,
-			WaitDelta:   waitDelta,
-			LatencyMs:   latMs,
+	samples := make([]lockSample, 0, len(stats))
+	for k, s := range stats {
+		samples = append(samples, lockSample{
+			UAddr:       k.UAddr,
+			StackID:     k.StackID,
+			WaitCount:   s.WaitCount,
+			WakeCount:   s.WakeCount,
+			LatSumNs:    s.LatSumNs,
+			LatCount:    s.LatCount,
 			LastWaitTID: int(s.LastWaitTID),
 			LastWakeTID: int(s.LastWakeTID),
-		}
-		all = append(all, entry)
-		if waitDelta >= contentionThreshold {
-			hot = append(hot, entry)
-		}
+		})
 	}
-	c.prev = stats
 
-	// Ranking: by WaitDelta desc, with total Waiters as tiebreaker.
-	sort.Slice(all, func(i, j int) bool {
-		if all[i].WaitDelta != all[j].WaitDelta {
-			return all[i].WaitDelta > all[j].WaitDelta
-		}
-		return all[i].Waiters > all[j].Waiters
-	})
-	if len(all) > topLockEntries {
-		all = all[:topLockEntries]
+	c.mu.Lock()
+	entries, cur := aggregateLocks(samples, c.prev)
+	c.prev = cur
+	c.mu.Unlock()
+
+	ranked := rankLocks(entries, -1)
+	hotN := countHot(ranked, contentionThreshold)
+
+	// Everything published is either in the top-N or hot, and rankLocks sorts
+	// by window delta first, so both are prefixes of ranked.
+	resolveN := topLockEntries
+	if hotN > resolveN {
+		resolveN = hotN
 	}
-	// Hot list also sorted by delta desc.
-	sort.Slice(hot, func(i, j int) bool {
-		return hot[i].WaitDelta > hot[j].WaitDelta
-	})
-	return all, hot
+	if resolveN > len(ranked) {
+		resolveN = len(ranked)
+	}
+	for i := range ranked[:resolveN] {
+		c.attachSite(&ranked[i])
+	}
+
+	snap = ranked[:min(topLockEntries, len(ranked))]
+	return snap, ranked[:hotN]
+}
+
+// attachSite fills e's call-site fields from its dominant contention stack.
+// A lock whose stack walk failed keeps StackID < 0 and zeroed site fields.
+func (c *FutexEBPFCollector) attachSite(e *LockEntry) {
+	if e.StackID < 0 {
+		return
+	}
+	site := c.resolveSite(e.StackID)
+	e.CallSite = site.addr
+	e.Func = site.frame.Func
+	e.File = site.frame.File
+	e.Line = site.frame.Line
+	e.Module = site.frame.Module
+	e.Offset = site.frame.Offset
+}
+
+// resolveSite maps a stack_id to the application frame that blocked on the
+// futex — the first frame outside libc/ld, since the leaf is libc's
+// pthread/futex wrapper. Cached under c.mu; returns a zero site when the stack
+// walk failed or nothing could be read.
+func (c *FutexEBPFCollector) resolveSite(stackID int32) lockSite {
+	if stackID < 0 || c.tracer == nil {
+		return lockSite{}
+	}
+	c.mu.Lock()
+	if s, ok := c.siteCache[stackID]; ok {
+		c.mu.Unlock()
+		return s
+	}
+	c.mu.Unlock()
+
+	frames, err := c.tracer.ResolveStack(stackID)
+	if err != nil || len(frames) == 0 {
+		return lockSite{}
+	}
+
+	var site lockSite
+	if c.sym != nil {
+		for _, f := range frames {
+			if f == 0 {
+				continue
+			}
+			fr := c.sym.Symbolize(f)
+			if !isLoaderModule(fr.Module) {
+				site = lockSite{addr: f, frame: fr}
+				break
+			}
+		}
+		if site.addr == 0 { // every frame was loader/libc — fall back to the leaf
+			site = lockSite{addr: frames[0], frame: c.sym.Symbolize(frames[0])}
+		}
+	} else {
+		site = lockSite{addr: frames[0]}
+	}
+
+	c.mu.Lock()
+	c.siteCache[stackID] = site
+	c.mu.Unlock()
+	return site
 }

--- a/pkg/collector/futex_ebpf_stub.go
+++ b/pkg/collector/futex_ebpf_stub.go
@@ -2,7 +2,11 @@
 
 package collector
 
-import "errors"
+import (
+	"errors"
+
+	"github.com/trentas/ptop/pkg/symbol"
+)
 
 type FutexEBPFCollector struct{}
 
@@ -24,3 +28,9 @@ func (c *FutexEBPFCollector) Stop() {}
 func (c *FutexEBPFCollector) Subscribe() <-chan interface{} {
 	return nil
 }
+
+// ResolveStack / ProcessBuildID satisfy the serve.StackResolver shape so the
+// headless server can hold a *FutexEBPFCollector uniformly (#89); without eBPF
+// there is nothing to resolve.
+func (*FutexEBPFCollector) ResolveStack(uint64) ([]symbol.Frame, bool) { return nil, false }
+func (*FutexEBPFCollector) ProcessBuildID() string                     { return "" }

--- a/pkg/collector/types.go
+++ b/pkg/collector/types.go
@@ -151,10 +151,13 @@ type ThreadInfo struct {
 
 // LockEntry describes a contended futex: cumulative WAITs and WAKEs observed
 // on the uaddr (virtual address of the futex word), plus average call
-// latency and the last waiter/waker.
+// latency, the last waiter/waker and the call site that blocked on it.
 //
-// UAddr is the virtual pointer in the process address space — without
-// unwind/symbols we can't resolve it to "mutex-A". We display it in hex.
+// UAddr is a pointer into the live process address space, so it identifies the
+// lock only for THIS run: ASLR and arena reuse hand the same logical lock a
+// different address next time, and a freed address to an unrelated lock. The
+// call site below (#89) is the identity that survives that — compare locks
+// across runs by Module+Offset or Func/File:Line, never by UAddr.
 type LockEntry struct {
 	UAddr       uint64
 	Waiters     uint64  // cumulative wait_count
@@ -163,6 +166,19 @@ type LockEntry struct {
 	LatencyMs   float64 // average latency per call (waits + wakes)
 	LastWaitTID int
 	LastWakeTID int
+
+	// Acquire/contention call site (#89), symbolized like HeapCallSite: the
+	// application frame that blocked on this futex. When a lock is taken from
+	// several places this is the DOMINANT site of the window (most waits).
+	// eBPF-only, and only in pid mode — a cgroup subtree spans processes with
+	// no single memory map to symbolize against, so these stay zero there.
+	CallSite uint64 // raw instruction pointer (0 when the stack walk failed)
+	Func     string // resolved function name ("" if unresolved)
+	File     string // source file (Go only in this cut; "" otherwise)
+	Line     int    // source line (0 if unknown)
+	Module   string // backing module basename ("" if unresolved)
+	Offset   uint64 // module-relative offset — comparable across runs/ASLR
+	StackID  int32  // kernel stack-map id (<0 unknown); resolves to full frames
 }
 
 // ─── I/O ─────────────────────────────────────────────────────────────────────

--- a/pkg/streampb/event.pb.go
+++ b/pkg/streampb/event.pb.go
@@ -2766,15 +2766,32 @@ func (x *FdEvent) GetMessage() string {
 }
 
 // ─── Locks (futex) ──────────────────────────────────────────────────────────
+// LockEntry is one contended futex word. uaddr identifies it inside the LIVE
+// process only — ASLR and arena reuse give the same logical lock a different
+// address on the next run, and hand a freed address to an unrelated lock. The
+// call site below (#89) is the identity that survives that, the way
+// HeapCallSite's is for an allocation: compare locks across runs/deploys by
+// call_site.module+offset (or func/file:line), never by uaddr.
 type LockEntry struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Uaddr         uint64                 `protobuf:"varint,1,opt,name=uaddr,proto3" json:"uaddr,omitempty"`                           // futex word virtual address (no symbols → shown in hex)
-	Waiters       uint64                 `protobuf:"varint,2,opt,name=waiters,proto3" json:"waiters,omitempty"`                       // cumulative wait_count
-	Wakers        uint64                 `protobuf:"varint,3,opt,name=wakers,proto3" json:"wakers,omitempty"`                         // cumulative wake_count
-	WaitDelta     uint64                 `protobuf:"varint,4,opt,name=wait_delta,json=waitDelta,proto3" json:"wait_delta,omitempty"`  // new waits in the current window
-	LatencyMs     float64                `protobuf:"fixed64,5,opt,name=latency_ms,json=latencyMs,proto3" json:"latency_ms,omitempty"` // average per call
-	LastWaitTid   int32                  `protobuf:"varint,6,opt,name=last_wait_tid,json=lastWaitTid,proto3" json:"last_wait_tid,omitempty"`
-	LastWakeTid   int32                  `protobuf:"varint,7,opt,name=last_wake_tid,json=lastWakeTid,proto3" json:"last_wake_tid,omitempty"`
+	state       protoimpl.MessageState `protogen:"open.v1"`
+	Uaddr       uint64                 `protobuf:"varint,1,opt,name=uaddr,proto3" json:"uaddr,omitempty"`                           // futex word virtual address (live process only; shown in hex)
+	Waiters     uint64                 `protobuf:"varint,2,opt,name=waiters,proto3" json:"waiters,omitempty"`                       // cumulative wait_count
+	Wakers      uint64                 `protobuf:"varint,3,opt,name=wakers,proto3" json:"wakers,omitempty"`                         // cumulative wake_count
+	WaitDelta   uint64                 `protobuf:"varint,4,opt,name=wait_delta,json=waitDelta,proto3" json:"wait_delta,omitempty"`  // new waits in the current window
+	LatencyMs   float64                `protobuf:"fixed64,5,opt,name=latency_ms,json=latencyMs,proto3" json:"latency_ms,omitempty"` // average per call
+	LastWaitTid int32                  `protobuf:"varint,6,opt,name=last_wait_tid,json=lastWaitTid,proto3" json:"last_wait_tid,omitempty"`
+	LastWakeTid int32                  `protobuf:"varint,7,opt,name=last_wake_tid,json=lastWakeTid,proto3" json:"last_wake_tid,omitempty"`
+	// Symbolized application frame that blocked on this futex — the DOMINANT
+	// contention site of the window when the lock is taken from several places
+	// (the one with the most waits). eBPF-only, and only in pid mode: a cgroup
+	// subtree spans processes with no single memory map to symbolize against.
+	// Unset when the stack walk failed (no frame pointers).
+	CallSite *StackFrame `protobuf:"bytes,8,opt,name=call_site,json=callSite,proto3" json:"call_site,omitempty"`
+	// Kernel stack id of that contention site, for
+	// EventStreamService.ResolveStack (the full leaf-first stack). Namespaced per
+	// tracer — the high 32 bits select the source map, the low 32 the kernel id —
+	// so pass the value back verbatim. 0 means no stack.
+	StackId       uint64 `protobuf:"varint,9,opt,name=stack_id,json=stackId,proto3" json:"stack_id,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -2854,6 +2871,20 @@ func (x *LockEntry) GetLastWaitTid() int32 {
 func (x *LockEntry) GetLastWakeTid() int32 {
 	if x != nil {
 		return x.LastWakeTid
+	}
+	return 0
+}
+
+func (x *LockEntry) GetCallSite() *StackFrame {
+	if x != nil {
+		return x.CallSite
+	}
+	return nil
+}
+
+func (x *LockEntry) GetStackId() uint64 {
+	if x != nil {
+		return x.StackId
 	}
 	return 0
 }
@@ -3170,7 +3201,7 @@ const file_event_proto_rawDesc = "" +
 	"FdSnapshot\x12\"\n" +
 	"\x03fds\x18\x01 \x03(\v2\x10.ptop.v1.FdEntryR\x03fds\"#\n" +
 	"\aFdEvent\x12\x18\n" +
-	"\amessage\x18\x01 \x01(\tR\amessage\"\xd9\x01\n" +
+	"\amessage\x18\x01 \x01(\tR\amessage\"\xa6\x02\n" +
 	"\tLockEntry\x12\x14\n" +
 	"\x05uaddr\x18\x01 \x01(\x04R\x05uaddr\x12\x18\n" +
 	"\awaiters\x18\x02 \x01(\x04R\awaiters\x12\x16\n" +
@@ -3180,7 +3211,9 @@ const file_event_proto_rawDesc = "" +
 	"\n" +
 	"latency_ms\x18\x05 \x01(\x01R\tlatencyMs\x12\"\n" +
 	"\rlast_wait_tid\x18\x06 \x01(\x05R\vlastWaitTid\x12\"\n" +
-	"\rlast_wake_tid\x18\a \x01(\x05R\vlastWakeTid\"8\n" +
+	"\rlast_wake_tid\x18\a \x01(\x05R\vlastWakeTid\x120\n" +
+	"\tcall_site\x18\b \x01(\v2\x13.ptop.v1.StackFrameR\bcallSite\x12\x19\n" +
+	"\bstack_id\x18\t \x01(\x04R\astackId\"8\n" +
 	"\fLockSnapshot\x12(\n" +
 	"\x05locks\x18\x01 \x03(\v2\x12.ptop.v1.LockEntryR\x05locks\")\n" +
 	"\rTimelineEvent\x12\x18\n" +
@@ -3284,12 +3317,13 @@ var file_event_proto_depIdxs = []int32{
 	20, // 28: ptop.v1.IoSnapshot.latency_buckets:type_name -> ptop.v1.LatencyBucket
 	2,  // 29: ptop.v1.SecurityEvent.call_site:type_name -> ptop.v1.StackFrame
 	27, // 30: ptop.v1.FdSnapshot.fds:type_name -> ptop.v1.FdEntry
-	30, // 31: ptop.v1.LockSnapshot.locks:type_name -> ptop.v1.LockEntry
-	32, // [32:32] is the sub-list for method output_type
-	32, // [32:32] is the sub-list for method input_type
-	32, // [32:32] is the sub-list for extension type_name
-	32, // [32:32] is the sub-list for extension extendee
-	0,  // [0:32] is the sub-list for field type_name
+	2,  // 31: ptop.v1.LockEntry.call_site:type_name -> ptop.v1.StackFrame
+	30, // 32: ptop.v1.LockSnapshot.locks:type_name -> ptop.v1.LockEntry
+	33, // [33:33] is the sub-list for method output_type
+	33, // [33:33] is the sub-list for method input_type
+	33, // [33:33] is the sub-list for extension type_name
+	33, // [33:33] is the sub-list for extension extendee
+	0,  // [0:33] is the sub-list for field type_name
 }
 
 func init() { file_event_proto_init() }

--- a/pkg/streampb/service.pb.go
+++ b/pkg/streampb/service.pb.go
@@ -344,8 +344,10 @@ func (*SubscribeResponse_Event) isSubscribeResponse_Kind() {}
 func (*SubscribeResponse_Meta) isSubscribeResponse_Kind() {}
 
 // ResolveStackRequest asks the server to symbolize a stack id referenced by an
-// event (Event.stack.stack_id or HeapCallSite.stack_id). The id is only valid
-// for the build identified by the accompanying StackRef.build_id.
+// event (Event.stack.stack_id, HeapCallSite.stack_id or LockEntry.stack_id).
+// The id is only valid for the build identified by the accompanying
+// StackRef.build_id, and is namespaced per capturing tracer — pass back exactly
+// the value the event carried, never a bare kernel id.
 type ResolveStackRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	StackId       uint64                 `protobuf:"varint,1,opt,name=stack_id,json=stackId,proto3" json:"stack_id,omitempty"`

--- a/proto/event.proto
+++ b/proto/event.proto
@@ -395,14 +395,31 @@ message FdEvent {
 }
 
 // ─── Locks (futex) ──────────────────────────────────────────────────────────
+// LockEntry is one contended futex word. uaddr identifies it inside the LIVE
+// process only — ASLR and arena reuse give the same logical lock a different
+// address on the next run, and hand a freed address to an unrelated lock. The
+// call site below (#89) is the identity that survives that, the way
+// HeapCallSite's is for an allocation: compare locks across runs/deploys by
+// call_site.module+offset (or func/file:line), never by uaddr.
 message LockEntry {
-  uint64 uaddr = 1; // futex word virtual address (no symbols → shown in hex)
+  uint64 uaddr = 1; // futex word virtual address (live process only; shown in hex)
   uint64 waiters = 2; // cumulative wait_count
   uint64 wakers = 3; // cumulative wake_count
   uint64 wait_delta = 4; // new waits in the current window
   double latency_ms = 5; // average per call
   int32 last_wait_tid = 6;
   int32 last_wake_tid = 7;
+  // Symbolized application frame that blocked on this futex — the DOMINANT
+  // contention site of the window when the lock is taken from several places
+  // (the one with the most waits). eBPF-only, and only in pid mode: a cgroup
+  // subtree spans processes with no single memory map to symbolize against.
+  // Unset when the stack walk failed (no frame pointers).
+  StackFrame call_site = 8;
+  // Kernel stack id of that contention site, for
+  // EventStreamService.ResolveStack (the full leaf-first stack). Namespaced per
+  // tracer — the high 32 bits select the source map, the low 32 the kernel id —
+  // so pass the value back verbatim. 0 means no stack.
+  uint64 stack_id = 9;
 }
 message LockSnapshot {
   repeated LockEntry locks = 1;

--- a/proto/service.proto
+++ b/proto/service.proto
@@ -63,8 +63,10 @@ message SubscribeResponse {
 }
 
 // ResolveStackRequest asks the server to symbolize a stack id referenced by an
-// event (Event.stack.stack_id or HeapCallSite.stack_id). The id is only valid
-// for the build identified by the accompanying StackRef.build_id.
+// event (Event.stack.stack_id, HeapCallSite.stack_id or LockEntry.stack_id).
+// The id is only valid for the build identified by the accompanying
+// StackRef.build_id, and is namespaced per capturing tracer — pass back exactly
+// the value the event carried, never a bare kernel id.
 message ResolveStackRequest {
   uint64 stack_id = 1;
 }


### PR DESCRIPTION
Closes #89.

## What

A `LockEntry` identified a lock only by `uaddr`, the futex word's virtual address — an identity that holds inside one live process and nowhere else. ASLR and arena reuse move it every run, so cross-deploy lock diffs were pure churn.

Locks now carry the same kind of identity heap allocations got in #53/#54: **the call site that blocks on them**.

- **Kernel**: `futex.bpf.c` captures a user stack at each futex WAIT (`futex_stacks`, depth 32) and keys `futex_stats` by `(uaddr, stack_id)`. Wake-class calls keep `stack_id = -1` — the release path never names a lock, and skipping the walk keeps the cheap path cheap.
- **Collector**: folds the per-site rows back into one entry per lock and names it by its **dominant** site (most waits), so a mutex taken from many places reports the one actually serializing it. Symbolization is best-effort and pid-mode only — a cgroup subtree has no single memory map, so its sites stay unresolved, as before.
- **Wire**: `LockEntry` gains `call_site` (`StackFrame`) + `stack_id`, resolvable via the `ResolveStack` RPC.
- **TUI (F4)**: a lock renders as `acquireSlot (pool.go:42)` when resolved, `futex@0xADDR` when not; the name absorbs the leftover width so a long symbol can't overflow the panel.

### Stack ids are now namespaced

Two tracers back `ResolveStack`, and their `STACK_TRACE` maps are independent id counters — id 7 in the heap map is a different stack from id 7 in the futex map. A wire stack id therefore carries its source in the high 32 bits:

```
stack_id = source<<32 | kernel_id      heap = 0, futex = 1, 0 = "no stack"
```

Heap is source 0, so **every id emitted before this PR is byte-identical**. `serve.CombineStackResolvers` routes an id back to the tracer that captured it; an id from an absent or wrong source reports `found=false` instead of answering with someone else's stack.

## Deviation from the issue sketch

The issue proposed six flat fields on `LockEntry` (`func`/`file`/`line`/`module`/`offset` + `stack_id`). This uses the nested `StackFrame call_site` instead — the newer precedent from `SecurityEvent` (#59), a superset of the flat fields, and one message to keep in sync. The collector-side struct keeps flat fields, like `SecurityEvent` does.

## Verification

Compiled the eBPF lane and **loaded it on a live arm64 kernel** (privileged container) against a contended-pthread workload:

```
lock uaddr=0xaaaada490058 waits=194010 site=hot_section module=lockload+0x868 stack_id=0x1000007f4
ResolveStack(tagged) found=true frames=6
   #0                          libc.so.6+0x7eb20
   #1 pthread_mutex_lock       libc.so.6+0x8519c
   #2 hot_section              lockload+0x868
   #3 worker                   lockload+0x8d0
   #4                          libc.so.6+0x82030
   #5                          libc.so.6+0xebf5c
ResolveStack(untagged 0x7f4 → heap namespace) found=false frames=0
```

The chosen site (`hot_section`) is the application frame, not libc's wrapper; the tag keeps the id out of the heap namespace.

Tests: both lanes green on Linux and macOS (`go test ./...`, `go test -tags=ebpf ./...`), plus new unit tests for the fold/dominant-site/ranking helpers, the resolver dispatch, the mapper, and the F4 row.

> Unrelated: `TestServeBackpressureMetaOverGRPC` flakes roughly 1-in-4 under container CPU limits — reproduced on `main` too, untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)