### PR TITLE
One collector bus: TUI, JSONL and gRPC as interchangeable consumers (#71)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -139,6 +139,7 @@ ptop/
 │   ├── collector/                 /proc + eBPF collectors + shared types
 │       ├── types.go               public type contracts (see below)
 │       ├── set.go                 source-priority selection + lifecycle (Set)
+│       ├── bus.go                 single fan-out: Set → N consumers (Feed, #71)
 │       ├── source_{linux,darwin}.go  platform source labels (Source*)
 │       ├── cpu_proc.go            /proc/<pid>/stat utime+stime
 │       ├── cpu_ebpf.go            eBPF perf_event sampling
@@ -298,6 +299,17 @@ Messages flow through `Update(msg tea.Msg)`:
 - `tea.WindowSizeMsg`: layout reflow
 - `tea.KeyMsg`: tab switch / pause / filter / snapshot / quit
 
+Collector values reach the model through **one** consumer, `waitBus` (#71),
+which reads the model's `collector.Bus` subscription and maps the value to a
+message with `busMsg`. Every collector case in `Update` re-arms that same
+command — there is no waiter per collector any more, and no case may read a
+collector channel directly: a collector hands out one shared channel, so a
+direct read would steal events from the gRPC stream and the JSONL export.
+`busMsg` demuxes on the value's own type, which is why a `TimelineEvent` from
+the fd collector and one from futex are the same message. A value it maps to
+nil (a per-allocation `HeapEvent`) is skipped inside the command, so the render
+loop never wakes for a payload no panel shows.
+
 ### Layout
 
 Use `lipgloss.JoinHorizontal` / `lipgloss.JoinVertical` to compose panels.
@@ -374,6 +386,7 @@ ptop --pid <PID> --fps 10   render rate (default: 5)
 ptop --pid <PID> --export   save JSON snapshot on exit (also bound to 'e')
 ptop --pid <PID> --no-ebpf  degraded mode: /proc only, no eBPF
 ptop --pid <PID> --serve unix:///run/ptop.sock   headless: stream events over gRPC, no TUI
+ptop --pid <PID> --serve unix:///run/ptop.sock --tui   TUI *and* stream, one set of collectors (#71)
 ptop --cgroup <path|container-id> --serve <addr>  target a cgroup subtree instead of a PID (#94)
 ptop --pid <PID> --serve tcp://127.0.0.1:50051 --serve-insecure   headless over TCP, cleartext (opt-in)
 ptop --pid <PID> --serve tcp://<ip>:50051 --serve-tls-cert <crt> --serve-tls-key <key>   over TLS
@@ -419,6 +432,15 @@ subscribers (fan-out), with bounded per-subscriber buffers that drop-with-counte
 under backpressure (surfaced as `StreamMeta`). `addr` is `unix:///path` or
 `tcp://host:port`. SIGINT/SIGTERM shuts down and releases collectors. The
 collector→`streampb` mapping + server live in `internal/serve`.
+
+`--serve --tui` (#71) adds the TUI as a second consumer of the same collectors:
+one `collector.Feed` (a `Set` plus the `Bus` fanning it out), the hub attached
+as an inline bus handler and the model as a bus subscription. The TUI runs in
+the foreground and quitting it stops the server; `serve.Options.Ready` closes
+once the endpoint is bound, so a bad address or certificate is reported before
+the alt-screen instead of behind a TUI with nothing behind it. `--export` keeps
+its `--serve` meaning there (the event-level JSONL), not the TUI's
+state-snapshot one.
 
 The gRPC subscriber and the JSONL writer are interchangeable `Sink`s
 (`internal/serve/sink.go`) fed by the hub. `--serve --export` adds the JSONL

--- a/README.md
+++ b/README.md
@@ -236,6 +236,14 @@ with `--export`, also to a JSONL file: one protojson `SubscribeResponse` per
 line — the same messages, so a file and a live stream parse identically. ptop
 holds `CAP_BPF`/`CAP_PERFMON`; subscribers connect with none.
 
+Add `--tui` to watch the process while it streams: the TUI and the subscribers
+become consumers of the *same* running collectors, so nobody sees half a stream.
+Quitting the TUI stops the server.
+
+```bash
+sudo ./bin/ptop --pid <PID> --serve unix:///run/ptop.sock --tui
+```
+
 ### Transport security
 
 The stream carries process internals — heap call sites, filesystem paths and,

--- a/cmd/ptop/main.go
+++ b/cmd/ptop/main.go
@@ -39,6 +39,7 @@ func main() {
 	serveTLSKey := flag.String("serve-tls-key", "", "--serve over TLS: PEM server private key (needs --serve-tls-cert)")
 	serveTLSClientCA := flag.String("serve-tls-client-ca", "", "--serve over mTLS: PEM CA bundle; subscribers must present a certificate signed by it")
 	serveInsecure := flag.Bool("serve-insecure", false, "Allow a PLAINTEXT tcp:// --serve endpoint (unencrypted, unauthenticated) — deliberate opt-in")
+	withTUI := flag.Bool("tui", false, "With --serve: also run the TUI on the same collectors (without --serve the TUI is already the default)")
 	cgroupSpec := flag.String("cgroup", "", "Target a cgroup subtree instead of one PID — a cgroup path or a container id (requires --serve and eBPF)")
 	tls := flag.Bool("tls", false, "Capture TLS payload metadata (direction/fd/byte count) via libssl uprobes — OFF by default (#55)")
 	tlsBytes := flag.Int("tls-bytes", 0, "Also capture up to N bytes of PLAINTEXT per TLS call (implies --tls; 0=metadata only, max 4096). Sensitive: may include credentials/PII")
@@ -53,7 +54,7 @@ func main() {
 
 	// One target, named one of two ways (#94). Everything that cannot hold for a
 	// cgroup subtree is rejected here rather than half-working later.
-	if err := checkTargetFlags(*pid, *cgroupSpec, *serveAddr, *noEBPF); err != nil {
+	if err := checkTargetFlags(*pid, *cgroupSpec, *serveAddr, *noEBPF, *withTUI); err != nil {
 		fmt.Fprintf(os.Stderr, "error: %v\n", err)
 		fmt.Fprintln(os.Stderr, "usage: ptop --pid <PID> [--fps 5] [--no-ebpf] [--export]")
 		fmt.Fprintln(os.Stderr, "       ptop --pid <PID> --serve unix:///run/ptop.sock")
@@ -166,19 +167,29 @@ func main() {
 		if *export {
 			opts.JSONLPath = fmt.Sprintf("ptop-events-%s.jsonl", time.Now().Format("20060102-150405"))
 		}
-		runServe(*serveAddr, target, *noEBPF, tlsEnabled, tlsCap, opts)
+		var tuiCfg *tui.Config
+		if *withTUI {
+			tuiCfg = &tui.Config{PID: *pid, FPS: *fps, NoEBPF: *noEBPF, TLS: tlsEnabled, TLSMaxBytes: tlsCap}
+		}
+		runServe(*serveAddr, target, *noEBPF, tlsEnabled, tlsCap, opts, tuiCfg)
 		return
 	}
 
-	cfg := tui.Config{
+	runTUI(tui.Config{
 		PID:         *pid,
 		FPS:         *fps,
 		NoEBPF:      *noEBPF,
 		Export:      *export,
 		TLS:         tlsEnabled,
 		TLSMaxBytes: tlsCap,
-	}
+	})
+}
 
+// runTUI drives the interactive program to completion: it builds the model
+// (which starts its own collectors unless cfg.Feed hands it a running set),
+// runs it, and then releases what the model owns and writes the --export
+// snapshot.
+func runTUI(cfg tui.Config) {
 	// Resolve the terminal color profile once and pin it. Otherwise lipgloss
 	// re-resolves it lazily and each styled segment re-probes the profile when
 	// converting the 24-bit palette to ANSI — wasteful on the render hot path.
@@ -211,7 +222,7 @@ func main() {
 // eBPF, and it names a set of processes, which the TUI has nowhere to put — its
 // header, thread table and fd list are all one process's. Rejecting those
 // combinations here beats a TUI that renders an empty shell.
-func checkTargetFlags(pid int, cgroupSpec, serveAddr string, noEBPF bool) error {
+func checkTargetFlags(pid int, cgroupSpec, serveAddr string, noEBPF, withTUI bool) error {
 	if cgroupSpec == "" {
 		if pid == 0 {
 			return errors.New("--pid is required (or --cgroup with --serve)")
@@ -227,6 +238,8 @@ func checkTargetFlags(pid int, cgroupSpec, serveAddr string, noEBPF bool) error 
 		return errors.New("--cgroup and --pid name different targets — pass one")
 	case serveAddr == "":
 		return errors.New("--cgroup requires --serve: a cgroup subtree is a set of processes, and the TUI shows one")
+	case withTUI:
+		return errors.New("--cgroup cannot be shown in the TUI: a cgroup subtree is a set of processes, and the TUI shows one")
 	case noEBPF:
 		return errors.New("--cgroup needs eBPF (the subtree filter runs in the kernel) — it cannot work with --no-ebpf")
 	}
@@ -256,20 +269,29 @@ func checkPIDExists(pid int) error {
 	}
 }
 
-// runServe builds the collector Set and streams it over gRPC until SIGINT/
-// SIGTERM. The Set's lifecycle is owned here: serve.Run only stops the server,
+// runServe builds the collector feed and streams it over gRPC until SIGINT/
+// SIGTERM. The feed's lifecycle is owned here: serve.Run only stops the server,
 // so we stop the collectors after it returns. opts carries the transport
 // security and, with --export, the event-level JSONL path (distinct from the
 // TUI's state-snapshot ptop-export-*.jsonl).
-func runServe(addr string, target serve.Target, noEBPF, tlsEnabled bool, tlsBytes int, opts serve.Options) {
+//
+// tuiCfg (--tui, #71) makes the TUI a second consumer of the same bus: one set
+// of collectors, watched live and streamed at once. The TUI then runs in the
+// foreground and quitting it shuts the server down; without it this is headless
+// as before.
+func runServe(addr string, target serve.Target, noEBPF, tlsEnabled bool, tlsBytes int, opts serve.Options, tuiCfg *tui.Config) {
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
 
-	set := collector.NewSet(collector.SetConfig{
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	feed := collector.StartFeed(ctx, collector.SetConfig{
 		PID: target.PID, Cgroup: target.CgroupPath,
 		NoEBPF: noEBPF, TLS: tlsEnabled, TLSMaxBytes: tlsBytes,
 	})
-	defer set.Stop()
+	defer feed.Stop()
+	set := feed.Set
 
 	// The heap (#54) and futex (#89) collectors each own a stack tracer +
 	// symbolizer, so they back the stack references and the ResolveStack RPC.
@@ -285,9 +307,41 @@ func runServe(addr string, target serve.Target, noEBPF, tlsEnabled bool, tlsByte
 	}
 	resolver := serve.CombineStackResolvers(resolvers)
 
-	if err := serve.Run(ctx, addr, target, set.Collectors(), resolver, opts); err != nil {
-		set.Stop() // os.Exit skips the defer
+	if tuiCfg == nil {
+		if err := serve.Run(ctx, addr, target, feed.Bus, resolver, opts); err != nil {
+			feed.Stop() // os.Exit skips the defer
+			fmt.Fprintf(os.Stderr, "fatal error: %v\n", err)
+			os.Exit(1)
+		}
+		return
+	}
+
+	// --serve --tui. The server goes to the background, but only after it is
+	// actually up: opts.Ready closes once the endpoint is bound, so a bad
+	// address or certificate is reported here instead of behind a TUI that
+	// looks fine while nothing is being served.
+	ready := make(chan struct{})
+	opts.Ready = ready
+	srvErr := make(chan error, 1)
+	go func() { srvErr <- serve.Run(ctx, addr, target, feed.Bus, resolver, opts) }()
+
+	select {
+	case <-ready:
+	case err := <-srvErr:
+		feed.Stop()
 		fmt.Fprintf(os.Stderr, "fatal error: %v\n", err)
+		os.Exit(1)
+	}
+
+	tuiCfg.Feed = feed
+	runTUI(*tuiCfg)
+
+	// The TUI is the foreground process here: quitting it stops the server and
+	// releases the collectors both were reading.
+	cancel()
+	if err := <-srvErr; err != nil {
+		feed.Stop()
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
 		os.Exit(1)
 	}
 }

--- a/cmd/ptop/main_test.go
+++ b/cmd/ptop/main_test.go
@@ -45,10 +45,13 @@ func TestCheckTargetFlags(t *testing.T) {
 		cgroup     string
 		serveAddr  string
 		noEBPF     bool
+		withTUI    bool
 		wantErrHas string // "" = must be accepted
 	}{
 		{name: "pid alone", pid: 42},
 		{name: "pid with serve", pid: 42, serveAddr: sock},
+		// #71: one pid, watched live and streamed at the same time.
+		{name: "pid with serve and tui", pid: 42, serveAddr: sock, withTUI: true},
 		{name: "pid with no-ebpf", pid: 42, noEBPF: true},
 		{name: "no target at all", wantErrHas: "--pid is required"},
 		{name: "negative pid", pid: -5, wantErrHas: "not a valid PID"},
@@ -65,11 +68,14 @@ func TestCheckTargetFlags(t *testing.T) {
 		// Two different targets.
 		{name: "cgroup and pid together", pid: 42, cgroup: "/x.scope", serveAddr: sock,
 			wantErrHas: "pass one"},
+		// --tui does not make a subtree renderable either.
+		{name: "cgroup with tui", cgroup: "/x.scope", serveAddr: sock, withTUI: true,
+			wantErrHas: "cannot be shown in the TUI"},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			err := checkTargetFlags(tc.pid, tc.cgroup, tc.serveAddr, tc.noEBPF)
+			err := checkTargetFlags(tc.pid, tc.cgroup, tc.serveAddr, tc.noEBPF, tc.withTUI)
 			if tc.wantErrHas == "" {
 				if err != nil {
 					t.Fatalf("checkTargetFlags = %v, want accepted", err)

--- a/internal/serve/hub.go
+++ b/internal/serve/hub.go
@@ -46,39 +46,31 @@ func (h *Hub) targetInfo() *pb.TargetInfo {
 	}
 }
 
-// Start launches one fan-in goroutine per collector. Each maps published values
-// to Events and broadcasts them to every sink. The goroutines exit when ctx is
-// cancelled or their source channel closes. Non-blocking — returns immediately.
-func (h *Hub) Start(ctx context.Context, cols []collector.Collector) {
-	for _, c := range cols {
-		ch := c.Subscribe()
-		if ch == nil {
-			continue
-		}
-		go h.drain(ctx, ch)
-	}
+// Start attaches the hub to the shared collector bus (#71) — the same bus the
+// TUI can be reading, so `--serve --tui` runs one set of collectors for both.
+// The handler runs inline on the bus's drain goroutine: it only maps and hands
+// off to the sinks, which own their buffering, so it adds no queue and no
+// second place for events to go missing. Detaches when ctx is cancelled.
+// Non-blocking — returns immediately.
+func (h *Hub) Start(ctx context.Context, bus *collector.Bus) {
+	handler := bus.AddHandler(h.handle)
+	go func() {
+		<-ctx.Done()
+		bus.RemoveHandler(handler)
+	}()
 }
 
-func (h *Hub) drain(ctx context.Context, ch <-chan interface{}) {
-	for {
-		select {
-		case <-ctx.Done():
-			return
-		case v, ok := <-ch:
-			if !ok {
-				return
-			}
-			// A ProcContext refreshes the cached identity before it (and every
-			// subsequent event) is stamped — so the snapshot event itself
-			// carries its own up-to-date uid/gid/cgroup_id.
-			if pc, ok := v.(collector.ProcContext); ok {
-				h.setIdent(pc)
-			}
-			if ev := toEvent(h.target.PID, h.buildID, v); ev != nil {
-				h.stampIdent(ev)
-				h.broadcast(ev)
-			}
-		}
+// handle maps one published collector value onto the stream and broadcasts it.
+func (h *Hub) handle(v interface{}) {
+	// A ProcContext refreshes the cached identity before it (and every
+	// subsequent event) is stamped — so the snapshot event itself carries its
+	// own up-to-date uid/gid/cgroup_id.
+	if pc, ok := v.(collector.ProcContext); ok {
+		h.setIdent(pc)
+	}
+	if ev := toEvent(h.target.PID, h.buildID, v); ev != nil {
+		h.stampIdent(ev)
+		h.broadcast(ev)
 	}
 }
 

--- a/internal/serve/hub_test.go
+++ b/internal/serve/hub_test.go
@@ -26,7 +26,7 @@ func TestHubFanOut(t *testing.T) {
 	f := newFake(8)
 	h := NewHub(TargetPID(7), "")
 	sub := h.subscribe(nil)
-	h.Start(ctx, []collector.Collector{f})
+	h.Start(ctx, collector.StartBus(ctx, []collector.Collector{f}))
 
 	f.ch <- collector.CpuSample{UsagePct: 50, Timestamp: time.Now()}
 
@@ -54,7 +54,7 @@ func TestHubCategoryFilter(t *testing.T) {
 	f := newFake(8)
 	h := NewHub(TargetPID(1), "")
 	sub := h.subscribe([]pb.Category{pb.Category_CATEGORY_NETWORK})
-	h.Start(ctx, []collector.Collector{f})
+	h.Start(ctx, collector.StartBus(ctx, []collector.Collector{f}))
 
 	// CPU is filtered out; the network snapshot gets through. So the first (and
 	// only) thing the subscriber sees must be the network event.
@@ -86,7 +86,7 @@ func TestHubBackpressureDrops(t *testing.T) {
 	f := newFake(subBuffer + 200)
 	h := NewHub(TargetPID(1), "")
 	sub := h.subscribe(nil) // never read → its buffer fills, then drops
-	h.Start(ctx, []collector.Collector{f})
+	h.Start(ctx, collector.StartBus(ctx, []collector.Collector{f}))
 
 	const n = subBuffer + 100
 	for i := 0; i < n; i++ {
@@ -115,5 +115,53 @@ func TestHubUnsubscribe(t *testing.T) {
 	h.unsubscribe(sub)
 	if h.sinkCount() != 0 {
 		t.Fatalf("count = %d, want 0 after unsubscribe", h.sinkCount())
+	}
+}
+
+// The point of #71: the headless hub and another consumer of the same bus (the
+// TUI, in the real program) each see the WHOLE stream. Before the bus they read
+// the collector channel directly and split it between them.
+func TestHubSharesTheBusWithAnotherConsumer(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	f := newFake(64)
+	bus := collector.StartBus(ctx, []collector.Collector{f})
+
+	h := NewHub(TargetPID(7), "")
+	sub := h.subscribe(nil)
+	h.Start(ctx, bus)
+
+	// Stands in for the TUI: a plain bus subscription with its own queue.
+	viewer := bus.Subscribe(64)
+	defer viewer.Close()
+
+	const n = 20
+	for i := 0; i < n; i++ {
+		f.ch <- collector.CpuSample{UsagePct: float64(i), Timestamp: time.Now()}
+	}
+
+	for i := 0; i < n; i++ {
+		select {
+		case resp := <-sub.ch:
+			if got := resp.GetEvent().GetCpu().GetUsagePct(); got != float64(i) {
+				t.Fatalf("subscriber event %d = %v, want %v", i, got, float64(i))
+			}
+		case <-time.After(2 * time.Second):
+			t.Fatalf("gRPC subscriber only received %d of %d events", i, n)
+		}
+
+		select {
+		case v := <-viewer.C():
+			s, ok := v.(collector.CpuSample)
+			if !ok || s.UsagePct != float64(i) {
+				t.Fatalf("viewer value %d = %#v, want CpuSample{%v}", i, v, float64(i))
+			}
+		case <-time.After(2 * time.Second):
+			t.Fatalf("viewer only received %d of %d values", i, n)
+		}
+	}
+	if d := viewer.Dropped(); d != 0 {
+		t.Errorf("viewer dropped %d values", d)
 	}
 }

--- a/internal/serve/serve.go
+++ b/internal/serve/serve.go
@@ -62,12 +62,21 @@ type Options struct {
 	// Serving tcp:// in cleartext requires TLS.AllowInsecure; a unix socket
 	// takes no TLS at all. See serverCredentials for the full policy.
 	TLS TLSOptions
+
+	// Ready, if set, is closed once the endpoint is bound and the server is
+	// about to serve. It exists so a caller that runs Run in a goroutine can
+	// tell "up" from "failed at startup" without racing a timer — everything
+	// that can go wrong (address, TLS material, bind) happens before it closes.
+	// Run closes it exactly once, and never closes it on a startup failure.
+	Ready chan<- struct{}
 }
 
 // Run starts the gRPC server bound to addr, streaming events for the given
-// target — a pid or a cgroup subtree — from cols. It blocks until ctx is cancelled, then stops the server
-// and returns. The caller owns the collectors' lifecycle (typically
-// set.Collectors() here and set.Stop() after Run returns). addr is
+// target — a pid or a cgroup subtree — off bus, the shared fan-out over the
+// running collectors (#71). It blocks until ctx is cancelled, then stops the
+// server and returns. The caller owns the feed's lifecycle (typically
+// collector.StartFeed here and feed.Stop() after Run returns), and may attach
+// other consumers to the same bus — the TUI does, under --serve --tui. addr is
 // "unix:///path" or "tcp://host:port"; a tcp:// endpoint must carry TLS
 // material or an explicit opt-in to cleartext (see serverCredentials).
 //
@@ -75,7 +84,7 @@ type Options struct {
 // per-process build-id onto every StackRef and backs the ResolveStack RPC.
 // Build it with CombineStackResolvers over the collectors that captured stacks
 // (heap, futex); nil leaves events without stack references.
-func Run(ctx context.Context, addr string, target Target, cols []collector.Collector, resolver StackResolver, opts Options) error {
+func Run(ctx context.Context, addr string, target Target, bus *collector.Bus, resolver StackResolver, opts Options) error {
 	// Resolve transport security first: a missing certificate or a refused
 	// cleartext endpoint should fail before anything is bound.
 	creds, mode, err := serverCredentials(addr, opts.TLS)
@@ -89,19 +98,19 @@ func Run(ctx context.Context, addr string, target Target, cols []collector.Colle
 	}
 	defer cleanup()
 
-	return runServer(ctx, lis, creds, mode, target, cols, resolver, opts)
+	return runServer(ctx, lis, creds, mode, target, bus, resolver, opts)
 }
 
 // runServer owns everything after the listener exists: the hub, the sinks, the
 // gRPC server and the shutdown. Split out of Run so tests can drive a real
 // server on an ephemeral tcp port (listen() picks it, only lis knows it).
-func runServer(ctx context.Context, lis net.Listener, creds credentials.TransportCredentials, mode string, target Target, cols []collector.Collector, resolver StackResolver, opts Options) error {
+func runServer(ctx context.Context, lis net.Listener, creds credentials.TransportCredentials, mode string, target Target, bus *collector.Bus, resolver StackResolver, opts Options) error {
 	var buildID string
 	if resolver != nil {
 		buildID = resolver.ProcessBuildID()
 	}
 	hub := NewHub(target, buildID)
-	hub.Start(ctx, cols)
+	hub.Start(ctx, bus)
 
 	// Optional JSONL sink: a non-gRPC consumer of the same event stream.
 	if opts.JSONLPath != "" {
@@ -132,6 +141,9 @@ func runServer(ctx context.Context, lis net.Listener, creds credentials.Transpor
 	}
 	fmt.Fprintf(os.Stderr, "[ptop] serving events for %s on %s://%s (%s)\n",
 		target, lis.Addr().Network(), lis.Addr().String(), mode)
+	if opts.Ready != nil {
+		close(opts.Ready)
+	}
 	if err := srv.Serve(lis); err != nil {
 		return fmt.Errorf("serve: %w", err)
 	}

--- a/internal/serve/serve_test.go
+++ b/internal/serve/serve_test.go
@@ -41,7 +41,7 @@ func TestServeUnixEndToEnd(t *testing.T) {
 	}()
 
 	runErr := make(chan error, 1)
-	go func() { runErr <- Run(ctx, addr, TargetPID(99), []collector.Collector{f}, nil, Options{}) }()
+	go func() { runErr <- Run(ctx, addr, TargetPID(99), collector.StartBus(ctx, []collector.Collector{f}), nil, Options{}) }()
 
 	// Wait for the listener socket to appear before dialing.
 	waitFor(t, func() bool { _, err := os.Stat(sock); return err == nil })
@@ -120,7 +120,7 @@ func TestServeBackpressureMetaOverGRPC(t *testing.T) {
 
 	f := newFake(8192) // holds the burst without blocking the producer
 	runErr := make(chan error, 1)
-	go func() { runErr <- Run(ctx, addr, TargetPID(1), []collector.Collector{f}, nil, Options{}) }()
+	go func() { runErr <- Run(ctx, addr, TargetPID(1), collector.StartBus(ctx, []collector.Collector{f}), nil, Options{}) }()
 	waitFor(t, func() bool { _, err := os.Stat(sock); return err == nil })
 
 	conn, err := grpc.NewClient(addr, grpc.WithTransportCredentials(insecure.NewCredentials()))
@@ -188,7 +188,7 @@ func TestServeJSONLExport(t *testing.T) {
 
 	runErr := make(chan error, 1)
 	go func() {
-		runErr <- Run(ctx, "unix://"+sock, TargetPID(5), []collector.Collector{f}, nil, Options{JSONLPath: jsonl})
+		runErr <- Run(ctx, "unix://"+sock, TargetPID(5), collector.StartBus(ctx, []collector.Collector{f}), nil, Options{JSONLPath: jsonl})
 	}()
 	waitFor(t, func() bool { _, err := os.Stat(sock); return err == nil })
 

--- a/internal/serve/serve_test.go
+++ b/internal/serve/serve_test.go
@@ -41,7 +41,9 @@ func TestServeUnixEndToEnd(t *testing.T) {
 	}()
 
 	runErr := make(chan error, 1)
-	go func() { runErr <- Run(ctx, addr, TargetPID(99), collector.StartBus(ctx, []collector.Collector{f}), nil, Options{}) }()
+	go func() {
+		runErr <- Run(ctx, addr, TargetPID(99), collector.StartBus(ctx, []collector.Collector{f}), nil, Options{})
+	}()
 
 	// Wait for the listener socket to appear before dialing.
 	waitFor(t, func() bool { _, err := os.Stat(sock); return err == nil })
@@ -111,6 +113,18 @@ func TestServeUnixEndToEnd(t *testing.T) {
 // exercised through the real gRPC stream (not just the hub). We never call Recv
 // during a large burst, so the transport stalls, the subscriber's bounded
 // buffer overflows, and the service surfaces the drop count.
+//
+// The stall has to be forced, not hoped for: with gRPC's dynamic flow-control
+// window the client's stack can absorb the whole burst without the test ever
+// reading, the sink queue then never fills, and the test fails having proved
+// nothing (it flaked roughly 1 run in 4 that way). Pinning small window sizes
+// disables the BDP tuner, so the server blocks in Send while the queue is still
+// bounded — which is the condition under test.
+// minWindowSize is gRPC's floor for a flow-control window (64KB); anything
+// smaller is raised to it. Setting it explicitly is what turns the dynamic
+// window off.
+const minWindowSize = 64 * 1024
+
 func TestServeBackpressureMetaOverGRPC(t *testing.T) {
 	sock := shortSock(t)
 	addr := "unix://" + sock
@@ -120,10 +134,16 @@ func TestServeBackpressureMetaOverGRPC(t *testing.T) {
 
 	f := newFake(8192) // holds the burst without blocking the producer
 	runErr := make(chan error, 1)
-	go func() { runErr <- Run(ctx, addr, TargetPID(1), collector.StartBus(ctx, []collector.Collector{f}), nil, Options{}) }()
+	go func() {
+		runErr <- Run(ctx, addr, TargetPID(1), collector.StartBus(ctx, []collector.Collector{f}), nil, Options{})
+	}()
 	waitFor(t, func() bool { _, err := os.Stat(sock); return err == nil })
 
-	conn, err := grpc.NewClient(addr, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	conn, err := grpc.NewClient(addr,
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+		grpc.WithInitialWindowSize(minWindowSize),
+		grpc.WithInitialConnWindowSize(minWindowSize),
+	)
 	if err != nil {
 		t.Fatalf("dial: %v", err)
 	}

--- a/internal/serve/target_test.go
+++ b/internal/serve/target_test.go
@@ -25,7 +25,7 @@ func handshakeFor(t *testing.T, target Target) *pb.TargetInfo {
 
 	f := newFake(4)
 	runErr := make(chan error, 1)
-	go func() { runErr <- Run(ctx, addr, target, []collector.Collector{f}, nil, Options{}) }()
+	go func() { runErr <- Run(ctx, addr, target, collector.StartBus(ctx, []collector.Collector{f}), nil, Options{}) }()
 	waitFor(t, func() bool { _, err := os.Stat(sock); return err == nil })
 
 	conn, err := grpc.NewClient(addr, grpc.WithTransportCredentials(insecure.NewCredentials()))
@@ -104,7 +104,7 @@ func TestCgroupModeLeavesEnvelopePidUnset(t *testing.T) {
 	defer cancel()
 	f := newFake(4)
 	sub := h.subscribe(nil)
-	h.Start(ctx, []collector.Collector{f})
+	h.Start(ctx, collector.StartBus(ctx, []collector.Collector{f}))
 	f.ch <- collector.CpuSample{UsagePct: 5, Timestamp: time.Now()}
 
 	select {

--- a/internal/serve/tls_test.go
+++ b/internal/serve/tls_test.go
@@ -213,7 +213,7 @@ func startTCPServer(ctx context.Context, t *testing.T, opts TLSOptions) string {
 	target := lis.Addr().String()
 	done := make(chan error, 1)
 	go func() {
-		done <- runServer(ctx, lis, creds, "test", TargetPID(4242), []collector.Collector{f}, nil, Options{})
+		done <- runServer(ctx, lis, creds, "test", TargetPID(4242), collector.StartBus(ctx, []collector.Collector{f}), nil, Options{})
 	}()
 	t.Cleanup(func() {
 		select {

--- a/internal/tui/bus_test.go
+++ b/internal/tui/bus_test.go
@@ -1,0 +1,150 @@
+package tui
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/trentas/ptop/pkg/collector"
+)
+
+// busFake is a Collector the test publishes on directly.
+type busFake struct{ ch chan interface{} }
+
+func newBusFake() *busFake { return &busFake{ch: make(chan interface{}, 64)} }
+
+func (f *busFake) Start(int) error               { return nil }
+func (f *busFake) Stop()                         {}
+func (f *busFake) Subscribe() <-chan interface{} { return f.ch }
+
+// feedFor wires a model onto collectors the test drives, the way --serve --tui
+// hands the model a feed someone else started.
+func feedFor(t *testing.T, cols ...collector.Collector) (*collector.Feed, Model) {
+	t.Helper()
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	feed := &collector.Feed{
+		Set: collector.NewSet(collector.SetConfig{}),
+		Bus: collector.StartBus(ctx, cols),
+	}
+	m := NewModel(Config{PID: 1, FPS: 5, NoEBPF: true, Feed: feed})
+	return feed, m
+}
+
+// One consumer, every collector: the model's single bus reader turns each
+// published value into the message the Update switch already handles.
+func TestBusMsgCoversEveryConsumedValue(t *testing.T) {
+	cases := []struct {
+		name string
+		in   interface{}
+		want tea.Msg
+	}{
+		{"cpu", collector.CpuSample{UsagePct: 3}, CpuMsg(collector.CpuSample{UsagePct: 3})},
+		{"threads", []collector.ThreadInfo{{TID: 9}}, ThreadsMsg([]collector.ThreadInfo{{TID: 9}})},
+		{"fds", []collector.FDEntry{{FD: 4}}, FDMsg([]collector.FDEntry{{FD: 4}})},
+		{"fd event", collector.FDEvent{Message: "open"}, FDEventMsg(collector.FDEvent{Message: "open"})},
+		{"syscalls", map[string]uint64{"read": 2}, SyscallsMsg(map[string]uint64{"read": 2})},
+		{"net", []collector.NetConn{{FD: 5}}, NetMsg([]collector.NetConn{{FD: 5}})},
+		{"locks", []collector.LockEntry{{UAddr: 1}}, LockGraphMsg([]collector.LockEntry{{UAddr: 1}})},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := busMsg(tc.in)
+			if got == nil {
+				t.Fatalf("busMsg(%T) = nil, want %T", tc.in, tc.want)
+			}
+			if gotT, wantT := fmt.Sprintf("%T", got), fmt.Sprintf("%T", tc.want); gotT != wantT {
+				t.Errorf("busMsg(%T) = %s, want %s", tc.in, gotT, wantT)
+			}
+		})
+	}
+
+	// Both futex and the fd collector publish TimelineEvents; with one bus the
+	// value's own type is what identifies it, so they map to the same message.
+	if _, ok := busMsg(collector.TimelineEvent{Category: "lock"}).(TimelineMsg); !ok {
+		t.Error("a lock TimelineEvent should map to TimelineMsg like any other")
+	}
+
+	// The per-allocation flood has no panel: skipping it here is what keeps it
+	// from waking Update thousands of times a second.
+	if msg := busMsg(collector.HeapEvent{Op: "malloc"}); msg != nil {
+		t.Errorf("busMsg(HeapEvent) = %T, want nil (no panel renders it)", msg)
+	}
+}
+
+// The model must consume through the bus, so what it reads is not taken away
+// from the other consumers of the same collectors.
+func TestModelConsumesSharedFeed(t *testing.T) {
+	f := newBusFake()
+	feed, m := feedFor(t, f)
+
+	// A second consumer standing in for the gRPC stream.
+	other := feed.Bus.Subscribe(16)
+	defer other.Close()
+
+	f.ch <- collector.CpuSample{UsagePct: 42}
+
+	msg := m.waitBus()()
+	cpu, ok := msg.(CpuMsg)
+	if !ok || cpu.UsagePct != 42 {
+		t.Fatalf("model received %#v, want CpuMsg{42}", msg)
+	}
+	select {
+	case v := <-other.C():
+		if s, ok := v.(collector.CpuSample); !ok || s.UsagePct != 42 {
+			t.Fatalf("other consumer received %#v, want CpuSample{42}", v)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("the model stole the value from the other consumer")
+	}
+}
+
+// Quitting the TUI must not take the stream down with it: the model closes its
+// own subscription and leaves collectors it did not start alone.
+func TestModelCloseLeavesAHandedInFeedRunning(t *testing.T) {
+	f := newBusFake()
+	feed, m := feedFor(t, f)
+
+	server := feed.Bus.Subscribe(16)
+	defer server.Close()
+
+	m.Close()
+
+	f.ch <- collector.CpuSample{UsagePct: 7}
+	select {
+	case v := <-server.C():
+		if s, ok := v.(collector.CpuSample); !ok || s.UsagePct != 7 {
+			t.Fatalf("server received %#v, want CpuSample{7}", v)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("the feed stopped when the TUI closed")
+	}
+	if m.ownsFeed {
+		t.Error("model claims ownership of a feed it was handed")
+	}
+}
+
+// A model that started its own feed keeps working exactly as before.
+func TestModelOwnsItsFeedByDefault(t *testing.T) {
+	m := NewModel(Config{PID: 0, FPS: 5, NoEBPF: true})
+	if !m.ownsFeed {
+		t.Fatal("a model with no Feed in its Config must own the one it starts")
+	}
+	if m.busSub == nil {
+		t.Fatal("model has no bus subscription")
+	}
+	m.Close()
+}
+
+// waitBus reports the end of the feed rather than spinning on a closed channel.
+func TestWaitBusOnClosedFeed(t *testing.T) {
+	f := newBusFake()
+	_, m := feedFor(t, f)
+	m.busSub.Close()
+	if _, ok := m.waitBus()().(busClosedMsg); !ok {
+		t.Error("waitBus on a closed subscription should report busClosedMsg")
+	}
+}

--- a/internal/tui/help.go
+++ b/internal/tui/help.go
@@ -1,6 +1,7 @@
 package tui
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/charmbracelet/lipgloss"
@@ -171,6 +172,25 @@ func renderHelpOverlayWithStatus(m Model, w, h int) string {
 				return statusRow("security", false, m.securitySource)
 			}
 			return statusRowNA("security", "needs eBPF (PROT_EXEC mmap/mprotect, SELinux AVC)")
+		}(),
+		// The view is one consumer of the collector bus (#71), never the only
+		// one. A non-zero drop count is the honest signal that this view fell
+		// behind and is missing values — the same thing a stream subscriber is
+		// told about itself.
+		func() string {
+			detail := "own collectors"
+			if !m.ownsFeed {
+				detail = "shared with the --serve stream"
+			}
+			line := keyStyle.Render(padRight("feed", 14)) + descStyle.Render(" ") +
+				sourceStyle.Render("one bus consumer — "+detail)
+			if m.busSub != nil {
+				if d := m.busSub.Dropped(); d > 0 {
+					line += lipgloss.NewStyle().Foreground(ColorAmber).Background(ColorPanel).
+						Render(fmt.Sprintf(" · dropped %d", d))
+				}
+			}
+			return line
 		}(),
 	}
 

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -1,6 +1,7 @@
 package tui
 
 import (
+	"context"
 	"debug/buildinfo"
 	"fmt"
 	"math"
@@ -70,6 +71,13 @@ type Config struct {
 	// TLS payload capture (#55) — opt-in, stream/export-only (no live panel).
 	TLS         bool
 	TLSMaxBytes int
+
+	// Feed, when set, is an already-running Set plus the Bus fanning it out
+	// (#71) — how `--serve --tui` drives the TUI and the gRPC stream from ONE
+	// set of collectors. The model then does not own it: Close leaves the
+	// collectors running for whoever started them. Nil (the default) makes the
+	// model start and own its own feed, exactly as before.
+	Feed *collector.Feed
 }
 
 // ─── Bubbletea messages ──────────────────────────────────────────────────────
@@ -95,7 +103,6 @@ type ProcContextMsg collector.ProcContext
 type ProcLifecycleMsg collector.ProcLifecycleEvent
 type SecurityMsg collector.SecurityEvent
 type LockGraphMsg []collector.LockEntry
-type LockTimelineMsg collector.TimelineEvent
 
 // exportTickMsg fires periodically when continuous export is ON.
 type exportTickMsg time.Time
@@ -170,6 +177,19 @@ type Model struct {
 	// collector.Set, shared with the headless gRPC server (#51). Never nil
 	// after NewModel — an empty Set (PID <= 0) leaves every Mock* true.
 	collectors *collector.Set
+
+	// The model is one consumer of the collector bus (#71), never a direct
+	// reader of a collector channel: a collector hands out a single shared
+	// channel, so reading one directly would steal events from the gRPC stream
+	// and the JSONL export. busSub is its bounded queue — falling behind drops
+	// values (counted) instead of stalling the collectors.
+	//
+	// ownsFeed says whether Close stops the collectors: false when the feed was
+	// handed in (--serve --tui), true when the model started it.
+	feed     *collector.Feed
+	busSub   *collector.Subscription
+	ownsFeed bool
+	stopFeed context.CancelFunc
 
 	// Simulation
 	rng                *rand.Rand
@@ -257,9 +277,22 @@ func NewModel(cfg Config) Model {
 	// duplicated. PID <= 0 yields an empty Set: every Mock* stays true and the
 	// model simulates everything. eBPF start failures are logged to stderr by
 	// the Set (before the alt-screen) and fall back to /proc where possible.
-	m.collectors = collector.NewSet(collector.SetConfig{
-		PID: cfg.PID, NoEBPF: cfg.NoEBPF, TLS: cfg.TLS, TLSMaxBytes: cfg.TLSMaxBytes,
-	})
+	//
+	// A caller can hand in a feed it already started (--serve --tui, #71); the
+	// model then shares those collectors instead of starting a second set that
+	// would fight the first for the same eBPF programs.
+	if cfg.Feed != nil {
+		m.feed = cfg.Feed
+	} else {
+		ctx, cancel := context.WithCancel(context.Background())
+		m.stopFeed = cancel
+		m.ownsFeed = true
+		m.feed = collector.StartFeed(ctx, collector.SetConfig{
+			PID: cfg.PID, NoEBPF: cfg.NoEBPF, TLS: cfg.TLS, TLSMaxBytes: cfg.TLSMaxBytes,
+		})
+	}
+	m.collectors = m.feed.Set
+	m.busSub = m.feed.Bus.Subscribe(busQueue)
 
 	// Mirror the Set's source labels + mock state into the model fields the
 	// help overlay (?) reads. Source "" means no real source started → mock.
@@ -304,64 +337,10 @@ func NewModel(cfg Config) Model {
 // ─── Init / Update / View ────────────────────────────────────────────────────
 
 func (m Model) Init() tea.Cmd {
-	cmds := []tea.Cmd{tick(m.cfg.FPS)}
-	if m.collectors.FD != nil {
-		cmds = append(cmds, waitForFD(m.collectors.FD))
-	}
-	if m.collectors.CPUProc != nil {
-		cmds = append(cmds, waitForCPU(m.collectors.CPUProc))
-	}
-	if m.collectors.CPUEBPF != nil {
-		cmds = append(cmds, waitForCPUEBPF(m.collectors.CPUEBPF))
-	}
-	if m.collectors.ThreadsProc != nil {
-		cmds = append(cmds, waitForThreads(m.collectors.ThreadsProc))
-	}
-	if m.collectors.MemProc != nil {
-		cmds = append(cmds, waitForMem(m.collectors.MemProc))
-	}
-	if m.collectors.IOWait != nil {
-		cmds = append(cmds, waitForIOWait(m.collectors.IOWait))
-	}
-	if m.collectors.IOThroughput != nil {
-		cmds = append(cmds, waitForIOThroughput(m.collectors.IOThroughput))
-	}
-	if m.collectors.SyscallsEBPF != nil {
-		cmds = append(cmds, waitForSyscalls(m.collectors.SyscallsEBPF))
-	}
-	if m.collectors.IOEBPF != nil {
-		cmds = append(cmds, waitForIOEBPF(m.collectors.IOEBPF))
-	}
-	if m.collectors.NetworkEBPF != nil {
-		cmds = append(cmds, waitForNetEBPF(m.collectors.NetworkEBPF))
-	}
-	if m.collectors.ThreadsEBPF != nil {
-		cmds = append(cmds, waitForThreadsEBPF(m.collectors.ThreadsEBPF))
-	}
-	if m.collectors.MemEBPF != nil {
-		cmds = append(cmds, waitForMemEBPF(m.collectors.MemEBPF))
-	}
-	if m.collectors.HeapEBPF != nil {
-		cmds = append(cmds, waitForHeapEBPF(m.collectors.HeapEBPF))
-	}
-	if m.collectors.FutexEBPF != nil {
-		cmds = append(cmds, waitForFutexEBPF(m.collectors.FutexEBPF))
-	}
-	if m.collectors.SignalEBPF != nil {
-		cmds = append(cmds, waitForSignalEBPF(m.collectors.SignalEBPF))
-	}
-	if m.collectors.TLSEBPF != nil {
-		cmds = append(cmds, waitForTLSEBPF(m.collectors.TLSEBPF))
-	}
-	if m.collectors.ProcContext != nil {
-		cmds = append(cmds, waitForProcContext(m.collectors.ProcContext))
-	}
-	if m.collectors.ProcLifecycleEBPF != nil {
-		cmds = append(cmds, waitForProcLifecycleEBPF(m.collectors.ProcLifecycleEBPF))
-	}
-	if m.collectors.SecurityEBPF != nil {
-		cmds = append(cmds, waitForSecurityEBPF(m.collectors.SecurityEBPF))
-	}
+	// One consumer for every collector: the bus fans them out (#71), so the
+	// model no longer arms a waiter per collector — and no longer competes with
+	// the gRPC stream / JSONL export for the same channels.
+	cmds := []tea.Cmd{tick(m.cfg.FPS), m.waitBus()}
 	if m.exportFile != nil {
 		cmds = append(cmds, exportTick())
 	}
@@ -400,11 +379,16 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.render.commit = true
 		return m, tick(m.cfg.FPS)
 
+	case busClosedMsg:
+		// The feed ended (shutdown). Nothing left to consume; the last state
+		// stays on screen until the program exits.
+		return m, nil
+
 	case FDMsg:
 		m.FDs = []collector.FDEntry(v)
 		m.usingMockFDs = false
 		m.FDCountHistory = appendCapped(m.FDCountHistory, float64(len(m.FDs)), 60)
-		return m, waitForFD(m.collectors.FD)
+		return m, m.waitBus()
 
 	case TimelineMsg:
 		// Timeline is prepended; most recent on top. Cap at 120 (same limit
@@ -413,52 +397,40 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if len(m.Timeline) > 120 {
 			m.Timeline = m.Timeline[:120]
 		}
-		return m, waitForFD(m.collectors.FD)
+		return m, m.waitBus()
 
 	case FDEventMsg:
 		m.FDEvents = append([]collector.FDEvent{collector.FDEvent(v)}, m.FDEvents...)
 		if len(m.FDEvents) > 60 {
 			m.FDEvents = m.FDEvents[:60]
 		}
-		return m, waitForFD(m.collectors.FD)
+		return m, m.waitBus()
 
 	case CpuMsg:
 		s := collector.CpuSample(v)
 		m.CPUHistory = appendCapped(m.CPUHistory, s.UsagePct, 60)
 		m.usingMockCPU = false
-		// Reschedule on the active source: eBPF takes priority when available.
-		if m.collectors.CPUEBPF != nil {
-			return m, waitForCPUEBPF(m.collectors.CPUEBPF)
-		}
-		return m, waitForCPU(m.collectors.CPUProc)
+		return m, m.waitBus()
 
 	case ThreadsMsg:
 		m.Threads = []collector.ThreadInfo(v)
 		m.usingMockThreads = false
-		// ThreadsMsg can come from eBPF or /proc — reschedule on the active source.
-		if m.collectors.ThreadsEBPF != nil {
-			return m, waitForThreadsEBPF(m.collectors.ThreadsEBPF)
-		}
-		return m, waitForThreads(m.collectors.ThreadsProc)
+		return m, m.waitBus()
 
 	case MemMsg:
 		m.MemStats = collector.MemStats(v)
 		m.usingMockMem = false
-		// Reschedule on the active source.
-		if m.collectors.MemEBPF != nil {
-			return m, waitForMemEBPF(m.collectors.MemEBPF)
-		}
-		return m, waitForMem(m.collectors.MemProc)
+		return m, m.waitBus()
 
 	case HeapMsg:
 		m.HeapStats = collector.HeapStats(v)
 		m.HeapLiveHist = appendCapped(m.HeapLiveHist, float64(m.HeapStats.LiveHeapBytes), 60)
-		return m, waitForHeapEBPF(m.collectors.HeapEBPF)
+		return m, m.waitBus()
 
 	case IOWaitMsg:
 		m.IOStats.IOWaitPct = collector.IOWaitSample(v).Pct
 		m.usingMockIOWait = false
-		return m, waitForIOWait(m.collectors.IOWait)
+		return m, m.waitBus()
 
 	case clearToastMsg:
 		m.toast = ""
@@ -483,12 +455,12 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// We overwrite the entire counts: the tracer keeps the per-pid cumulative.
 		m.SyscallCounts = map[string]uint64(v)
 		m.usingMockSyscalls = false
-		return m, waitForSyscalls(m.collectors.SyscallsEBPF)
+		return m, m.waitBus()
 
 	case NetMsg:
 		m.NetConns = []collector.NetConn(v)
 		m.usingMockNet = false
-		return m, waitForNetEBPF(m.collectors.NetworkEBPF)
+		return m, m.waitBus()
 
 	case NetErrorMsg:
 		// Real kernel network error (#56) — record it for the F3 Anomalies
@@ -508,7 +480,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if len(m.Timeline) > 120 {
 			m.Timeline = m.Timeline[:120]
 		}
-		return m, waitForNetEBPF(m.collectors.NetworkEBPF)
+		return m, m.waitBus()
 
 	case SignalMsg:
 		// Real signal delivered to the target (#58) — record it (newest-first,
@@ -527,7 +499,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if len(m.Timeline) > 120 {
 			m.Timeline = m.Timeline[:120]
 		}
-		return m, waitForSignalEBPF(m.collectors.SignalEBPF)
+		return m, m.waitBus()
 
 	case TLSPayloadMsg:
 		// Real TLS payload (#55). Stream/export-only — there is no live panel
@@ -539,14 +511,14 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if len(m.TLSPayloads) > 40 {
 			m.TLSPayloads = m.TLSPayloads[:40]
 		}
-		return m, waitForTLSEBPF(m.collectors.TLSEBPF)
+		return m, m.waitBus()
 
 	case ProcContextMsg:
 		// Execution/container context refresh (#60). We keep only the latest
 		// snapshot — the header shows the container badge; the full context is
 		// in the export and the stream. Never simulated.
 		m.ProcCtx = collector.ProcContext(v)
-		return m, waitForProcContext(m.collectors.ProcContext)
+		return m, m.waitBus()
 
 	case ProcLifecycleMsg:
 		// Real exec-lineage event (#60) — fork/exec/exit in the target's
@@ -566,7 +538,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if len(m.Timeline) > 120 {
 			m.Timeline = m.Timeline[:120]
 		}
-		return m, waitForProcLifecycleEBPF(m.collectors.ProcLifecycleEBPF)
+		return m, m.waitBus()
 
 	case SecurityMsg:
 		// Real security event (#59) — a runtime PROT_EXEC mapping or an LSM
@@ -586,19 +558,11 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if len(m.Timeline) > 120 {
 			m.Timeline = m.Timeline[:120]
 		}
-		return m, waitForSecurityEBPF(m.collectors.SecurityEBPF)
+		return m, m.waitBus()
 
 	case LockGraphMsg:
 		m.LockGraph = []collector.LockEntry(v)
-		return m, waitForFutexEBPF(m.collectors.FutexEBPF)
-
-	case LockTimelineMsg:
-		ev := collector.TimelineEvent(v)
-		m.Timeline = append([]collector.TimelineEvent{ev}, m.Timeline...)
-		if len(m.Timeline) > 120 {
-			m.Timeline = m.Timeline[:120]
-		}
-		return m, waitForFutexEBPF(m.collectors.FutexEBPF)
+		return m, m.waitBus()
 
 	case IOEBPFMsg:
 		s := collector.IOEBPFSnapshot(v)
@@ -614,7 +578,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.IOStats.LatencyBuckets = s.Buckets
 		}
 		m.usingMockIOFiles = false
-		return m, waitForIOEBPF(m.collectors.IOEBPF)
+		return m, m.waitBus()
 
 	case FSEventMsg:
 		// Real kernel filesystem event (#57) — record it for the F5 Anomalies
@@ -635,7 +599,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if len(m.Timeline) > 120 {
 			m.Timeline = m.Timeline[:120]
 		}
-		return m, waitForIOEBPF(m.collectors.IOEBPF)
+		return m, m.waitBus()
 
 	case IOThroughputMsg:
 		s := collector.IOThroughputSample(v)
@@ -654,7 +618,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.ioMaxWrite = 100 * 1024
 		}
 		m.usingMockIOThrough = false
-		return m, waitForIOThroughput(m.collectors.IOThroughput)
+		return m, m.waitBus()
 	}
 	return m, nil
 }
@@ -1227,323 +1191,105 @@ func (m Model) Close() {
 	if m.exportFile != nil {
 		_ = m.exportFile.Close()
 	}
-	m.collectors.Stop()
+	if m.busSub != nil {
+		m.busSub.Close()
+	}
+	// Only stop what we started: under --serve --tui the collectors belong to
+	// the server, and quitting the TUI must not take the stream down with it.
+	if !m.ownsFeed {
+		return
+	}
+	if m.stopFeed != nil {
+		m.stopFeed()
+	}
+	m.feed.Stop()
 }
 
-// waitForFD blocks until receiving a message from the FD collector and delivers it to Update.
-// FDCollector publishes 3 different types on the same channel; we demux via
-// type-switch and map to specific tea.Msg.
-func waitForFD(c *collector.FDCollector) tea.Cmd {
-	if c == nil {
+// busQueue bounds the model's queue on the collector bus. Deep enough to ride
+// out a render, small enough that a stalled TUI sheds events instead of hoarding
+// them: the newest state is what a live view wants, not a backlog.
+const busQueue = 256
+
+// busClosedMsg says the feed is finished (the bus subscription was closed at
+// shutdown). The model stops consuming; the render keeps working on the last
+// state it had.
+type busClosedMsg struct{}
+
+// waitBus is the model's ONLY collector consumer (#71): it takes the next value
+// off the bus subscription and turns it into the tea.Msg the Update switch
+// already knows. Every collector case re-arms it, so exactly one read is in
+// flight at a time.
+//
+// Values the TUI has no panel for are skipped here rather than delivered and
+// ignored — that is what keeps the per-allocation HeapEvent flood (#53) from
+// waking Update thousands of times a second for a panel that only renders the
+// periodic HeapStats aggregate.
+func (m Model) waitBus() tea.Cmd {
+	sub := m.busSub
+	if sub == nil {
 		return nil
 	}
 	return func() tea.Msg {
-		v := <-c.Subscribe()
-		switch t := v.(type) {
-		case []collector.FDEntry:
-			return FDMsg(t)
-		case collector.TimelineEvent:
-			return TimelineMsg(t)
-		case collector.FDEvent:
-			return FDEventMsg(t)
-		}
-		return TickMsg(time.Now())
-	}
-}
-
-func waitForCPU(c *collector.CPUCollector) tea.Cmd {
-	if c == nil {
-		return nil
-	}
-	return func() tea.Msg {
-		v := <-c.Subscribe()
-		if s, ok := v.(collector.CpuSample); ok {
-			return CpuMsg(s)
-		}
-		return TickMsg(time.Now())
-	}
-}
-
-func waitForCPUEBPF(c *collector.CPUEBPFCollector) tea.Cmd {
-	if c == nil {
-		return nil
-	}
-	return func() tea.Msg {
-		ch := c.Subscribe()
-		if ch == nil {
-			return TickMsg(time.Now())
-		}
-		v := <-ch
-		if s, ok := v.(collector.CpuSample); ok {
-			return CpuMsg(s)
-		}
-		return TickMsg(time.Now())
-	}
-}
-
-func waitForThreadsEBPF(c *collector.ThreadsEBPFCollector) tea.Cmd {
-	if c == nil {
-		return nil
-	}
-	return func() tea.Msg {
-		ch := c.Subscribe()
-		if ch == nil {
-			return TickMsg(time.Now())
-		}
-		v := <-ch
-		if t, ok := v.([]collector.ThreadInfo); ok {
-			return ThreadsMsg(t)
-		}
-		return TickMsg(time.Now())
-	}
-}
-
-func waitForThreads(c *collector.ThreadsCollector) tea.Cmd {
-	if c == nil {
-		return nil
-	}
-	return func() tea.Msg {
-		v := <-c.Subscribe()
-		if t, ok := v.([]collector.ThreadInfo); ok {
-			return ThreadsMsg(t)
-		}
-		return TickMsg(time.Now())
-	}
-}
-
-func waitForFutexEBPF(c *collector.FutexEBPFCollector) tea.Cmd {
-	if c == nil {
-		return nil
-	}
-	return func() tea.Msg {
-		ch := c.Subscribe()
-		if ch == nil {
-			return TickMsg(time.Now())
-		}
-		v := <-ch
-		switch t := v.(type) {
-		case []collector.LockEntry:
-			return LockGraphMsg(t)
-		case collector.TimelineEvent:
-			return LockTimelineMsg(t)
-		}
-		return TickMsg(time.Now())
-	}
-}
-
-func waitForSignalEBPF(c *collector.SignalEBPFCollector) tea.Cmd {
-	if c == nil {
-		return nil
-	}
-	return func() tea.Msg {
-		ch := c.Subscribe()
-		if ch == nil {
-			return TickMsg(time.Now())
-		}
-		if s, ok := (<-ch).(collector.SignalEvent); ok {
-			return SignalMsg(s)
-		}
-		return TickMsg(time.Now())
-	}
-}
-
-func waitForProcContext(c *collector.ProcContextCollector) tea.Cmd {
-	if c == nil {
-		return nil
-	}
-	return func() tea.Msg {
-		ch := c.Subscribe()
-		if ch == nil {
-			return TickMsg(time.Now())
-		}
-		if s, ok := (<-ch).(collector.ProcContext); ok {
-			return ProcContextMsg(s)
-		}
-		return TickMsg(time.Now())
-	}
-}
-
-func waitForProcLifecycleEBPF(c *collector.ProcLifecycleEBPFCollector) tea.Cmd {
-	if c == nil {
-		return nil
-	}
-	return func() tea.Msg {
-		ch := c.Subscribe()
-		if ch == nil {
-			return TickMsg(time.Now())
-		}
-		if s, ok := (<-ch).(collector.ProcLifecycleEvent); ok {
-			return ProcLifecycleMsg(s)
-		}
-		return TickMsg(time.Now())
-	}
-}
-
-func waitForSecurityEBPF(c *collector.SecurityEBPFCollector) tea.Cmd {
-	if c == nil {
-		return nil
-	}
-	return func() tea.Msg {
-		ch := c.Subscribe()
-		if ch == nil {
-			return TickMsg(time.Now())
-		}
-		if s, ok := (<-ch).(collector.SecurityEvent); ok {
-			return SecurityMsg(s)
-		}
-		return TickMsg(time.Now())
-	}
-}
-
-func waitForTLSEBPF(c *collector.TLSEBPFCollector) tea.Cmd {
-	if c == nil {
-		return nil
-	}
-	return func() tea.Msg {
-		ch := c.Subscribe()
-		if ch == nil {
-			return TickMsg(time.Now())
-		}
-		if p, ok := (<-ch).(collector.TLSPayload); ok {
-			return TLSPayloadMsg(p)
-		}
-		return TickMsg(time.Now())
-	}
-}
-
-func waitForMemEBPF(c *collector.MemEBPFCollector) tea.Cmd {
-	if c == nil {
-		return nil
-	}
-	return func() tea.Msg {
-		ch := c.Subscribe()
-		if ch == nil {
-			return TickMsg(time.Now())
-		}
-		v := <-ch
-		if s, ok := v.(collector.MemStats); ok {
-			return MemMsg(s)
-		}
-		return TickMsg(time.Now())
-	}
-}
-
-// waitForHeapEBPF drains the heap collector's channel. It carries two payloads:
-// the periodic HeapStats aggregate (what the F1 panel renders) and per-alloc/free
-// HeapEvents (for the gRPC stream). The TUI only surfaces the aggregate, so it
-// blocks reading — discarding HeapEvents — until the next HeapStats, which avoids
-// a per-allocation render storm.
-func waitForHeapEBPF(c *collector.HeapEBPFCollector) tea.Cmd {
-	if c == nil {
-		return nil
-	}
-	return func() tea.Msg {
-		ch := c.Subscribe()
-		if ch == nil {
-			return TickMsg(time.Now())
-		}
-		for v := range ch {
-			if s, ok := v.(collector.HeapStats); ok {
-				return HeapMsg(s)
+		for v := range sub.C() {
+			if msg := busMsg(v); msg != nil {
+				return msg
 			}
-			// HeapEvent: not shown in the aggregate panel — keep reading.
 		}
-		return TickMsg(time.Now())
+		return busClosedMsg{}
 	}
 }
 
-func waitForMem(c *collector.MemCollector) tea.Cmd {
-	if c == nil {
-		return nil
+// busMsg maps a published collector value onto the model's message type, or nil
+// when the TUI has nothing to do with it. This is the whole demux: the value's
+// own type says what it is, so it no longer matters which collector produced it
+// (a TimelineEvent from the fd collector and one from futex are the same event
+// to the timeline, and CpuSample means the same whether eBPF or /proc sent it).
+func busMsg(v interface{}) tea.Msg {
+	switch t := v.(type) {
+	case []collector.FDEntry:
+		return FDMsg(t)
+	case collector.FDEvent:
+		return FDEventMsg(t)
+	case collector.TimelineEvent:
+		return TimelineMsg(t)
+	case collector.CpuSample:
+		return CpuMsg(t)
+	case []collector.ThreadInfo:
+		return ThreadsMsg(t)
+	case collector.MemStats:
+		return MemMsg(t)
+	case collector.HeapStats:
+		return HeapMsg(t)
+	case collector.IOWaitSample:
+		return IOWaitMsg(t)
+	case collector.IOThroughputSample:
+		return IOThroughputMsg(t)
+	case map[string]uint64:
+		return SyscallsMsg(t)
+	case collector.IOEBPFSnapshot:
+		return IOEBPFMsg(t)
+	case collector.FSEvent:
+		return FSEventMsg(t)
+	case []collector.NetConn:
+		return NetMsg(t)
+	case collector.NetError:
+		return NetErrorMsg(t)
+	case []collector.LockEntry:
+		return LockGraphMsg(t)
+	case collector.SignalEvent:
+		return SignalMsg(t)
+	case collector.TLSPayload:
+		return TLSPayloadMsg(t)
+	case collector.ProcContext:
+		return ProcContextMsg(t)
+	case collector.ProcLifecycleEvent:
+		return ProcLifecycleMsg(t)
+	case collector.SecurityEvent:
+		return SecurityMsg(t)
 	}
-	return func() tea.Msg {
-		v := <-c.Subscribe()
-		if s, ok := v.(collector.MemStats); ok {
-			return MemMsg(s)
-		}
-		return TickMsg(time.Now())
-	}
-}
-
-func waitForIOWait(c *collector.IOWaitCollector) tea.Cmd {
-	if c == nil {
-		return nil
-	}
-	return func() tea.Msg {
-		v := <-c.Subscribe()
-		if s, ok := v.(collector.IOWaitSample); ok {
-			return IOWaitMsg(s)
-		}
-		return TickMsg(time.Now())
-	}
-}
-
-func waitForIOThroughput(c *collector.IOThroughputCollector) tea.Cmd {
-	if c == nil {
-		return nil
-	}
-	return func() tea.Msg {
-		v := <-c.Subscribe()
-		if s, ok := v.(collector.IOThroughputSample); ok {
-			return IOThroughputMsg(s)
-		}
-		return TickMsg(time.Now())
-	}
-}
-
-func waitForSyscalls(c *collector.SyscallsEBPFCollector) tea.Cmd {
-	if c == nil {
-		return nil
-	}
-	return func() tea.Msg {
-		ch := c.Subscribe()
-		if ch == nil {
-			return TickMsg(time.Now())
-		}
-		v := <-ch
-		if m, ok := v.(map[string]uint64); ok {
-			return SyscallsMsg(m)
-		}
-		return TickMsg(time.Now())
-	}
-}
-
-func waitForNetEBPF(c *collector.NetworkEBPFCollector) tea.Cmd {
-	if c == nil {
-		return nil
-	}
-	return func() tea.Msg {
-		ch := c.Subscribe()
-		if ch == nil {
-			return TickMsg(time.Now())
-		}
-		switch v := (<-ch).(type) {
-		case []collector.NetConn:
-			return NetMsg(v)
-		case collector.NetError:
-			return NetErrorMsg(v)
-		}
-		return TickMsg(time.Now())
-	}
-}
-
-func waitForIOEBPF(c *collector.IOEBPFCollector) tea.Cmd {
-	if c == nil {
-		return nil
-	}
-	return func() tea.Msg {
-		ch := c.Subscribe()
-		if ch == nil {
-			return TickMsg(time.Now())
-		}
-		switch v := (<-ch).(type) {
-		case collector.IOEBPFSnapshot:
-			return IOEBPFMsg(v)
-		case collector.FSEvent:
-			return FSEventMsg(v)
-		}
-		return TickMsg(time.Now())
-	}
+	// collector.HeapEvent lands here: the F1 panel renders the aggregate, and
+	// waking Update per allocation would be a render storm for nothing.
+	return nil
 }
 
 func appendCapped(s []float64, v float64, capN int) []float64 {

--- a/pkg/collector/bus.go
+++ b/pkg/collector/bus.go
@@ -1,0 +1,191 @@
+package collector
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+)
+
+// Bus is the single fan-out over a running set of collectors (#71).
+//
+// A collector's Subscribe() hands out ONE shared channel, so two direct readers
+// steal each other's values — each sees roughly half the stream. The Bus reads
+// every collector exactly once and re-broadcasts what it publishes, which is
+// what lets the TUI, the JSONL export and any number of gRPC subscribers
+// consume the same running collectors at the same time.
+//
+// Two consumer styles share one bus:
+//
+//   - AddHandler — called inline on the drain goroutine. No queue, so nothing
+//     is ever dropped on the way in, and therefore the handler MUST NOT block:
+//     it is for a consumer that transforms and hands off immediately (the
+//     headless hub maps to an Event and gives it to its sinks, which own their
+//     own buffering).
+//   - Subscribe — a bounded channel for a consumer with its own loop (the TUI).
+//     A consumer that falls behind has values dropped and counted, rather than
+//     stalling the collectors behind it.
+//
+// The zero value is not usable; call NewBus (or StartFeed).
+type Bus struct {
+	mu       sync.RWMutex
+	handlers map[*Handler]struct{}
+}
+
+// Handler is one registered inline consumer. Keep the returned pointer to
+// unregister it later.
+type Handler struct{ fn func(v interface{}) }
+
+func NewBus() *Bus { return &Bus{handlers: make(map[*Handler]struct{})} }
+
+// StartBus builds a Bus over cols and starts draining them — the one-liner for
+// callers that already have their collectors (StartFeed builds the Set too).
+func StartBus(ctx context.Context, cols []Collector) *Bus {
+	b := NewBus()
+	b.Start(ctx, cols)
+	return b
+}
+
+// Start drains every collector in cols exactly once and broadcasts whatever
+// they publish. One goroutine per collector, each ending when ctx is cancelled
+// or its channel closes. Returns immediately.
+//
+// Ordering is per collector: values from one collector reach every consumer in
+// publish order. Across collectors there is no ordering — the same as reading
+// their channels directly.
+//
+// Start must be called once per set of collectors. Starting a second Bus over
+// collectors already being drained brings back exactly the event-stealing this
+// type exists to prevent.
+func (b *Bus) Start(ctx context.Context, cols []Collector) {
+	for _, c := range cols {
+		ch := c.Subscribe()
+		if ch == nil {
+			continue // stub collector (non-Linux / no-ebpf build)
+		}
+		go b.drain(ctx, ch)
+	}
+}
+
+func (b *Bus) drain(ctx context.Context, ch <-chan interface{}) {
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case v, ok := <-ch:
+			if !ok {
+				return
+			}
+			b.broadcast(v)
+		}
+	}
+}
+
+func (b *Bus) broadcast(v interface{}) {
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+	for h := range b.handlers {
+		h.fn(v)
+	}
+}
+
+// AddHandler registers fn to be called with every published value, inline on
+// the drain goroutine. fn must not block.
+func (b *Bus) AddHandler(fn func(v interface{})) *Handler {
+	h := &Handler{fn: fn}
+	b.mu.Lock()
+	b.handlers[h] = struct{}{}
+	b.mu.Unlock()
+	return h
+}
+
+// RemoveHandler stops a handler from receiving values. It takes the write lock,
+// so it waits for any in-flight broadcast to finish: once it returns the
+// handler is neither running nor about to run. That is what makes closing a
+// subscription's channel safe.
+func (b *Bus) RemoveHandler(h *Handler) {
+	if h == nil {
+		return
+	}
+	b.mu.Lock()
+	delete(b.handlers, h)
+	b.mu.Unlock()
+}
+
+// HandlerCount reports how many consumers are attached.
+func (b *Bus) HandlerCount() int {
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+	return len(b.handlers)
+}
+
+// Subscription is a channel-style consumer with its own bounded queue. Values
+// arriving while the queue is full are dropped and counted — a slow consumer
+// loses events, it never slows the collectors down.
+type Subscription struct {
+	bus     *Bus
+	h       *Handler
+	ch      chan interface{}
+	dropped atomic.Uint64
+	once    sync.Once
+}
+
+// Subscribe registers a channel consumer with a queue of the given size
+// (buffer < 1 is raised to 1).
+func (b *Bus) Subscribe(buffer int) *Subscription {
+	if buffer < 1 {
+		buffer = 1
+	}
+	s := &Subscription{bus: b, ch: make(chan interface{}, buffer)}
+	s.h = b.AddHandler(func(v interface{}) {
+		select {
+		case s.ch <- v:
+		default:
+			s.dropped.Add(1)
+		}
+	})
+	return s
+}
+
+// C is the subscription's queue. Close closes it, so a consumer loop should
+// treat a closed channel as "the feed is done".
+func (s *Subscription) C() <-chan interface{} { return s.ch }
+
+// Dropped is how many values this consumer missed by falling behind.
+// Cumulative, never reset — report gaps, never hide them.
+func (s *Subscription) Dropped() uint64 { return s.dropped.Load() }
+
+// Close unregisters the subscription and closes its channel. Idempotent, and
+// safe against a concurrent broadcast (RemoveHandler waits for it to finish).
+func (s *Subscription) Close() {
+	s.once.Do(func() {
+		s.bus.RemoveHandler(s.h)
+		close(s.ch)
+	})
+}
+
+// Feed pairs a running Set with the Bus fanning it out. The two always travel
+// together: handing them around separately invites the bug this package exists
+// to prevent — a second Bus built over collectors already being drained, with
+// the two stealing each other's values.
+type Feed struct {
+	Set *Set
+	Bus *Bus
+}
+
+// StartFeed builds the Set for cfg, starts its collectors and begins draining
+// them onto a Bus. The caller owns the lifecycle: cancel ctx to stop the drain
+// goroutines and call Feed.Stop to release the collectors.
+func StartFeed(ctx context.Context, cfg SetConfig) *Feed {
+	set := NewSet(cfg)
+	return &Feed{Set: set, Bus: StartBus(ctx, set.Collectors())}
+}
+
+// Stop releases the collectors (idempotent, like Set.Stop). The bus's drain
+// goroutines end on their own once the collector channels close or the context
+// passed to StartFeed is cancelled.
+func (f *Feed) Stop() {
+	if f == nil || f.Set == nil {
+		return
+	}
+	f.Set.Stop()
+}

--- a/pkg/collector/bus_test.go
+++ b/pkg/collector/bus_test.go
@@ -1,0 +1,217 @@
+package collector
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+// fakeCollector publishes whatever the test feeds it, on the single shared
+// channel every real collector hands out.
+type fakeCollector struct{ ch chan interface{} }
+
+func newFakeCollector(buf int) *fakeCollector {
+	return &fakeCollector{ch: make(chan interface{}, buf)}
+}
+
+func (f *fakeCollector) Start(int) error               { return nil }
+func (f *fakeCollector) Stop()                         { close(f.ch) }
+func (f *fakeCollector) Subscribe() <-chan interface{} { return f.ch }
+
+// The whole point of the bus: two consumers of one collector both see every
+// value, instead of splitting the stream between them.
+func TestBusFansOutToEveryConsumer(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	f := newFakeCollector(8)
+	bus := NewBus()
+	bus.Start(ctx, []Collector{f})
+
+	a := bus.Subscribe(8)
+	defer a.Close()
+	b := bus.Subscribe(8)
+	defer b.Close()
+
+	var inline []interface{}
+	done := make(chan struct{}, 4)
+	bus.AddHandler(func(v interface{}) { inline = append(inline, v); done <- struct{}{} })
+
+	for i := 0; i < 3; i++ {
+		f.ch <- CpuSample{UsagePct: float64(i)}
+	}
+	for i := 0; i < 3; i++ {
+		<-done // the inline handler runs on the drain goroutine; wait for it
+	}
+
+	for name, sub := range map[string]*Subscription{"a": a, "b": b} {
+		for i := 0; i < 3; i++ {
+			v := recvValue(t, sub)
+			s, ok := v.(CpuSample)
+			if !ok || s.UsagePct != float64(i) {
+				t.Fatalf("%s got %#v, want CpuSample{%d}", name, v, i)
+			}
+		}
+	}
+	if len(inline) != 3 {
+		t.Errorf("inline handler saw %d values, want 3", len(inline))
+	}
+}
+
+// A consumer that stops reading must lose events and count them — never stall
+// the collectors, and never hide the gap.
+func TestBusSlowConsumerDropsAndCounts(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	f := newFakeCollector(1)
+	bus := NewBus()
+	bus.Start(ctx, []Collector{f})
+
+	slow := bus.Subscribe(2)
+	defer slow.Close()
+	fast := bus.Subscribe(64)
+	defer fast.Close()
+
+	for i := 0; i < 20; i++ {
+		f.ch <- CpuSample{UsagePct: float64(i)}
+	}
+	// The fast consumer draining all 20 proves the producer was never blocked
+	// by the slow one.
+	for i := 0; i < 20; i++ {
+		recvValue(t, fast)
+	}
+	if got := slow.Dropped(); got == 0 {
+		t.Error("slow consumer dropped nothing; expected the bounded queue to shed")
+	}
+	if got := fast.Dropped(); got != 0 {
+		t.Errorf("fast consumer dropped %d, want 0", got)
+	}
+}
+
+// Close must unregister before closing the channel, or a broadcast racing it
+// would send on a closed channel and panic.
+func TestSubscriptionCloseIsSafeAndIdempotent(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	f := newFakeCollector(64)
+	bus := NewBus()
+	bus.Start(ctx, []Collector{f})
+
+	sub := bus.Subscribe(4)
+	stop := make(chan struct{})
+	go func() {
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+				f.ch <- CpuSample{}
+			}
+		}
+	}()
+
+	sub.Close()
+	sub.Close() // idempotent
+	close(stop)
+
+	if _, open := <-sub.C(); open {
+		t.Error("channel still delivering after Close")
+	}
+	if n := bus.HandlerCount(); n != 0 {
+		t.Errorf("HandlerCount = %d after Close, want 0", n)
+	}
+}
+
+// A removed handler must not be called again — RemoveHandler waits for the
+// in-flight broadcast rather than racing it.
+func TestRemoveHandlerStopsDelivery(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	f := newFakeCollector(8)
+	bus := NewBus()
+	bus.Start(ctx, []Collector{f})
+
+	seen := make(chan struct{}, 16)
+	h := bus.AddHandler(func(interface{}) { seen <- struct{}{} })
+	f.ch <- CpuSample{}
+	<-seen
+
+	bus.RemoveHandler(h)
+	sentinel := bus.Subscribe(4) // ordering probe: it is attached after h left
+	defer sentinel.Close()
+
+	f.ch <- CpuSample{}
+	recvValue(t, sentinel) // the value has now been broadcast
+	select {
+	case <-seen:
+		t.Error("removed handler still received a value")
+	default:
+	}
+}
+
+// Cancelling the context stops the drain goroutines.
+func TestBusStopsWithContext(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	f := newFakeCollector(8)
+	bus := NewBus()
+	bus.Start(ctx, []Collector{f})
+
+	sub := bus.Subscribe(8)
+	defer sub.Close()
+	f.ch <- CpuSample{UsagePct: 1}
+	recvValue(t, sub)
+
+	cancel()
+	// Give the drain goroutine a moment to observe the cancellation, then check
+	// that further publishes go nowhere.
+	deadline := time.After(time.Second)
+	for {
+		f.ch <- CpuSample{UsagePct: 2}
+		select {
+		case <-sub.C():
+			select {
+			case <-deadline:
+				t.Fatal("drain goroutine still broadcasting after cancel")
+			default:
+				continue // may still be draining what was queued
+			}
+		case <-time.After(100 * time.Millisecond):
+			return // nothing arrived: the drain goroutine is gone
+		}
+	}
+}
+
+// A stub collector (Subscribe returns nil off Linux / without eBPF) must be
+// skipped, not panic the drain.
+func TestBusSkipsNilChannels(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	bus := NewBus()
+	bus.Start(ctx, []Collector{stubCollector{}})
+	if n := bus.HandlerCount(); n != 0 {
+		t.Errorf("HandlerCount = %d, want 0", n)
+	}
+}
+
+type stubCollector struct{}
+
+func (stubCollector) Start(int) error               { return nil }
+func (stubCollector) Stop()                         {}
+func (stubCollector) Subscribe() <-chan interface{} { return nil }
+
+func recvValue(t *testing.T, s *Subscription) interface{} {
+	t.Helper()
+	select {
+	case v, ok := <-s.C():
+		if !ok {
+			t.Fatal("subscription channel closed")
+		}
+		return v
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for a value")
+		return nil
+	}
+}


### PR DESCRIPTION
Closes #71.

## The problem

A collector's `Subscribe()` hands out **one shared channel**, so two readers steal each other's values — each sees about half the stream. That forced two separate consumption models: the TUI armed a `waitFor*` command per collector and read the channels directly, while the headless hub read those same channels for its sinks. Running the TUI *and* an external subscriber against one process was not possible.

## The change

`collector.Bus` reads each collector exactly once and re-broadcasts. Two consumer styles on the same bus:

| | when | backpressure |
|---|---|---|
| `AddHandler` | inline on the drain goroutine; must not block | none needed — the hub maps to an `Event` and hands off to its sinks, which already own their buffering |
| `Subscribe(buffer)` | a consumer with its own loop (the TUI) | bounded queue, drop-with-counter — the same policy the sinks use |

`collector.Feed` pairs a running `Set` with the `Bus` fanning it out; handing those around separately invites exactly the bug this replaces (a second bus over collectors already being drained).

**The TUI becomes one bus consumer.** The ~19 `waitFor*` commands collapse into `waitBus` + `busMsg`, which demuxes on the value's own type. Two things fall out of that:

- the "reschedule on the active source" branches disappear — a `CpuSample` means the same thing whether eBPF or /proc published it;
- `LockTimelineMsg` disappears — a `TimelineEvent` from futex and one from the fd collector are the same event to the timeline. It only ever existed because they arrived on different channels.

`busMsg` returning nil is how a value with no panel gets skipped *inside* the command — that is what keeps the per-allocation `HeapEvent` flood from waking `Update`, the job `waitForHeapEBPF`'s loop used to do. `model.go` loses ~370 lines.

## New: `--serve --tui`

```bash
ptop --pid 42 --serve unix:///run/ptop.sock         # headless, byte for byte as before
ptop --pid 42 --serve unix:///run/ptop.sock --tui   # TUI + stream, one set of collectors
```

One `Feed`, the hub attached as a bus handler, the model as a subscription. The TUI runs in the foreground and quitting it stops the server. `serve.Options.Ready` closes once the endpoint is bound, so a bad address or certificate is reported *before* the alt-screen rather than behind a TUI with nothing behind it. `--cgroup` still refuses the TUI (a subtree is a set of processes; the TUI shows one), and `--export` keeps its `--serve` meaning there (event-level JSONL).

The help overlay grew a `feed` row: which collectors this view reads (its own, or shared with the stream) and how many values it has dropped — the same honesty the stream gives its subscribers.

## Verification

Tests: `pkg/collector/bus_test.go` (fan-out, slow-consumer drops, close-vs-broadcast race, context teardown), `internal/serve` (hub + a second consumer of one bus each receive all 20 events), `internal/tui` (every consumed value maps to a message, the model doesn't steal from a co-consumer, `Close` leaves a handed-in feed running). Race detector clean on all three packages.

**Live on a real kernel** (Ubuntu 26.04 / 7.0.0-29 aarch64), TUI and subscriber at the same time against a contended-pthread workload:

```
===== gRPC subscriber (while the TUI is running) =====
lock uaddr=0xc9ce26720018 waits=28163 site=hot_section module=lockload+0x97c stack_id=0x100000b86
ResolveStack(tagged) found=true frames=6
   #2 hot_section              lockload+0x97c
   #3 worker                   lockload+0x9e4
===== TUI frames: same collectors, same data? =====
captured bytes: 107816
  TUI shows: lockload
  TUI shows: hot_section
  TUI shows: Threads
.305 LCK  hot_section ↑ 3599 waits (avg 0.2ms, last tid 520088)
```

Both consumers, same running collectors, neither starved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)