### PR TITLE
serve: subscriber-selected targets, collectors only while watched (#72)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -106,6 +106,7 @@ ptop/
 │   │   ├── tls.go                 transport security: TLS/mTLS policy + hot reload (#95)
 │   │   ├── hub.go                 fan-in collectors → fan-out to sinks
 │   │   ├── sink.go                Sink iface: gRPC subscriber + JSONL writer
+│   │   ├── registry.go            fixed target vs targets on demand, refcounted (#72)
 │   │   ├── stackid.go             wire stack-id namespace + combined resolver (#89)
 │   │   ├── service.go             EventStream gRPC service impl
 │   │   └── mapper.go              collector value → streampb.Event
@@ -387,6 +388,8 @@ ptop --pid <PID> --export   save JSON snapshot on exit (also bound to 'e')
 ptop --pid <PID> --no-ebpf  degraded mode: /proc only, no eBPF
 ptop --pid <PID> --serve unix:///run/ptop.sock   headless: stream events over gRPC, no TUI
 ptop --pid <PID> --serve unix:///run/ptop.sock --tui   TUI *and* stream, one set of collectors (#71)
+ptop --serve unix:///run/ptop.sock          no --pid: each subscriber names its target (#72)
+ptop --serve unix:///run/ptop.sock --serve-max-targets 16   raise the concurrent-target cap (default 8)
 ptop --cgroup <path|container-id> --serve <addr>  target a cgroup subtree instead of a PID (#94)
 ptop --pid <PID> --serve tcp://127.0.0.1:50051 --serve-insecure   headless over TCP, cleartext (opt-in)
 ptop --pid <PID> --serve tcp://<ip>:50051 --serve-tls-cert <crt> --serve-tls-key <key>   over TLS
@@ -441,6 +444,31 @@ once the endpoint is bound, so a bad address or certificate is reported before
 the alt-screen instead of behind a TUI with nothing behind it. `--export` keeps
 its `--serve` meaning there (the event-level JSONL), not the TUI's
 state-snapshot one.
+
+**`--serve` with no `--pid`/`--cgroup` serves targets on demand** (#72):
+`SubscribeRequest.pid` names the process, a target's collectors start with its
+first subscriber and are released when its last one disconnects, so nothing
+keeps eBPF loaded for a process nobody watches. `internal/serve/registry.go`
+holds both shapes behind one interface — `fixedRegistry` (the command-line
+target; it starts and releases nothing) and `onDemandRegistry` (refcounted
+`collector.Feed` + `Hub` per pid, capped by `--serve-max-targets`, default 8).
+One mutex covers the whole map and is held across collector startup, which
+serializes an eBPF load for pid B behind one for pid A; that is deliberate —
+it makes a teardown-vs-subscribe race for the same pid impossible.
+
+Three consequences worth knowing:
+
+- **`ResolveStack` takes a pid too.** Kernel stack maps are per-target, so the
+  same id means different stacks in different processes. It uses `lookup`, not
+  `acquire`: an id for a process nobody is streaming reports `found=false`
+  rather than starting collectors to answer, because that stack died with the
+  tracer.
+- **A fixed-target server validates the pid** instead of ignoring it: `0` (the
+  pre-#72 request shape) or its own pid are served, anything else is
+  `InvalidArgument` — never the wrong process silently.
+- **`--export` and `--tui` need a fixed target.** A JSONL export names one
+  target in its header, and the TUI shows one process; both are refused at
+  startup in on-demand mode.
 
 The gRPC subscriber and the JSONL writer are interchangeable `Sink`s
 (`internal/serve/sink.go`) fed by the hub. `--serve --export` adds the JSONL

--- a/README.md
+++ b/README.md
@@ -244,6 +244,16 @@ Quitting the TUI stops the server.
 sudo ./bin/ptop --pid <PID> --serve unix:///run/ptop.sock --tui
 ```
 
+Started **without** `--pid`, the server has no target of its own: each
+subscriber names the process it wants in `SubscribeRequest.pid`, that pid's
+collectors start with its first subscriber and are released when its last one
+disconnects. `--serve-max-targets` (default 8) caps how many run at once, since
+each target carries its own eBPF programs.
+
+```bash
+sudo ./bin/ptop --serve unix:///run/ptop.sock          # subscribers pick the target
+```
+
 ### Transport security
 
 The stream carries process internals — heap call sites, filesystem paths and,

--- a/cmd/ptop/main.go
+++ b/cmd/ptop/main.go
@@ -40,6 +40,7 @@ func main() {
 	serveTLSClientCA := flag.String("serve-tls-client-ca", "", "--serve over mTLS: PEM CA bundle; subscribers must present a certificate signed by it")
 	serveInsecure := flag.Bool("serve-insecure", false, "Allow a PLAINTEXT tcp:// --serve endpoint (unencrypted, unauthenticated) — deliberate opt-in")
 	withTUI := flag.Bool("tui", false, "With --serve: also run the TUI on the same collectors (without --serve the TUI is already the default)")
+	maxTargets := flag.Int("serve-max-targets", 0, "With --serve and no --pid: how many processes to observe at once (0 = default)")
 	cgroupSpec := flag.String("cgroup", "", "Target a cgroup subtree instead of one PID — a cgroup path or a container id (requires --serve and eBPF)")
 	tls := flag.Bool("tls", false, "Capture TLS payload metadata (direction/fd/byte count) via libssl uprobes — OFF by default (#55)")
 	tlsBytes := flag.Int("tls-bytes", 0, "Also capture up to N bytes of PLAINTEXT per TLS call (implies --tls; 0=metadata only, max 4096). Sensitive: may include credentials/PII")
@@ -60,11 +61,14 @@ func main() {
 		fmt.Fprintln(os.Stderr, "       ptop --pid <PID> --serve unix:///run/ptop.sock")
 		fmt.Fprintln(os.Stderr, "       ptop --pid <PID> --serve tcp://<ip>:50051 --serve-tls-cert <crt> --serve-tls-key <key>")
 		fmt.Fprintln(os.Stderr, "       ptop --cgroup <path|container-id> --serve tcp://127.0.0.1:50051")
+		fmt.Fprintln(os.Stderr, "       ptop --serve unix:///run/ptop.sock          (no --pid: subscribers pick the target)")
 		fmt.Fprintln(os.Stderr, "       ptop --version")
 		os.Exit(1)
 	}
 
-	if *cgroupSpec == "" {
+	// With no target of our own the pid arrives per subscriber, and the server
+	// checks each one when it starts that target's collectors (#72).
+	if *cgroupSpec == "" && *pid != 0 {
 		if err := checkPIDExists(*pid); err != nil {
 			fmt.Fprintf(os.Stderr, "error: %v\n", err)
 			os.Exit(1)
@@ -111,7 +115,13 @@ func main() {
 				fmt.Fprint(os.Stderr, diag)
 				os.Exit(1)
 			}
-			fmt.Fprintln(os.Stderr, "[ptop] eBPF embedded, kernel supports it. Starting tracers...")
+			if *serveAddr != "" && *pid == 0 && *cgroupSpec == "" {
+				// On-demand mode loads nothing until a subscriber names a pid,
+				// so don't claim tracers are starting (#72).
+				fmt.Fprintln(os.Stderr, "[ptop] eBPF embedded, kernel supports it. Tracers start per target, on subscribe.")
+			} else {
+				fmt.Fprintln(os.Stderr, "[ptop] eBPF embedded, kernel supports it. Starting tracers...")
+			}
 		}
 	}
 
@@ -167,6 +177,18 @@ func main() {
 		if *export {
 			opts.JSONLPath = fmt.Sprintf("ptop-events-%s.jsonl", time.Now().Format("20060102-150405"))
 		}
+		// No --pid and no --cgroup: serve whatever pid each subscriber asks
+		// for, starting and stopping collectors with its subscribers (#72).
+		if *pid == 0 && *cgroupSpec == "" {
+			opts.MaxTargets = *maxTargets
+			if *export {
+				fmt.Fprintln(os.Stderr, "error: --export needs a fixed target (--pid): an event export names one target in its header")
+				os.Exit(1)
+			}
+			runServeOnDemand(*serveAddr, *noEBPF, tlsEnabled, tlsCap, opts)
+			return
+		}
+
 		var tuiCfg *tui.Config
 		if *withTUI {
 			tuiCfg = &tui.Config{PID: *pid, FPS: *fps, NoEBPF: *noEBPF, TLS: tlsEnabled, TLSMaxBytes: tlsCap}
@@ -183,6 +205,43 @@ func main() {
 		TLS:         tlsEnabled,
 		TLSMaxBytes: tlsCap,
 	})
+}
+
+// runServeOnDemand serves targets its subscribers pick (#72): no collectors run
+// until someone subscribes to a pid, and a target's collectors are released
+// when its last subscriber disconnects. Everything about a single target is
+// built exactly as runServe builds its one — same Set config, same resolver.
+func runServeOnDemand(addr string, noEBPF, tlsEnabled bool, tlsBytes int, opts serve.Options) {
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	factory := func(ctx context.Context, pid int) (*collector.Feed, serve.StackResolver, error) {
+		feed := collector.StartFeed(ctx, collector.SetConfig{
+			PID: pid, NoEBPF: noEBPF, TLS: tlsEnabled, TLSMaxBytes: tlsBytes,
+		})
+		return feed, stackResolverFor(feed.Set), nil
+	}
+
+	if err := serve.RunOnDemand(ctx, addr, factory, opts); err != nil {
+		fmt.Fprintf(os.Stderr, "fatal error: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+// stackResolverFor builds the ResolveStack backing for one target. The heap
+// (#54) and futex (#89) collectors each own a stack tracer + symbolizer, and
+// wire ids are namespaced by source, so one combined resolver serves both. Only
+// a collector that actually started is registered — a nil pointer stored in the
+// map would still read as a non-nil interface.
+func stackResolverFor(set *collector.Set) serve.StackResolver {
+	resolvers := make(map[serve.StackSource]serve.StackResolver, 2)
+	if set.HeapEBPF != nil {
+		resolvers[serve.StackSourceHeap] = set.HeapEBPF
+	}
+	if set.FutexEBPF != nil {
+		resolvers[serve.StackSourceFutex] = set.FutexEBPF
+	}
+	return serve.CombineStackResolvers(resolvers)
 }
 
 // runTUI drives the interactive program to completion: it builds the model
@@ -224,11 +283,21 @@ func runTUI(cfg tui.Config) {
 // combinations here beats a TUI that renders an empty shell.
 func checkTargetFlags(pid int, cgroupSpec, serveAddr string, noEBPF, withTUI bool) error {
 	if cgroupSpec == "" {
-		if pid == 0 {
-			return errors.New("--pid is required (or --cgroup with --serve)")
-		}
 		if pid < 0 {
 			return fmt.Errorf("--pid %d is not a valid PID", pid)
+		}
+		if pid > 0 {
+			return nil
+		}
+		// No target named at all. With --serve that is the on-demand mode
+		// (#72): subscribers name the pid, and each target's collectors live
+		// only as long as someone is watching it. Without --serve there is
+		// nothing to show.
+		switch {
+		case serveAddr == "":
+			return errors.New("--pid is required (or --cgroup/--serve with no --pid, where subscribers pick the target)")
+		case withTUI:
+			return errors.New("--tui needs a target: with no --pid the target is chosen per subscriber, and the TUI shows one process")
 		}
 		return nil
 	}
@@ -293,19 +362,7 @@ func runServe(addr string, target serve.Target, noEBPF, tlsEnabled bool, tlsByte
 	defer feed.Stop()
 	set := feed.Set
 
-	// The heap (#54) and futex (#89) collectors each own a stack tracer +
-	// symbolizer, so they back the stack references and the ResolveStack RPC.
-	// Wire ids are namespaced by source, so one combined resolver serves both.
-	// Only register a collector that actually started — a nil pointer stored in
-	// the map would still read as a non-nil interface.
-	resolvers := make(map[serve.StackSource]serve.StackResolver, 2)
-	if set.HeapEBPF != nil {
-		resolvers[serve.StackSourceHeap] = set.HeapEBPF
-	}
-	if set.FutexEBPF != nil {
-		resolvers[serve.StackSourceFutex] = set.FutexEBPF
-	}
-	resolver := serve.CombineStackResolvers(resolvers)
+	resolver := stackResolverFor(set)
 
 	if tuiCfg == nil {
 		if err := serve.Run(ctx, addr, target, feed.Bus, resolver, opts); err != nil {

--- a/cmd/ptop/main_test.go
+++ b/cmd/ptop/main_test.go
@@ -53,7 +53,15 @@ func TestCheckTargetFlags(t *testing.T) {
 		// #71: one pid, watched live and streamed at the same time.
 		{name: "pid with serve and tui", pid: 42, serveAddr: sock, withTUI: true},
 		{name: "pid with no-ebpf", pid: 42, noEBPF: true},
+		// #72: no target named + --serve is the on-demand mode; subscribers say
+		// which pid they want.
+		{name: "no target with serve", serveAddr: sock},
+		{name: "no target with serve and max-targets", serveAddr: sock},
 		{name: "no target at all", wantErrHas: "--pid is required"},
+		// There is no one process for the TUI to draw when the target is
+		// whatever each subscriber asks for.
+		{name: "no target with serve and tui", serveAddr: sock, withTUI: true,
+			wantErrHas: "--tui needs a target"},
 		{name: "negative pid", pid: -5, wantErrHas: "not a valid PID"},
 
 		{name: "cgroup with serve", cgroup: "/kubepods.slice/x.scope", serveAddr: sock},

--- a/internal/serve/registry.go
+++ b/internal/serve/registry.go
@@ -1,0 +1,234 @@
+package serve
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"sync"
+	"syscall"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/trentas/ptop/pkg/collector"
+)
+
+// defaultMaxTargets bounds how many processes one on-demand server observes at
+// once. Each target loads its own eBPF programs and perf events, so this is a
+// resource ceiling, not a policy preference — Options.MaxTargets overrides it.
+const defaultMaxTargets = 8
+
+// FeedFactory starts the collectors for one pid and returns the running feed
+// plus the stack resolver built over it. The caller of RunOnDemand supplies it:
+// WHAT to collect (eBPF or /proc, TLS capture, …) is CLI policy, not the
+// server's business. The feed must be stopped by whoever owns it — the registry
+// does that when the target's last subscriber leaves.
+type FeedFactory func(ctx context.Context, pid int) (*collector.Feed, StackResolver, error)
+
+// A server serves either ONE target fixed at startup or targets its subscribers
+// name (#72). Both go through a registry: the service asks for the hub of the
+// pid in the request and hands back a release when the stream ends. What
+// differs between the two modes is only whether the target was already running.
+type registry interface {
+	// acquire returns the hub and stack resolver for pid, plus the release to
+	// call when done with them. On an on-demand server this starts the target's
+	// collectors if it is the first caller. Errors are already gRPC statuses.
+	acquire(pid int) (*Hub, StackResolver, func(), error)
+
+	// lookup returns a RUNNING target's resolver without starting anything, so
+	// an out-of-band ResolveStack never spins up eBPF for a process nobody is
+	// streaming (its stack ids died with the tracer anyway). ok is false when
+	// the pid is not being observed or is not this server's target.
+	lookup(pid int) (StackResolver, func(), bool)
+
+	// describe is what the startup log and errors call this server's scope.
+	describe() string
+}
+
+// ─── fixed target ────────────────────────────────────────────────────────────
+
+// fixedRegistry serves the single target given on the command line. It starts
+// nothing and releases nothing: the collectors outlive every subscriber.
+type fixedRegistry struct {
+	target   Target
+	hub      *Hub
+	resolver StackResolver
+}
+
+func noopRelease() {}
+
+func (r *fixedRegistry) check(pid int) error {
+	// 0 means "whatever this server observes" — the pre-#72 request shape, and
+	// the only accepted value in cgroup mode.
+	if pid == 0 || pid == r.target.PID {
+		return nil
+	}
+	return status.Errorf(codes.InvalidArgument,
+		"this server observes %s and cannot serve pid %d", r.target, pid)
+}
+
+func (r *fixedRegistry) acquire(pid int) (*Hub, StackResolver, func(), error) {
+	if err := r.check(pid); err != nil {
+		return nil, nil, nil, err
+	}
+	return r.hub, r.resolver, noopRelease, nil
+}
+
+func (r *fixedRegistry) lookup(pid int) (StackResolver, func(), bool) {
+	if err := r.check(pid); err != nil {
+		return nil, nil, false
+	}
+	return r.resolver, noopRelease, true
+}
+
+func (r *fixedRegistry) describe() string { return r.target.String() }
+
+// ─── targets on demand ───────────────────────────────────────────────────────
+
+// liveTarget is one observed process: its collectors, the hub fanning them out
+// and how many subscribers are holding it open.
+type liveTarget struct {
+	hub      *Hub
+	resolver StackResolver
+	feed     *collector.Feed
+	cancel   context.CancelFunc
+	refs     int
+}
+
+// onDemandRegistry starts a target's collectors for its first subscriber and
+// stops them when the last one disconnects (#72).
+//
+// One mutex covers the whole map, and it is held across collector startup and
+// teardown. That serializes a subscribe for pid B behind one for pid A (an eBPF
+// load is on the order of a hundred milliseconds), which is the price of the
+// property that matters here: a teardown can never interleave with a subscribe
+// for the same pid, so nobody is ever handed a hub whose collectors are being
+// stopped underneath them.
+type onDemandRegistry struct {
+	ctx     context.Context // server lifetime; each target's ctx derives from it
+	factory FeedFactory
+	max     int
+
+	mu      sync.Mutex
+	targets map[int]*liveTarget
+}
+
+func newOnDemandRegistry(ctx context.Context, factory FeedFactory, max int) *onDemandRegistry {
+	if max <= 0 {
+		max = defaultMaxTargets
+	}
+	return &onDemandRegistry{
+		ctx:     ctx,
+		factory: factory,
+		max:     max,
+		targets: make(map[int]*liveTarget),
+	}
+}
+
+func (r *onDemandRegistry) acquire(pid int) (*Hub, StackResolver, func(), error) {
+	if pid <= 0 {
+		return nil, nil, nil, status.Error(codes.InvalidArgument,
+			"this server has no fixed target: name the pid to observe in SubscribeRequest.pid")
+	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if t := r.targets[pid]; t != nil {
+		t.refs++
+		return t.hub, t.resolver, r.releaseFunc(pid), nil
+	}
+	if len(r.targets) >= r.max {
+		return nil, nil, nil, status.Errorf(codes.ResourceExhausted,
+			"already observing %d processes (limit %d): disconnect a subscriber or raise --serve-max-targets",
+			len(r.targets), r.max)
+	}
+	// Check before loading anything: a typo'd pid should fail as a clear
+	// NotFound, not as a set of collectors that quietly observe nothing.
+	if err := processExists(pid); err != nil {
+		return nil, nil, nil, status.Errorf(codes.NotFound, "%v", err)
+	}
+
+	ctx, cancel := context.WithCancel(r.ctx)
+	feed, resolver, err := r.factory(ctx, pid)
+	if err != nil {
+		cancel()
+		return nil, nil, nil, status.Errorf(codes.Internal, "start collectors for pid %d: %v", pid, err)
+	}
+
+	buildID := ""
+	if resolver != nil {
+		buildID = resolver.ProcessBuildID()
+	}
+	hub := NewHub(TargetPID(pid), buildID)
+	hub.Start(ctx, feed.Bus)
+
+	t := &liveTarget{hub: hub, resolver: resolver, feed: feed, cancel: cancel, refs: 1}
+	r.targets[pid] = t
+	fmt.Fprintf(os.Stderr, "[ptop] observing pid %d (%d target(s) live)\n", pid, len(r.targets))
+	return hub, resolver, r.releaseFunc(pid), nil
+}
+
+func (r *onDemandRegistry) lookup(pid int) (StackResolver, func(), bool) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	t := r.targets[pid]
+	if t == nil {
+		return nil, nil, false
+	}
+	t.refs++
+	return t.resolver, r.releaseFunc(pid), true
+}
+
+// releaseFunc returns a release that runs at most once, so a double defer
+// cannot drop a reference twice and tear a target down under its subscribers.
+func (r *onDemandRegistry) releaseFunc(pid int) func() {
+	var once sync.Once
+	return func() { once.Do(func() { r.release(pid) }) }
+}
+
+func (r *onDemandRegistry) release(pid int) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	t := r.targets[pid]
+	if t == nil {
+		return
+	}
+	t.refs--
+	if t.refs > 0 {
+		return
+	}
+	delete(r.targets, pid)
+	t.cancel()    // detaches the hub and ends the bus drain goroutines
+	t.feed.Stop() // releases the eBPF tracers — nothing lingers for a pid nobody watches
+	fmt.Fprintf(os.Stderr, "[ptop] released pid %d (%d target(s) live)\n", pid, len(r.targets))
+}
+
+func (r *onDemandRegistry) describe() string {
+	return fmt.Sprintf("targets chosen by subscribers (max %d)", r.max)
+}
+
+// liveCount is how many targets are running. Tests assert teardown with it.
+func (r *onDemandRegistry) liveCount() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return len(r.targets)
+}
+
+// processExists reports whether the pid can be observed at all. kill(pid, 0)
+// delivers no signal, it only performs the existence/permission check — the
+// same probe the TUI path uses before starting. EPERM means it exists but
+// belongs to another user: the collectors degrade rather than fail, so it is
+// allowed through here.
+func processExists(pid int) error {
+	err := syscall.Kill(pid, 0)
+	switch {
+	case err == nil, errors.Is(err, syscall.EPERM):
+		return nil
+	case errors.Is(err, syscall.ESRCH):
+		return fmt.Errorf("process %d does not exist", pid)
+	default:
+		return fmt.Errorf("cannot check process %d: %w", pid, err)
+	}
+}

--- a/internal/serve/registry_test.go
+++ b/internal/serve/registry_test.go
@@ -1,0 +1,241 @@
+package serve
+
+import (
+	"context"
+	"os"
+	"sync"
+	"testing"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/trentas/ptop/pkg/collector"
+)
+
+// testFactory hands out a feed over a fake collector per pid, records how many
+// times it was asked to start one, and keeps each target's context so a test
+// can prove the teardown actually cancelled it.
+type testFactory struct {
+	mu    sync.Mutex
+	calls map[int]int
+	ctxs  map[int]context.Context
+	feeds map[int]*fakeCollector
+	err   error
+}
+
+func newTestFactory() *testFactory {
+	return &testFactory{
+		calls: map[int]int{},
+		ctxs:  map[int]context.Context{},
+		feeds: map[int]*fakeCollector{},
+	}
+}
+
+func (f *testFactory) make(ctx context.Context, pid int) (*collector.Feed, StackResolver, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.err != nil {
+		return nil, nil, f.err
+	}
+	f.calls[pid]++
+	f.ctxs[pid] = ctx
+	c := newFake(8)
+	f.feeds[pid] = c
+	feed := &collector.Feed{
+		Set: collector.NewSet(collector.SetConfig{}),
+		Bus: collector.StartBus(ctx, []collector.Collector{c}),
+	}
+	return feed, nil, nil
+}
+
+func (f *testFactory) callsFor(pid int) int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.calls[pid]
+}
+
+func (f *testFactory) ctxFor(pid int) context.Context {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.ctxs[pid]
+}
+
+func statusCode(t *testing.T, err error) codes.Code {
+	t.Helper()
+	st, ok := status.FromError(err)
+	if !ok {
+		t.Fatalf("error is not a gRPC status: %v", err)
+	}
+	return st.Code()
+}
+
+// Collectors start once for a target however many subscribers it has, and are
+// released only when the last one lets go.
+func TestOnDemandRefcount(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	f := newTestFactory()
+	reg := newOnDemandRegistry(ctx, f.make, 4)
+	pid := os.Getpid()
+
+	hub1, _, release1, err := reg.acquire(pid)
+	if err != nil {
+		t.Fatalf("first acquire: %v", err)
+	}
+	hub2, _, release2, err := reg.acquire(pid)
+	if err != nil {
+		t.Fatalf("second acquire: %v", err)
+	}
+	if hub1 != hub2 {
+		t.Error("two subscribers of one pid got different hubs — they'd be reading different collectors")
+	}
+	if n := f.callsFor(pid); n != 1 {
+		t.Errorf("factory called %d times for one target, want 1", n)
+	}
+
+	release1()
+	if reg.liveCount() != 1 {
+		t.Fatal("target torn down while a subscriber still holds it")
+	}
+	release1() // idempotent: a double release must not drop someone else's ref
+	if reg.liveCount() != 1 {
+		t.Fatal("a repeated release dropped a live reference")
+	}
+
+	targetCtx := f.ctxFor(pid)
+	release2()
+	if reg.liveCount() != 0 {
+		t.Error("target still live after its last subscriber left")
+	}
+	if targetCtx.Err() == nil {
+		t.Error("target context not cancelled on teardown — the hub is still attached to the bus")
+	}
+
+	// A later subscriber gets a fresh target, not the corpse of the old one.
+	if _, _, release, err := reg.acquire(pid); err != nil {
+		t.Fatalf("re-acquire: %v", err)
+	} else {
+		defer release()
+	}
+	if n := f.callsFor(pid); n != 2 {
+		t.Errorf("factory called %d times after teardown+re-acquire, want 2", n)
+	}
+}
+
+func TestOnDemandRejections(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	f := newTestFactory()
+	reg := newOnDemandRegistry(ctx, f.make, 1) // cap of one target
+
+	// No pid at all: this server has no target of its own to fall back on.
+	if _, _, _, err := reg.acquire(0); statusCode(t, err) != codes.InvalidArgument {
+		t.Errorf("acquire(0) = %v, want InvalidArgument", err)
+	}
+
+	// A pid that does not exist fails before any collector is loaded.
+	const gonePID = 0x7FFFFFF0
+	if _, _, _, err := reg.acquire(gonePID); statusCode(t, err) != codes.NotFound {
+		t.Errorf("acquire(nonexistent) = %v, want NotFound", err)
+	}
+	if f.callsFor(gonePID) != 0 {
+		t.Error("collectors were started for a pid that does not exist")
+	}
+
+	// The cap is enforced, and says how to raise it.
+	_, _, release, err := reg.acquire(os.Getpid())
+	if err != nil {
+		t.Fatalf("acquire: %v", err)
+	}
+	defer release()
+
+	_, _, _, err = reg.acquire(os.Getppid())
+	if statusCode(t, err) != codes.ResourceExhausted {
+		t.Fatalf("acquire beyond the cap = %v, want ResourceExhausted", err)
+	}
+	if got := status.Convert(err).Message(); got == "" {
+		t.Error("cap error has no message")
+	}
+	if reg.liveCount() != 1 {
+		t.Errorf("liveCount = %d after a refused acquire, want 1", reg.liveCount())
+	}
+}
+
+// A factory that fails must not leave a half-registered target behind.
+func TestOnDemandFactoryFailure(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	f := newTestFactory()
+	f.err = context.DeadlineExceeded
+	reg := newOnDemandRegistry(ctx, f.make, 4)
+
+	if _, _, _, err := reg.acquire(os.Getpid()); statusCode(t, err) != codes.Internal {
+		t.Errorf("acquire with a failing factory = %v, want Internal", err)
+	}
+	if reg.liveCount() != 0 {
+		t.Errorf("liveCount = %d after a failed start, want 0", reg.liveCount())
+	}
+}
+
+// ResolveStack must never start collectors: an id from a target nobody is
+// streaming refers to a stack map that is already gone.
+func TestOnDemandLookupNeverStarts(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	f := newTestFactory()
+	reg := newOnDemandRegistry(ctx, f.make, 4)
+	pid := os.Getpid()
+
+	if _, _, ok := reg.lookup(pid); ok {
+		t.Error("lookup found a target nobody is observing")
+	}
+	if f.callsFor(pid) != 0 {
+		t.Error("lookup started collectors")
+	}
+
+	_, _, release, err := reg.acquire(pid)
+	if err != nil {
+		t.Fatalf("acquire: %v", err)
+	}
+	if _, releaseLookup, ok := reg.lookup(pid); !ok {
+		t.Error("lookup missed a running target")
+	} else {
+		releaseLookup()
+	}
+	release()
+	if reg.liveCount() != 0 {
+		t.Error("a lookup's reference outlived its release")
+	}
+}
+
+// The fixed-target server answers for its own pid (or 0, the pre-#72 request
+// shape) and refuses to pretend it can serve another process.
+func TestFixedRegistryChecksPID(t *testing.T) {
+	reg := &fixedRegistry{target: TargetPID(42), hub: NewHub(TargetPID(42), "")}
+
+	for _, pid := range []int{0, 42} {
+		if _, _, _, err := reg.acquire(pid); err != nil {
+			t.Errorf("acquire(%d) = %v, want accepted", pid, err)
+		}
+	}
+	_, _, _, err := reg.acquire(7)
+	if statusCode(t, err) != codes.InvalidArgument {
+		t.Errorf("acquire(7) = %v, want InvalidArgument", err)
+	}
+	if _, _, ok := reg.lookup(7); ok {
+		t.Error("lookup(7) succeeded on a server observing pid 42")
+	}
+
+	// Cgroup mode has no pid to name, so only 0 is meaningful.
+	cg := &fixedRegistry{target: TargetCgroup("/x.scope", 99), hub: NewHub(TargetCgroup("/x.scope", 99), "")}
+	if _, _, _, err := cg.acquire(0); err != nil {
+		t.Errorf("cgroup acquire(0) = %v, want accepted", err)
+	}
+	if _, _, _, err := cg.acquire(42); statusCode(t, err) != codes.InvalidArgument {
+		t.Errorf("cgroup acquire(42) = %v, want InvalidArgument", err)
+	}
+}

--- a/internal/serve/serve.go
+++ b/internal/serve/serve.go
@@ -7,6 +7,7 @@ package serve
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net"
 	"os"
@@ -63,6 +64,12 @@ type Options struct {
 	// takes no TLS at all. See serverCredentials for the full policy.
 	TLS TLSOptions
 
+	// MaxTargets caps how many processes a RunOnDemand server observes at once
+	// (#72); 0 uses defaultMaxTargets. Each target carries its own eBPF programs
+	// and perf events, so this is a resource ceiling. Ignored with a fixed
+	// target — there is only ever one.
+	MaxTargets int
+
 	// Ready, if set, is closed once the endpoint is bound and the server is
 	// about to serve. It exists so a caller that runs Run in a goroutine can
 	// tell "up" from "failed at startup" without racing a timer — everything
@@ -98,34 +105,77 @@ func Run(ctx context.Context, addr string, target Target, bus *collector.Bus, re
 	}
 	defer cleanup()
 
-	return runServer(ctx, lis, creds, mode, target, bus, resolver, opts)
+	reg := fixedTargetRegistry(ctx, target, bus, resolver)
+	return runServer(ctx, lis, creds, mode, reg, reg.hub, opts)
 }
 
-// runServer owns everything after the listener exists: the hub, the sinks, the
-// gRPC server and the shutdown. Split out of Run so tests can drive a real
-// server on an ephemeral tcp port (listen() picks it, only lis knows it).
-func runServer(ctx context.Context, lis net.Listener, creds credentials.TransportCredentials, mode string, target Target, bus *collector.Bus, resolver StackResolver, opts Options) error {
-	var buildID string
+// RunOnDemand starts the gRPC server bound to addr with NO target of its own
+// (#72): each subscriber names the pid it wants in SubscribeRequest.pid, and
+// factory starts that process's collectors for its first subscriber. They are
+// released when its last subscriber disconnects, so nothing keeps eBPF loaded
+// for a process nobody is watching. opts.MaxTargets caps how many run at once.
+//
+// Everything else matches Run: the same transport-security policy, the same
+// event stream, the same handshake — a subscriber cannot tell how the server
+// was started except by what TargetInfo says.
+func RunOnDemand(ctx context.Context, addr string, factory FeedFactory, opts Options) error {
+	if factory == nil {
+		return errors.New("serve: RunOnDemand needs a FeedFactory")
+	}
+	// An event-level export has one TargetInfo header and one file; with targets
+	// coming and going there is no single scope it could honestly claim. Refuse
+	// before binding, like every other startup misconfiguration.
+	if opts.JSONLPath != "" {
+		return errors.New("serve: --export needs a fixed target (--pid), not one chosen per subscriber")
+	}
+
+	creds, mode, err := serverCredentials(addr, opts.TLS)
+	if err != nil {
+		return err
+	}
+
+	lis, cleanup, err := listen(addr)
+	if err != nil {
+		return err
+	}
+	defer cleanup()
+
+	return runServer(ctx, lis, creds, mode, newOnDemandRegistry(ctx, factory, opts.MaxTargets), nil, opts)
+}
+
+// fixedTargetRegistry starts the hub for a server whose target was named on the
+// command line, and wraps it in the registry the service talks to.
+func fixedTargetRegistry(ctx context.Context, target Target, bus *collector.Bus, resolver StackResolver) *fixedRegistry {
+	buildID := ""
 	if resolver != nil {
 		buildID = resolver.ProcessBuildID()
 	}
 	hub := NewHub(target, buildID)
 	hub.Start(ctx, bus)
+	return &fixedRegistry{target: target, hub: hub, resolver: resolver}
+}
 
+// runServer owns everything after the listener exists: the sinks, the gRPC
+// server and the shutdown. Split out of Run so tests can drive a real server on
+// an ephemeral tcp port (listen() picks it, only lis knows it).
+// reg maps a request's pid to the target serving it; sinkHub is the one hub a
+// JSONL export can attach to, and is nil when targets are chosen per subscriber
+// (there is no single stream to write).
+func runServer(ctx context.Context, lis net.Listener, creds credentials.TransportCredentials, mode string, reg registry, sinkHub *Hub, opts Options) error {
 	// Optional JSONL sink: a non-gRPC consumer of the same event stream.
-	if opts.JSONLPath != "" {
-		js, err := newJSONLSink(opts.JSONLPath, hub.targetInfo())
+	if opts.JSONLPath != "" && sinkHub != nil {
+		js, err := newJSONLSink(opts.JSONLPath, sinkHub.targetInfo())
 		if err != nil {
 			return fmt.Errorf("serve: jsonl export: %w", err)
 		}
-		hub.AddSink(js)
+		sinkHub.AddSink(js)
 		// RemoveSink before Close so no Emit races the channel close.
-		defer func() { hub.RemoveSink(js); _ = js.Close() }()
+		defer func() { sinkHub.RemoveSink(js); _ = js.Close() }()
 		fmt.Fprintf(os.Stderr, "[ptop] also exporting events to %s\n", opts.JSONLPath)
 	}
 
 	srv := grpc.NewServer(grpc.Creds(creds))
-	pb.RegisterEventStreamServiceServer(srv, &eventStreamService{hub: hub, resolver: resolver})
+	pb.RegisterEventStreamServiceServer(srv, &eventStreamService{reg: reg})
 
 	// On cancel, Stop() (not GracefulStop): Subscribe streams are long-lived and
 	// only end when the client disconnects, so GracefulStop would block forever.
@@ -140,7 +190,7 @@ func runServer(ctx context.Context, lis net.Listener, creds credentials.Transpor
 		fmt.Fprintln(os.Stderr, "       unauthenticated. Anyone who reaches the port reads process internals.")
 	}
 	fmt.Fprintf(os.Stderr, "[ptop] serving events for %s on %s://%s (%s)\n",
-		target, lis.Addr().Network(), lis.Addr().String(), mode)
+		reg.describe(), lis.Addr().Network(), lis.Addr().String(), mode)
 	if opts.Ready != nil {
 		close(opts.Ready)
 	}

--- a/internal/serve/serve_test.go
+++ b/internal/serve/serve_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials/insecure"
 
 	"github.com/trentas/ptop/pkg/collector"
@@ -284,4 +285,145 @@ func waitFor(t *testing.T, cond func() bool) {
 		time.Sleep(10 * time.Millisecond)
 	}
 	t.Fatal("condition not met within deadline")
+}
+
+// #72 end to end: one server, no target of its own, two subscribers on two
+// different pids. Each gets its own handshake and its own events — the whole
+// point being that neither one's collectors are the other's.
+func TestServeOnDemandTwoTargets(t *testing.T) {
+	sock := shortSock(t)
+	addr := "unix://" + sock
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	f := newTestFactory()
+	runErr := make(chan error, 1)
+	go func() { runErr <- RunOnDemand(ctx, addr, f.make, Options{}) }()
+	waitFor(t, func() bool { _, err := os.Stat(sock); return err == nil })
+
+	conn, err := grpc.NewClient(addr, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer conn.Close()
+	client := pb.NewEventStreamServiceClient(conn)
+
+	// Two live processes to observe: this test binary and its parent.
+	pidA, pidB := os.Getpid(), os.Getppid()
+	if pidA == pidB {
+		t.Skip("need two distinct live pids")
+	}
+
+	// A's stream gets its own context so the test can hang up on it alone.
+	ctxA, hangUpA := context.WithCancel(ctx)
+	defer hangUpA()
+	streamA, err := client.Subscribe(ctxA, &pb.SubscribeRequest{Pid: int32(pidA)})
+	if err != nil {
+		t.Fatalf("subscribe A: %v", err)
+	}
+	streamB, err := client.Subscribe(ctx, &pb.SubscribeRequest{Pid: int32(pidB)})
+	if err != nil {
+		t.Fatalf("subscribe B: %v", err)
+	}
+
+	// The handshake tells each subscriber which process it is watching.
+	for _, tc := range []struct {
+		name   string
+		stream pb.EventStreamService_SubscribeClient
+		pid    int
+	}{{"A", streamA, pidA}, {"B", streamB, pidB}} {
+		resp, err := tc.stream.Recv()
+		if err != nil {
+			t.Fatalf("%s handshake: %v", tc.name, err)
+		}
+		target := resp.GetMeta().GetTarget()
+		if target.GetMode() != pb.TargetMode_TARGET_MODE_PID || target.GetPid() != int32(tc.pid) {
+			t.Fatalf("%s handshake target = %v, want pid %d", tc.name, target, tc.pid)
+		}
+	}
+
+	// Each target's collectors feed only its own subscriber.
+	waitFor(t, func() bool { return f.callsFor(pidA) == 1 && f.callsFor(pidB) == 1 })
+	f.mu.Lock()
+	chA, chB := f.feeds[pidA].ch, f.feeds[pidB].ch
+	f.mu.Unlock()
+	chA <- collector.CpuSample{UsagePct: 11, Timestamp: time.Now()}
+	chB <- collector.CpuSample{UsagePct: 22, Timestamp: time.Now()}
+
+	for _, tc := range []struct {
+		name   string
+		stream pb.EventStreamService_SubscribeClient
+		pid    int
+		usage  float64
+	}{{"A", streamA, pidA, 11}, {"B", streamB, pidB, 22}} {
+		resp, err := tc.stream.Recv()
+		if err != nil {
+			t.Fatalf("%s event: %v", tc.name, err)
+		}
+		ev := resp.GetEvent()
+		if ev.GetPid() != int32(tc.pid) || ev.GetCpu().GetUsagePct() != tc.usage {
+			t.Errorf("%s got pid=%d usage=%v, want pid=%d usage=%v",
+				tc.name, ev.GetPid(), ev.GetCpu().GetUsagePct(), tc.pid, tc.usage)
+		}
+	}
+
+	// Hanging up on A releases A's collectors — its context is cancelled — and
+	// leaves B's alone. Nothing keeps eBPF loaded for a process nobody watches.
+	hangUpA()
+	waitFor(t, func() bool { return f.ctxFor(pidA).Err() != nil })
+	if err := f.ctxFor(pidB).Err(); err != nil {
+		t.Errorf("B's target was torn down when A disconnected: %v", err)
+	}
+
+	cancel()
+	<-runErr
+}
+
+// An on-demand subscriber that names no pid is told what to do, rather than
+// being served some arbitrary process.
+func TestServeOnDemandRequiresAPID(t *testing.T) {
+	sock := shortSock(t)
+	addr := "unix://" + sock
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	f := newTestFactory()
+	runErr := make(chan error, 1)
+	go func() { runErr <- RunOnDemand(ctx, addr, f.make, Options{}) }()
+	waitFor(t, func() bool { _, err := os.Stat(sock); return err == nil })
+
+	conn, err := grpc.NewClient(addr, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer conn.Close()
+
+	stream, err := pb.NewEventStreamServiceClient(conn).Subscribe(ctx, &pb.SubscribeRequest{})
+	if err != nil {
+		t.Fatalf("subscribe: %v", err)
+	}
+	if _, err := stream.Recv(); statusCode(t, err) != codes.InvalidArgument {
+		t.Errorf("recv = %v, want InvalidArgument", err)
+	}
+
+	cancel()
+	<-runErr
+}
+
+// An event export names one target in its header, so it cannot describe a
+// server whose targets come and go. Refused at startup, before binding.
+func TestServeOnDemandRefusesExport(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	sock := shortSock(t)
+	err := RunOnDemand(ctx, "unix://"+sock, newTestFactory().make, Options{JSONLPath: filepath.Join(t.TempDir(), "e.jsonl")})
+	if err == nil {
+		t.Fatal("RunOnDemand with --export = nil, want an error")
+	}
+	if _, statErr := os.Stat(sock); statErr == nil {
+		t.Error("the endpoint was bound despite the refused configuration")
+	}
 }

--- a/internal/serve/service.go
+++ b/internal/serve/service.go
@@ -21,21 +21,30 @@ type StackResolver interface {
 	ResolveStack(stackID uint64) (frames []symbol.Frame, ok bool)
 }
 
-// eventStreamService implements the generated EventStreamServiceServer over a Hub.
+// eventStreamService implements the generated EventStreamServiceServer. It owns
+// no target of its own: the registry maps the pid in a request to the hub and
+// resolver serving it, whether that target was fixed at startup or is being
+// observed on demand (#72).
 type eventStreamService struct {
 	pb.UnimplementedEventStreamServiceServer
-	hub      *Hub
-	resolver StackResolver // nil when the build has no symbolization
+	reg registry
 }
 
 // ResolveStack symbolizes a stack id seen on the stream into its leaf-first
 // frames (out-of-band so high-rate events stay small). Resolution is
-// best-effort: an unknown id, or no resolver, yields found=false (not an error).
+// best-effort: an unknown id, no resolver, or a pid nobody is observing yields
+// found=false (not an error) — a stack id outlives nothing, so there is no
+// point starting collectors to answer.
 func (svc *eventStreamService) ResolveStack(_ context.Context, req *pb.ResolveStackRequest) (*pb.ResolveStackResponse, error) {
-	if svc.resolver == nil {
+	resolver, release, ok := svc.reg.lookup(int(req.GetPid()))
+	if !ok || resolver == nil {
+		if ok {
+			release()
+		}
 		return &pb.ResolveStackResponse{Found: false}, nil
 	}
-	frames, ok := svc.resolver.ResolveStack(req.GetStackId())
+	defer release()
+	frames, ok := resolver.ResolveStack(req.GetStackId())
 	if !ok {
 		return &pb.ResolveStackResponse{Found: false}, nil
 	}
@@ -48,14 +57,23 @@ func (svc *eventStreamService) ResolveStack(_ context.Context, req *pb.ResolveSt
 // advanced (backpressure), a StreamMeta is sent ahead of the next event so the
 // consumer learns it missed some.
 func (svc *eventStreamService) Subscribe(req *pb.SubscribeRequest, stream pb.EventStreamService_SubscribeServer) error {
-	sub := svc.hub.subscribe(req.GetCategories())
-	defer svc.hub.unsubscribe(sub)
+	// Acquiring the target is what starts its collectors on an on-demand
+	// server, and the release below is what stops them once the last subscriber
+	// is gone (#72).
+	hub, _, release, err := svc.reg.acquire(int(req.GetPid()))
+	if err != nil {
+		return err
+	}
+	defer release()
+
+	sub := hub.subscribe(req.GetCategories())
+	defer hub.unsubscribe(sub)
 
 	// Handshake (#94): the scope of the stream, before anything is streamed. A
 	// consumer needs it to read what follows correctly — notably, cgroup-mode
 	// events carry no single pid.
 	handshake := &pb.SubscribeResponse{
-		Kind: &pb.SubscribeResponse_Meta{Meta: &pb.StreamMeta{Target: svc.hub.targetInfo()}},
+		Kind: &pb.SubscribeResponse_Meta{Meta: &pb.StreamMeta{Target: hub.targetInfo()}},
 	}
 	if err := stream.Send(handshake); err != nil {
 		return err

--- a/internal/serve/service_test.go
+++ b/internal/serve/service_test.go
@@ -30,7 +30,7 @@ func TestResolveStackRPC(t *testing.T) {
 			},
 		},
 	}
-	svc := &eventStreamService{resolver: res}
+	svc := &eventStreamService{reg: &fixedRegistry{target: TargetPID(7), resolver: res}}
 
 	// Known id → found, frames mapped leaf-first 1:1.
 	resp, err := svc.ResolveStack(context.Background(), &pb.ResolveStackRequest{StackId: 42})
@@ -49,6 +49,16 @@ func TestResolveStackRPC(t *testing.T) {
 		t.Errorf("frame[0] = %+v", f0)
 	}
 
+	// A pid this server does not observe → found=false, never another
+	// process's stack (#72).
+	resp, err = svc.ResolveStack(context.Background(), &pb.ResolveStackRequest{StackId: 42, Pid: 999})
+	if err != nil {
+		t.Fatalf("ResolveStack(other pid): %v", err)
+	}
+	if resp.GetFound() {
+		t.Error("found = true for a pid this server does not observe")
+	}
+
 	// Unknown id → found=false, no error.
 	resp, err = svc.ResolveStack(context.Background(), &pb.ResolveStackRequest{StackId: 99})
 	if err != nil {
@@ -61,7 +71,7 @@ func TestResolveStackRPC(t *testing.T) {
 
 func TestResolveStackRPCNilResolver(t *testing.T) {
 	// A build without symbolization (nil resolver) never errors — just not-found.
-	svc := &eventStreamService{}
+	svc := &eventStreamService{reg: &fixedRegistry{target: TargetPID(7)}}
 	resp, err := svc.ResolveStack(context.Background(), &pb.ResolveStackRequest{StackId: 1})
 	if err != nil {
 		t.Fatalf("ResolveStack: %v", err)

--- a/internal/serve/target_test.go
+++ b/internal/serve/target_test.go
@@ -25,7 +25,9 @@ func handshakeFor(t *testing.T, target Target) *pb.TargetInfo {
 
 	f := newFake(4)
 	runErr := make(chan error, 1)
-	go func() { runErr <- Run(ctx, addr, target, collector.StartBus(ctx, []collector.Collector{f}), nil, Options{}) }()
+	go func() {
+		runErr <- Run(ctx, addr, target, collector.StartBus(ctx, []collector.Collector{f}), nil, Options{})
+	}()
 	waitFor(t, func() bool { _, err := os.Stat(sock); return err == nil })
 
 	conn, err := grpc.NewClient(addr, grpc.WithTransportCredentials(insecure.NewCredentials()))

--- a/internal/serve/tls_test.go
+++ b/internal/serve/tls_test.go
@@ -213,7 +213,8 @@ func startTCPServer(ctx context.Context, t *testing.T, opts TLSOptions) string {
 	target := lis.Addr().String()
 	done := make(chan error, 1)
 	go func() {
-		done <- runServer(ctx, lis, creds, "test", TargetPID(4242), collector.StartBus(ctx, []collector.Collector{f}), nil, Options{})
+		reg := fixedTargetRegistry(ctx, TargetPID(4242), collector.StartBus(ctx, []collector.Collector{f}), nil)
+		done <- runServer(ctx, lis, creds, "test", reg, reg.hub, Options{})
 	}()
 	t.Cleanup(func() {
 		select {

--- a/pkg/streampb/service.pb.go
+++ b/pkg/streampb/service.pb.go
@@ -75,12 +75,19 @@ func (TargetMode) EnumDescriptor() ([]byte, []int) {
 }
 
 // SubscribeRequest opens a stream. categories filters which Event categories
-// the server sends; empty means all. The target is fixed per server instance
-// (set via `ptop --serve --pid` or `--cgroup`), so it is not part of the
-// request — see TargetInfo, which the server reports on the stream.
+// the server sends; empty means all.
+//
+// pid names the process to observe (#72). It is required when the server was
+// started without a target (`ptop --serve` with no `--pid`/`--cgroup`), which
+// serves targets on demand: the collectors for a pid start with its first
+// subscriber and stop with its last. When the server WAS started with a fixed
+// target, pid must be 0 or that exact pid — anything else is rejected rather
+// than silently served the wrong process. Either way the server reports what it
+// is actually observing in the TargetInfo handshake.
 type SubscribeRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Categories    []Category             `protobuf:"varint,1,rep,packed,name=categories,proto3,enum=ptop.v1.Category" json:"categories,omitempty"`
+	Pid           int32                  `protobuf:"varint,2,opt,name=pid,proto3" json:"pid,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -120,6 +127,13 @@ func (x *SubscribeRequest) GetCategories() []Category {
 		return x.Categories
 	}
 	return nil
+}
+
+func (x *SubscribeRequest) GetPid() int32 {
+	if x != nil {
+		return x.Pid
+	}
+	return 0
 }
 
 // TargetInfo describes the SCOPE of everything on this stream. The server sends
@@ -349,8 +363,13 @@ func (*SubscribeResponse_Meta) isSubscribeResponse_Kind() {}
 // StackRef.build_id, and is namespaced per capturing tracer — pass back exactly
 // the value the event carried, never a bare kernel id.
 type ResolveStackRequest struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	StackId       uint64                 `protobuf:"varint,1,opt,name=stack_id,json=stackId,proto3" json:"stack_id,omitempty"`
+	state   protoimpl.MessageState `protogen:"open.v1"`
+	StackId uint64                 `protobuf:"varint,1,opt,name=stack_id,json=stackId,proto3" json:"stack_id,omitempty"`
+	// The process the stack was captured in (#72). Kernel stack maps are
+	// per-target, so the same id means different stacks in different processes:
+	// required on an on-demand server, and on a fixed-target server it must be 0
+	// or the server's own pid.
+	Pid           int32 `protobuf:"varint,2,opt,name=pid,proto3" json:"pid,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -388,6 +407,13 @@ func (*ResolveStackRequest) Descriptor() ([]byte, []int) {
 func (x *ResolveStackRequest) GetStackId() uint64 {
 	if x != nil {
 		return x.StackId
+	}
+	return 0
+}
+
+func (x *ResolveStackRequest) GetPid() int32 {
+	if x != nil {
+		return x.Pid
 	}
 	return 0
 }
@@ -451,11 +477,12 @@ var File_service_proto protoreflect.FileDescriptor
 
 const file_service_proto_rawDesc = "" +
 	"\n" +
-	"\rservice.proto\x12\aptop.v1\x1a\vevent.proto\"E\n" +
+	"\rservice.proto\x12\aptop.v1\x1a\vevent.proto\"W\n" +
 	"\x10SubscribeRequest\x121\n" +
 	"\n" +
 	"categories\x18\x01 \x03(\x0e2\x11.ptop.v1.CategoryR\n" +
-	"categories\"\x85\x01\n" +
+	"categories\x12\x10\n" +
+	"\x03pid\x18\x02 \x01(\x05R\x03pid\"\x85\x01\n" +
 	"\n" +
 	"TargetInfo\x12'\n" +
 	"\x04mode\x18\x01 \x01(\x0e2\x13.ptop.v1.TargetModeR\x04mode\x12\x10\n" +
@@ -470,9 +497,10 @@ const file_service_proto_rawDesc = "" +
 	"\x11SubscribeResponse\x12&\n" +
 	"\x05event\x18\x01 \x01(\v2\x0e.ptop.v1.EventH\x00R\x05event\x12)\n" +
 	"\x04meta\x18\x02 \x01(\v2\x13.ptop.v1.StreamMetaH\x00R\x04metaB\x06\n" +
-	"\x04kind\"0\n" +
+	"\x04kind\"B\n" +
 	"\x13ResolveStackRequest\x12\x19\n" +
-	"\bstack_id\x18\x01 \x01(\x04R\astackId\"Y\n" +
+	"\bstack_id\x18\x01 \x01(\x04R\astackId\x12\x10\n" +
+	"\x03pid\x18\x02 \x01(\x05R\x03pid\"Y\n" +
 	"\x14ResolveStackResponse\x12+\n" +
 	"\x06frames\x18\x01 \x03(\v2\x13.ptop.v1.StackFrameR\x06frames\x12\x14\n" +
 	"\x05found\x18\x02 \x01(\bR\x05found*V\n" +

--- a/pkg/streampb/service_grpc.pb.go
+++ b/pkg/streampb/service_grpc.pb.go
@@ -30,10 +30,12 @@ const (
 // EventStreamService is ptop's headless collection surface. ptop runs with the
 // elevated capabilities (CAP_BPF/CAP_PERFMON); subscribers connect with none.
 type EventStreamServiceClient interface {
-	// Subscribe streams collector events for the server's target until the client
-	// disconnects. The first response is always a StreamMeta carrying TargetInfo,
-	// so a consumer knows the scope of what follows. Multiple subscribers fan out
-	// from one collector.
+	// Subscribe streams collector events for the requested target until the
+	// client disconnects. The first response is always a StreamMeta carrying
+	// TargetInfo, so a consumer knows the scope of what follows. Multiple
+	// subscribers of one target fan out from a single set of collectors; an
+	// on-demand server starts a target's collectors for its first subscriber and
+	// releases them when the last one disconnects.
 	Subscribe(ctx context.Context, in *SubscribeRequest, opts ...grpc.CallOption) (grpc.ServerStreamingClient[SubscribeResponse], error)
 	// ResolveStack symbolizes a stack id seen on the stream into its leaf-first
 	// frames — an out-of-band lookup so high-rate events stay small (they carry
@@ -85,10 +87,12 @@ func (c *eventStreamServiceClient) ResolveStack(ctx context.Context, in *Resolve
 // EventStreamService is ptop's headless collection surface. ptop runs with the
 // elevated capabilities (CAP_BPF/CAP_PERFMON); subscribers connect with none.
 type EventStreamServiceServer interface {
-	// Subscribe streams collector events for the server's target until the client
-	// disconnects. The first response is always a StreamMeta carrying TargetInfo,
-	// so a consumer knows the scope of what follows. Multiple subscribers fan out
-	// from one collector.
+	// Subscribe streams collector events for the requested target until the
+	// client disconnects. The first response is always a StreamMeta carrying
+	// TargetInfo, so a consumer knows the scope of what follows. Multiple
+	// subscribers of one target fan out from a single set of collectors; an
+	// on-demand server starts a target's collectors for its first subscriber and
+	// releases them when the last one disconnects.
 	Subscribe(*SubscribeRequest, grpc.ServerStreamingServer[SubscribeResponse]) error
 	// ResolveStack symbolizes a stack id seen on the stream into its leaf-first
 	// frames — an out-of-band lookup so high-rate events stay small (they carry

--- a/proto/service.proto
+++ b/proto/service.proto
@@ -7,11 +7,18 @@ import "event.proto";
 option go_package = "github.com/trentas/ptop/pkg/streampb;streampb";
 
 // SubscribeRequest opens a stream. categories filters which Event categories
-// the server sends; empty means all. The target is fixed per server instance
-// (set via `ptop --serve --pid` or `--cgroup`), so it is not part of the
-// request — see TargetInfo, which the server reports on the stream.
+// the server sends; empty means all.
+//
+// pid names the process to observe (#72). It is required when the server was
+// started without a target (`ptop --serve` with no `--pid`/`--cgroup`), which
+// serves targets on demand: the collectors for a pid start with its first
+// subscriber and stop with its last. When the server WAS started with a fixed
+// target, pid must be 0 or that exact pid — anything else is rejected rather
+// than silently served the wrong process. Either way the server reports what it
+// is actually observing in the TargetInfo handshake.
 message SubscribeRequest {
   repeated Category categories = 1;
+  int32 pid = 2;
 }
 
 // TargetMode is how the server was told what to observe (#94).
@@ -69,6 +76,11 @@ message SubscribeResponse {
 // the value the event carried, never a bare kernel id.
 message ResolveStackRequest {
   uint64 stack_id = 1;
+  // The process the stack was captured in (#72). Kernel stack maps are
+  // per-target, so the same id means different stacks in different processes:
+  // required on an on-demand server, and on a fixed-target server it must be 0
+  // or the server's own pid.
+  int32 pid = 2;
 }
 
 // ResolveStackResponse returns the leaf-first symbolized frames for the stack
@@ -82,10 +94,12 @@ message ResolveStackResponse {
 // EventStreamService is ptop's headless collection surface. ptop runs with the
 // elevated capabilities (CAP_BPF/CAP_PERFMON); subscribers connect with none.
 service EventStreamService {
-  // Subscribe streams collector events for the server's target until the client
-  // disconnects. The first response is always a StreamMeta carrying TargetInfo,
-  // so a consumer knows the scope of what follows. Multiple subscribers fan out
-  // from one collector.
+  // Subscribe streams collector events for the requested target until the
+  // client disconnects. The first response is always a StreamMeta carrying
+  // TargetInfo, so a consumer knows the scope of what follows. Multiple
+  // subscribers of one target fan out from a single set of collectors; an
+  // on-demand server starts a target's collectors for its first subscriber and
+  // releases them when the last one disconnects.
   rpc Subscribe(SubscribeRequest) returns (stream SubscribeResponse);
 
   // ResolveStack symbolizes a stack id seen on the stream into its leaf-first


### PR DESCRIPTION
Closes #72.

## The change

`ptop --serve` bound **one target per server instance**: the pid came from the command line and `SubscribeRequest` carried only a category filter. Watching a second process meant a second ptop — its own socket, its own privileges, its own slot in whatever supervises it.

Started with no `--pid` (and no `--cgroup`), the server now has no target of its own:

```bash
sudo ptop --serve unix:///run/ptop.sock                        # subscribers pick
sudo ptop --serve unix:///run/ptop.sock --serve-max-targets 16 # raise the cap (default 8)
```

Each subscriber names its pid in `SubscribeRequest.pid`. That process's collectors start for its **first** subscriber and are released when its **last** one disconnects, so nothing keeps eBPF loaded for a process nobody watches.

`internal/serve/registry.go` holds both shapes behind one interface, so the service never branches on which kind of server it is:

| | starts collectors | releases them | pid in the request |
|---|---|---|---|
| `fixedRegistry` (`--pid`/`--cgroup`) | no — the hub is already running | never | must be `0` or its own pid |
| `onDemandRegistry` (no target) | on first acquire | on last release | required |

One mutex covers the whole map and is held across collector startup. That serializes an eBPF load for pid B behind one for pid A — deliberate: it makes a teardown-vs-subscribe race for the same pid impossible, which is the thing the issue flagged as the risk.

## Three details the shape forces

- **`ResolveStack` takes a pid too.** Kernel stack maps are per-target, so the same id means different stacks in different processes. It goes through `lookup`, not `acquire`: an id for a process nobody is streaming reports `found=false` rather than starting collectors to answer — that stack died with its tracer.
- **A fixed-target server now validates the request pid** instead of ignoring it. `0` (the pre-#72 request shape, so old clients are unaffected) or its own pid are served; anything else is `InvalidArgument`. Being handed another process's events would be worse than an error.
- **`--export` and `--tui` need a fixed target.** An event export names one target in its header; the TUI shows one process. Both are refused at startup, before anything binds.

Proto additions are field adds (`SubscribeRequest.pid`, `ResolveStackRequest.pid`) — `buf breaking` stays green.

## Verification

Unit: refcounting (one factory call for two subscribers, teardown only on the last release, re-acquire starts fresh), the cap, unknown pid → `NotFound` with no collectors started, a failing factory leaving nothing registered, `lookup` never starting anything, and the fixed registry's pid check in both pid and cgroup mode. End-to-end over a real gRPC socket: two subscribers on two pids, per-target handshakes, and hanging up on one releasing only its target. Race detector clean.

**Live on kernel 7.0.0-29** (three `lockload` workloads, cap set to 2):

```
A handshake: mode=TARGET_MODE_PID pid=8 (asked for 8)
B handshake: mode=TARGET_MODE_PID pid=9 (asked for 9)
  A: 12 events, 0 from the wrong pid, categories map[CPU:1 FD:2 IO:4 MEMORY:2 NETWORK:1 SYSCALL:1 THREAD:1]
  B: 12 events, 0 from the wrong pid, categories map[FD:8 IO:2 PROCESS:1 SYSCALL:1]
C refused: rpc error: code = ResourceExhausted desc = already observing 2 processes (limit 2): disconnect a subscriber or raise --serve-max-targets
after A hung up:
  B: 12 events, 0 from the wrong pid, …

[ptop] serving events for targets chosen by subscribers (max 2) on unix:///tmp/p.sock (unix socket, owner-only)
[ptop] observing pid 8 (1 target(s) live)
[ptop] observing pid 9 (2 target(s) live)
[ptop] released pid 8 (1 target(s) live)
[ptop] released pid 9 (0 target(s) live)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)