### PR TITLE
Symbolize what the collector could not: Go allocations, JIT frames, C/C++ lines — and measure what it all costs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all build build-ebpf run gen proto proto-lint clean dev test test-all vet lint install install-bare install-ebpf uninstall ebpf-selftest
+.PHONY: all build build-ebpf run gen proto proto-lint clean dev test test-all vet lint install install-bare install-ebpf uninstall ebpf-selftest bench
 
 .DEFAULT_GOAL := all
 
@@ -90,6 +90,28 @@ CLANG  ?= clang
 
 # `make gen` produces all .o files from programs/. Requires libbpf-dev.
 gen: $(BPF_OBJS)
+
+# ─── benchmark ───────────────────────────────────────────────────────────────
+
+# Measure what ptop costs the process it observes (bench/README.md).
+#
+# eBPF needs privileges, and the answer must come from a real kernel, so this
+# runs in a privileged container rather than mocking anything. Override BENCH_ARGS
+# to change the sweep, e.g.
+#   make bench BENCH_ARGS="-repeats 7 -compute-sweep 64,6400"
+BENCH_IMAGE ?= ubuntu:26.04
+BENCH_DIR   ?= $(CURDIR)/bin/bench
+BENCH_ARGS  ?= -repeats 3
+
+bench: gen
+	@mkdir -p $(BENCH_DIR)
+	CGO_ENABLED=0 $(GO) build -o $(BENCH_DIR)/workload ./bench/workload
+	CGO_ENABLED=0 $(GO) build -o $(BENCH_DIR)/runner   ./bench/runner
+	CGO_ENABLED=0 $(GO) build -tags=ebpf -o $(BENCH_DIR)/ptop ./cmd/ptop
+	docker run --rm --privileged -v $(BENCH_DIR):/b $(BENCH_IMAGE) sh -c '\
+		mount -t debugfs nodev /sys/kernel/debug 2>/dev/null; \
+		mount -t tracefs nodev /sys/kernel/tracing 2>/dev/null; \
+		cd /b && ./runner $(BENCH_ARGS)'
 
 # ─── protobuf codegen ─────────────────────────────────────────────────────────
 

--- a/Makefile
+++ b/Makefile
@@ -61,6 +61,7 @@ BPF_SRCS := \
 	internal/bpf/programs/threads.bpf.c \
 	internal/bpf/programs/memory.bpf.c \
 	internal/bpf/programs/heap.bpf.c \
+	internal/bpf/programs/goalloc.bpf.c \
 	internal/bpf/programs/futex.bpf.c \
 	internal/bpf/programs/signal.bpf.c \
 	internal/bpf/programs/tls.bpf.c \

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ what the live binary renders against a real PID.
 │· gc          ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░    -- ⏳ nanosleep  ││18:06:31.367 I/O  write /var/log/app/api.log 512B     │
 │■ http-pool   ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░    -- ⏳ epoll_wait ││18:06:31.367  FD  openat → fd=15 /tmp/tmpXXXX         │
 └──────────────────────────────────────────────────────────────────────────────────┘└──────────────────────────────────────────────────────┘
- F1-F7 tabs  ·  q quit  ·  p pause  ·  / filter  ·  s snapshot  ·  e export                          eBPF kernel 6.8 · sampling 100Hz · overhead <0.5%
+ F1-F7 tabs  ·  q quit  ·  p pause  ·  / filter  ·  s snapshot  ·  e export                                       eBPF kernel 6.8 · sampling 100Hz
 ```
 
 A live recording (vhs script in [`assets/demo.tape`](assets/demo.tape)) will
@@ -223,10 +223,53 @@ eBPF programs in `internal/bpf/programs/`:
 - `memory.bpf.c` — mmap/brk/page-fault counters
 - `heap.bpf.c` — libc malloc/free uprobes → live-heap + lifetime + leak suspects
 - `goalloc.bpf.c` — `runtime.mallocgc` uprobe → Go allocation sites (rate + volume)
+
+Any subsystem can be switched off with `--disable <name,...>` — see
+[what it costs](#what-it-costs-the-process-it-watches) for why you might.
 - `signal.bpf.c` — `signal:signal_generate` → signals delivered, with sender
 - `proc.bpf.c` — `sched_process_{fork,exec,exit}` → exec-lineage subtree
 - `security.bpf.c` — PROT_EXEC `mmap`/`mprotect` + SELinux AVC denials
 - `tls.bpf.c` — libssl `SSL_write`/`SSL_read` uprobes → plaintext (opt-in `--tls`)
+
+### What it costs the process it watches
+
+Measured, not asserted — the harness, methodology and raw data are in
+[`bench/`](bench/). ptop used to claim `overhead <0.5%` with nothing behind it;
+that claim is gone, and this is what replaced it.
+
+The cost is **not a constant**. ptop's expensive probe fires once per
+allocation, so what it costs depends on how often the target allocates:
+
+| target allocation rate | all probes | without the heap probe | heap probe alone |
+|---|---|---|---|
+| 0 (no allocations) | −4.9% | −4.9% | −4.6% |
+| 11k/s | +14.8% | +0.1% | +15.9% |
+| 114k/s | +109.9% | +0.2% | +98.1% |
+| 1.2M/s | +404.4% | −0.9% | +358.1% |
+| 14.4M/s | +3213.9% | +2.3% | +3159.1% |
+
+Target CPU time per unit of work, median of 3 runs, on a 2-core aarch64 host
+(kernel 7.0). The noise floor there is **±4.9%**, measured from the row that
+allocates nothing — where every cell should read 0% and does not. Nothing
+below that magnitude is resolved, which is why the "without the heap probe"
+column reads as zero rather than as its literal sign.
+
+Two things follow, and both are actionable:
+
+**Everything except the heap probe is free**, at every rate tested — syscalls,
+CPU, threads, I/O, network, locks, signals, security and lifecycle together sit
+inside the noise floor. The old `<0.5%` was, by accident, about right for them.
+
+**The heap probe is the entire cost**, and on an allocation-heavy target it is
+not a tax, it is a different program. `--disable heap` removes it and keeps
+everything else:
+
+```
+ptop --pid <PID> --disable heap
+```
+
+ptop's own CPU is a separate question with a separate answer: 37–53% of one
+core with the heap probe attached, ~1% without.
 
 ### Heap: two lanes, picked from the target
 

--- a/README.md
+++ b/README.md
@@ -271,8 +271,26 @@ sources the module carries, in that order:
 | `.gopclntab` | func + file:line | every Go binary, stripped ones included |
 | `.symtab` / `.dynsym` | func | C/C++ not built with `-s` |
 | DWARF line program | file:line | anything built with `-g` |
+| `/tmp/perf-<pid>.map` | func + file:line | JIT runtimes (Node, JVM) |
 
 A module with none of them degrades to `module+0xoffset` rather than guessing.
+
+JIT'd code has no ELF behind it — V8 and the JVM compile into anonymous
+executable memory — so an address in no file-backed mapping is resolved from
+the runtime's perf map instead. Node writes one under `--perf-basic-prof`, the
+JVM under perf-map-agent; it is the same side file `perf(1)` consumes. The
+frame's module is reported as `[jit]`, because there is no file to name.
+
+V8 emits the same function once per optimization tier, distinguished only by a
+marker: `JS:~hotSmall`, `JS:+hotSmall`, `JS:^hotSmall`. Those are one function
+at three addresses. The marker is stripped so they normalize to one identity —
+without that, a deploy diff keyed on call-site name would show functions
+appearing and vanishing purely because V8 re-tiered them during warm-up.
+
+The map is located through the target's own namespaces: the runtime names the
+file with the pid it can see (`perf-1.map` inside a container), and puts it in
+its own `/tmp`, so ptop reads `NSpid` from `/proc/<pid>/status` and crosses
+into the target's mount namespace via `/proc/<pid>/root`.
 DWARF sections are copied in while the file is open and parsed on demand, so a
 `Module` still holds no file handle; past a size budget the copy is skipped and
 the frame keeps its function name without a line, which is what a

--- a/README.md
+++ b/README.md
@@ -249,7 +249,7 @@ The lanes measure different things, and the snapshot says which:
 | | `lane="libc"` | `lane="go"` |
 |---|---|---|
 | allocation rate + volume per site | yes | yes |
-| `func` / `file:line` per site | func only (no DWARF yet) | yes, via `.gopclntab` |
+| `func` / `file:line` per site | via `.symtab` + DWARF | via `.gopclntab` |
 | live bytes, lifetime, leak suspects | yes | **no** — `live_measured=false` |
 
 Nothing frees a Go allocation at a point a probe can observe: the GC sweeper
@@ -260,6 +260,23 @@ before comparing them.
 
 Symbolization works on stripped release builds (`-ldflags="-s -w"`): `.symtab`
 is gone but `.gopclntab` survives, because the runtime needs it for tracebacks.
+
+### Symbolization
+
+A captured stack address becomes `func (file:line)` through whichever of three
+sources the module carries, in that order:
+
+| Source | Gives | Present in |
+|---|---|---|
+| `.gopclntab` | func + file:line | every Go binary, stripped ones included |
+| `.symtab` / `.dynsym` | func | C/C++ not built with `-s` |
+| DWARF line program | file:line | anything built with `-g` |
+
+A module with none of them degrades to `module+0xoffset` rather than guessing.
+DWARF sections are copied in while the file is open and parsed on demand, so a
+`Module` still holds no file handle; past a size budget the copy is skipped and
+the frame keeps its function name without a line, which is what a
+debug-info-heavy C++ image gets instead of hundreds of pinned megabytes.
 
 
 ## Event stream (`--serve`)

--- a/README.md
+++ b/README.md
@@ -222,10 +222,45 @@ eBPF programs in `internal/bpf/programs/`:
 - `futex.bpf.c` — wait/wake → lock graph
 - `memory.bpf.c` — mmap/brk/page-fault counters
 - `heap.bpf.c` — libc malloc/free uprobes → live-heap + lifetime + leak suspects
+- `goalloc.bpf.c` — `runtime.mallocgc` uprobe → Go allocation sites (rate + volume)
 - `signal.bpf.c` — `signal:signal_generate` → signals delivered, with sender
 - `proc.bpf.c` — `sched_process_{fork,exec,exit}` → exec-lineage subtree
 - `security.bpf.c` — PROT_EXEC `mmap`/`mprotect` + SELinux AVC denials
 - `tls.bpf.c` — libssl `SSL_write`/`SSL_read` uprobes → plaintext (opt-in `--tls`)
+
+### Heap: two lanes, picked from the target
+
+`heap.bpf.c` probes the libc allocator. The Go runtime never calls it —
+`runtime.mallocgc` carves out of per-P caches backed by mmap'd spans — so a Go
+process observed on that lane produces an **empty** call-site axis. Since the
+call-site axis is the only part of the heap surface carrying `func`/`file:line`,
+that means no link from allocation behaviour back to source for an entire
+runtime family.
+
+`goalloc.bpf.c` attaches one uprobe to `runtime.mallocgc`, the single funnel
+every Go heap allocation passes through (`newobject`, `makeslice`, `growslice`
+and `reflect.unsafe_New` all call it; the size-specialised fast paths are
+dispatched from inside it). ptop picks the lane from the target's own
+executable — a Go image gets the Go lane, including a cgo build with libc
+mapped, since that is where a Go program's allocations actually are.
+
+The lanes measure different things, and the snapshot says which:
+
+| | `lane="libc"` | `lane="go"` |
+|---|---|---|
+| allocation rate + volume per site | yes | yes |
+| `func` / `file:line` per site | func only (no DWARF yet) | yes, via `.gopclntab` |
+| live bytes, lifetime, leak suspects | yes | **no** — `live_measured=false` |
+
+Nothing frees a Go allocation at a point a probe can observe: the GC sweeper
+reclaims spans in bulk, asynchronously, naming no object. So the Go lane sets
+`live_measured=false` and leaves those fields at 0 to mean *not measured*,
+never *measured, and zero* — a consumer diffing two deploys must check the flag
+before comparing them.
+
+Symbolization works on stripped release builds (`-ldflags="-s -w"`): `.symtab`
+is gone but `.gopclntab` survives, because the runtime needs it for tracebacks.
+
 
 ## Event stream (`--serve`)
 
@@ -320,7 +355,7 @@ envelope):
 
 | Category | Event | What it captures |
 |---|---|---|
-| `MEMORY` | `HeapEvent` / `HeapSnapshot` | libc malloc/free paired → live-heap, lifetime, leak suspects, top call sites (symbolized) |
+| `MEMORY` | `HeapEvent` / `HeapSnapshot` | allocations by call site (symbolized). libc lane: malloc/free paired → live-heap, lifetime, leak suspects. Go lane: rate + volume, `live_measured=false` |
 | `NETWORK` | `NetErrorEvent` | TCP failures: connection refused, reset, retransmits |
 | `NETWORK` | `TLSPayloadEvent` | pre-encryption / post-decryption plaintext (opt-in `--tls`) |
 | `IO` | `FSEvent` | filesystem semantics: permission denials, deletes, renames (real paths) |

--- a/bench/README.md
+++ b/bench/README.md
@@ -1,0 +1,95 @@
+# Measuring what ptop costs
+
+This directory answers a question ptop used to assert: **how much does
+observing a process cost that process?**
+
+The old answer was `overhead <0.5%`, printed in the TUI footer and the README.
+Nothing produced it. There was no harness, no workload and no raw data in
+either this repository or Witness's, so the figure could not be reproduced,
+disputed, or updated when a probe was added.
+
+It was also the wrong *shape* of answer. ptop's dominant cost is a uprobe on
+the allocator — libc `malloc`/`free`, or `runtime.mallocgc` on a Go target —
+which fires once per allocation. Its cost therefore scales with **how often the
+target allocates**, not with wall time. No single percentage can be true for
+both an idle service and one allocating a million times a second, so what this
+produces is a table across allocation rates rather than a number.
+
+## Running it
+
+eBPF needs privileges. Either run as root on a host with `CAP_BPF`, or use a
+privileged container, which is what the `bench` target does:
+
+```
+make bench
+```
+
+The raw form, if you want to drive it yourself:
+
+```
+go build -o /tmp/b/workload ./bench/workload
+go build -o /tmp/b/runner   ./bench/runner
+go build -tags=ebpf -o /tmp/b/ptop ./cmd/ptop
+
+sudo /tmp/b/runner -workload /tmp/b/workload -ptop /tmp/b/ptop
+```
+
+Useful flags: `-allocs` (the sweep, allocations per iteration), `-repeats`,
+`-target-sec` (how long a calibrated baseline run should take).
+
+## Method, and why each part is there
+
+**The metric is the target's CPU time, not its wall time.** A uprobe executes
+on the thread that tripped it, so its cost lands in the target's own
+user+system time. Wall time also moves when the scheduler runs ptop instead of
+the target, which is not the question being asked. This is not a refinement:
+measured by wall time on a two-core host, identical runs of the same
+configuration varied by 65x, and the resulting table contained impossibilities
+such as *"ptop made the target 80% faster"*.
+
+**Fixed work, variable time.** Every run does an identical number of
+iterations and reports how long that took. Measuring the reverse — work
+completed in a fixed window — has far higher run-to-run variance, and variance
+is the entire difficulty at these effect sizes.
+
+**The work is calibrated, not guessed.** Before each sweep point the runner
+grows the iteration count until an uninstrumented run costs at least
+`-target-sec` of CPU. A percentage computed against a baseline that finished in
+200 microseconds is noise divided by noise — which is exactly what the first
+draft of this harness reported before the calibration step existed.
+
+**Median, with the spread shown.** One descheduled run moves a mean and does
+not move a median, and on a shared machine there is always one. The spread
+(slowest − fastest, over the median) is printed beside every cell: where it is
+comparable to the overhead, the cell has not measured anything and says so.
+
+**The baseline is re-measured at every allocation rate**, interleaved with the
+instrumented runs, so drift in machine conditions over a long sweep lands on
+both arms rather than on the result.
+
+**Attachment is a handshake, not a sleep.** The workload warms up until the
+runner creates a start file, and the runner creates it only after ptop's socket
+appears — ptop's own statement that its collectors have started. Without that,
+a run can measure a half-attached ptop and report it as attached.
+
+**The workload mixes observable and unobservable work.** A compute part no
+probe can see, and an allocation part every probe does. Sweeping the ratio is
+what separates *"ptop costs something"* from *"ptop costs something here"*.
+
+## Configurations
+
+| Configuration | What it isolates |
+|---|---|
+| no ptop | the baseline |
+| ptop, all probes | what an operator actually pays |
+| ptop, no heap probe | everything except the per-allocation uprobe (`--disable heap`) |
+| ptop, heap probe only | the per-allocation uprobe alone |
+
+The decomposition is the actionable part. *"ptop costs N%"* leaves an operator
+with nothing to do; *"the heap probe is N% of it and you can turn it off with
+`--disable heap`"* is a decision they can make.
+
+## Reading the result
+
+Take the row whose allocation rate resembles your workload. Quoting a single
+cell as "ptop's overhead" repeats the mistake this directory exists to correct.

--- a/bench/results/2026-08-23-aarch64.txt
+++ b/bench/results/2026-08-23-aarch64.txt
@@ -1,0 +1,129 @@
+Host
+----
+arch          aarch64 (ARM), 2 cores
+kernel        7.0.0-29-generic
+memory        5 GB
+container     ubuntu:26.04, --privileged, debugfs+tracefs mounted
+go            go1.26.5
+ptop          feat/go-alloc-axis, eBPF build (CGO_ENABLED=0, -tags=ebpf)
+command       ./runner -repeats 3 -target-sec 3 -warmup 1s -compute-sweep 64,640,6400,64000
+
+A two-core shared host is a small machine for a benchmark, which is why the
+noise floor is measured and published rather than assumed. It is also why the
+sweep was run twice: the two independent runs agreed to within a few percent
+at every point (+3254%/+3214%, +415%/+404%, +113%/+110%, +15.2%/+14.8%), which
+is the only evidence here that the numbers are reproducible rather than a
+property of one afternoon.
+
+compute=64 allocs/iter=0
+  no ptop                   70638931 iters      50.1 ns/iter (spread 4%)  0k allocs/s
+  ptop, all probes          71290675 iters      47.7 ns/iter (spread 1%)  0k allocs/s
+  ptop, no heap probe       72221351 iters      47.7 ns/iter (spread 1%)  0k allocs/s
+  ptop, heap probe only     70966512 iters      47.8 ns/iter (spread 17%)  0k allocs/s
+compute=64 allocs/iter=1
+  no ptop                   45799644 iters      71.0 ns/iter (spread 5%)  14371k allocs/s
+  ptop, all probes           1508040 iters    2351.2 ns/iter (spread 9%)  388k allocs/s
+  ptop, no heap probe       52973629 iters      72.6 ns/iter (spread 7%)  14206k allocs/s
+  ptop, heap probe only      1413702 iters    2312.3 ns/iter (spread 3%)  399k allocs/s
+compute=640 allocs/iter=1
+  no ptop                    4097058 iters     852.5 ns/iter (spread 1%)  1161k allocs/s
+  ptop, all probes            841745 iters    4299.4 ns/iter (spread 3%)  217k allocs/s
+  ptop, no heap probe        4046934 iters     844.9 ns/iter (spread 0%)  1171k allocs/s
+  ptop, heap probe only       979430 iters    3905.3 ns/iter (spread 4%)  238k allocs/s
+compute=6400 allocs/iter=1
+  no ptop                     396950 iters    8732.7 ns/iter (spread 0%)  114k allocs/s
+  ptop, all probes            189512 iters   18332.3 ns/iter (spread 2%)  53k allocs/s
+  ptop, no heap probe         395051 iters    8747.4 ns/iter (spread 1%)  113k allocs/s
+  ptop, heap probe only       231929 iters   17297.5 ns/iter (spread 2%)  56k allocs/s
+compute=64000 allocs/iter=1
+  no ptop                      50000 iters   87464.3 ns/iter (spread 1%)  11k allocs/s
+  ptop, all probes             50000 iters  100385.8 ns/iter (spread 1%)  10k allocs/s
+  ptop, no heap probe          50000 iters   87533.5 ns/iter (spread 0%)  11k allocs/s
+  ptop, heap probe only        50000 iters  101384.2 ns/iter (spread 3%)  10k allocs/s
+# ptop overhead
+
+Metric: the TARGET's CPU time per unit of work (user+system, nanoseconds
+per iteration), median of 3 runs, 128-byte allocations. Overhead is the
+increase against the identical workload with no ptop attached.
+
+`spread` is (slowest - fastest) / median across the repetitions of that
+cell. Where spread is comparable to the overhead, the cell is noise and
+should be read as such.
+
+| target allocation rate | ptop, all probes | ptop, no heap probe | ptop, heap probe only | 
+|---|---|---|---|
+| 0 (no allocations) | -4.9% <sub>±4%</sub> | -4.9% <sub>±4%</sub> | -4.6% <sub>±17%</sub> | 
+| 14.4M/s | +3213.9% <sub>±9%</sub> | +2.3% <sub>±7%</sub> | +3159.1% <sub>±5%</sub> | 
+| 1.2M/s | +404.4% <sub>±3%</sub> | -0.9% <sub>±1%</sub> | +358.1% <sub>±4%</sub> | 
+| 114k/s | +109.9% <sub>±2%</sub> | +0.2% <sub>±1%</sub> | +98.1% <sub>±2%</sub> | 
+| 11k/s | +14.8% <sub>±1%</sub> | +0.1% <sub>±1%</sub> | +15.9% <sub>±3%</sub> | 
+
+## Cost per allocation observed
+
+The percentages above are this cost divided by how much other work the
+target does between allocations. It would be convenient if it were a
+constant of the probe that could simply be multiplied by anyone's
+allocation rate. It is not: it RISES as allocations get sparser.
+
+The likely reason is cache and branch state. At a high allocation rate
+the trap path, the BPF program and its maps stay hot, and each firing
+reuses them; at a low one every firing is a cold path through the same
+code. That is a hypothesis this harness does not test — it is stated so
+the numbers are not mistaken for a linear model.
+
+| target allocation rate | ptop, all probes | ptop, no heap probe | ptop, heap probe only | 
+|---|---|---|---|
+| 14.4M/s | +2280 ns | +2 ns | +2241 ns | 
+| 1.2M/s | +3447 ns | -8 ns | +3053 ns | 
+| 114k/s | +9600 ns | +15 ns | +8565 ns | 
+| 11k/s | +12921 ns | +69 ns | +13920 ns | 
+
+The control row allocates nothing, so the per-allocation probe has
+nothing to fire on and every cell in it SHOULD read 0%. What it reads
+instead is this host's floor: **±4.9%**. Attaching a probe cannot make a
+process faster, so a negative or small positive figure there is the
+measurement apparatus, not the probe — and no overhead below that
+magnitude is resolved by this run.
+
+## ptop's own CPU, as a share of one core
+
+A separate question from the one above: this is what ptop costs the MACHINE,
+not what it costs the observed process.
+
+| target allocation rate | ptop, all probes | ptop, no heap probe | ptop, heap probe only | 
+|---|---|---|---|
+| 0 (no allocations) | 1% | 1% | 0% | 
+| 14.4M/s | 55% | 1% | 53% | 
+| 1.2M/s | 48% | 0% | 44% | 
+| 114k/s | 40% | 1% | 37% | 
+| 11k/s | 12% | 1% | 11% | 
+
+## Raw
+
+```
+compute=64 allocs/iter=0
+  no ptop                   70638931 iters       50.1 ns/iter  cpu_median=3.541s  ns/iter runs=[50.1223 50.1866 48.1648]
+  ptop, all probes          71290675 iters       47.7 ns/iter  cpu_median=3.398s  ns/iter runs=[47.5007 47.9116 47.6642]
+  ptop, no heap probe       72221351 iters       47.7 ns/iter  cpu_median=3.443s  ns/iter runs=[47.6771 47.4837 47.8836]
+  ptop, heap probe only     70966512 iters       47.8 ns/iter  cpu_median=3.395s  ns/iter runs=[47.8359 47.6809 55.9143]
+compute=64 allocs/iter=1
+  no ptop                   45799644 iters       71.0 ns/iter  cpu_median=3.250s  ns/iter runs=[72.4564 68.8798 70.9506]
+  ptop, all probes           1508040 iters     2351.2 ns/iter  cpu_median=3.546s  ns/iter runs=[2351.2451 2541.0773 2334.9358]
+  ptop, no heap probe       52973629 iters       72.6 ns/iter  cpu_median=3.845s  ns/iter runs=[72.5825 74.0571 69.1234]
+  ptop, heap probe only      1413702 iters     2312.3 ns/iter  cpu_median=3.269s  ns/iter runs=[2348.8732 2269.7160 2312.3217]
+compute=640 allocs/iter=1
+  no ptop                    4097058 iters      852.5 ns/iter  cpu_median=3.493s  ns/iter runs=[855.2870 852.4572 850.6569]
+  ptop, all probes            841745 iters     4299.4 ns/iter  cpu_median=3.619s  ns/iter runs=[4267.9428 4299.4172 4386.0748]
+  ptop, no heap probe        4046934 iters      844.9 ns/iter  cpu_median=3.419s  ns/iter runs=[844.8688 846.6306 844.8765]
+  ptop, heap probe only       979430 iters     3905.3 ns/iter  cpu_median=3.825s  ns/iter runs=[3879.2757 3905.2818 4035.4014]
+compute=6400 allocs/iter=1
+  no ptop                     396950 iters     8732.7 ns/iter  cpu_median=3.466s  ns/iter runs=[8734.2105 8732.6686 8724.3867]
+  ptop, all probes            189512 iters    18332.3 ns/iter  cpu_median=3.474s  ns/iter runs=[18593.6641 18332.2562 18307.9838]
+  ptop, no heap probe         395051 iters     8747.4 ns/iter  cpu_median=3.456s  ns/iter runs=[8726.1633 8772.9280 8747.4108]
+  ptop, heap probe only       231929 iters    17297.5 ns/iter  cpu_median=4.012s  ns/iter runs=[17297.5238 17556.3150 17258.4657]
+compute=64000 allocs/iter=1
+  no ptop                      50000 iters    87464.3 ns/iter  cpu_median=4.373s  ns/iter runs=[87936.9682 87427.8194 87464.3170]
+  ptop, all probes             50000 iters   100385.8 ns/iter  cpu_median=5.019s  ns/iter runs=[100320.6971 100385.8116 101597.4112]
+  ptop, no heap probe          50000 iters    87533.5 ns/iter  cpu_median=4.377s  ns/iter runs=[87533.5264 87516.8851 87550.5366]
+  ptop, heap probe only        50000 iters   101384.2 ns/iter  cpu_median=5.069s  ns/iter runs=[100712.3815 101384.2354 103874.2792]
+```

--- a/bench/runner/main.go
+++ b/bench/runner/main.go
@@ -1,0 +1,608 @@
+// Command runner measures what ptop costs the process it observes.
+//
+// It exists because the number ptop shipped with — "overhead <0.5%" — was an
+// assertion with no measurement, no workload and no methodology behind it. It
+// was also the wrong SHAPE of claim: ptop's dominant cost is a uprobe that
+// fires once per allocation, so its overhead is a function of the target's
+// allocation rate, not a constant. A single percentage cannot be right for
+// both an idle service and one allocating a million times a second.
+//
+// So this sweeps allocation rate against collector configuration and reports a
+// table. Reading one cell of it as "the" overhead is exactly the mistake the
+// old number encoded.
+//
+// # Method
+//
+//   - The metric is the TARGET'S CPU TIME, not wall time. A uprobe executes on
+//     the thread that tripped it, so its cost lands in the target's own CPU
+//     accounting; and unlike wall time, CPU time does not move when the
+//     scheduler deschedules the target in favour of ptop. This is not a
+//     refinement — measured by wall time on this two-core host, identical runs
+//     of the same configuration varied by 65x and the table contained
+//     impossibilities like "ptop made the target 80% faster".
+//
+//   - Fixed work, variable time. Each run does an identical number of
+//     iterations; run-to-run variance is far lower than for "ops completed in
+//     a fixed window".
+//
+//   - EVERY CONFIGURATION IS SIZED SEPARATELY, and the metric is CPU time PER
+//     ITERATION. This took three tries to get right and the failures are worth
+//     recording, because each produced a confident table that was wrong:
+//
+//     Sizing the work by a guess left the compute-only baseline finishing in
+//     200 microseconds — every percentage derived from it was noise over
+//     noise. Sizing it by a calibrated BASELINE put the instrumented arm into
+//     the minutes, since the heap probe costs a large multiple of the
+//     uninstrumented run; the sweep never finished. Sizing it by the
+//     EXPENSIVE arm bounded the run but left the baseline at ~0.1s, where its
+//     own repetitions disagreed by ±22% and the decomposition cell — the one
+//     that says how much is NOT the heap probe — came out at -28.8%, i.e.
+//     "attaching ptop made the target faster".
+//
+//     Giving each configuration its own iteration count fixes all three:
+//     every arm runs long enough to be measured, no arm runs longer than it
+//     needs to, and dividing by iterations makes them comparable.
+//
+//   - The MEDIAN of N repetitions is reported, not the mean. One descheduled
+//     run moves a mean and does not move a median, and on a shared machine
+//     there is always one. The spread is printed too, so a reader can see when
+//     a cell should not be trusted.
+//
+//   - The baseline is re-measured for every allocation rate, interleaved with
+//     the instrumented runs, so machine drift over the sweep hits both arms.
+//
+//   - The target confirms every probe is attached before timing starts (see
+//     the --start-file handshake in the workload), so no run can measure a
+//     half-attached ptop and report it as attached.
+//
+//   - ptop's own CPU time is read from /proc and reported separately. It is a
+//     different question from "how much slower is the target", and conflating
+//     the two is part of how a number like <0.5% survives unchallenged.
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"math"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// config is one ptop configuration under test. Decomposing by subsystem is an
+// acceptance criterion, not a nicety: "ptop costs N%" is unactionable, while
+// "the heap probe costs N% and everything else costs M%" tells an operator
+// what to turn off.
+type config struct {
+	name    string
+	ptop    bool
+	disable string // --disable value; "" means everything on
+}
+
+var configs = []config{
+	{name: "no ptop", ptop: false},
+	{name: "ptop, all probes", ptop: true},
+	{name: "ptop, no heap probe", ptop: true, disable: "heap"},
+	{name: "ptop, heap probe only", ptop: true,
+		disable: "cpu,threads,memory,syscalls,io,network,futex,signals,lifecycle,security,fd"},
+}
+
+// sweepPoint is one row of the table: a workload shape. compute sets how much
+// unobservable work sits between allocations, which is what varies the
+// allocation RATE — the axis the heap probe's cost actually scales on. The
+// control row allocates nothing at all, isolating what the other probes cost.
+type sweepPoint struct {
+	compute int
+	allocs  int
+}
+
+func (p sweepPoint) control() bool { return p.allocs == 0 }
+
+type workloadResult struct {
+	Iterations   int     `json:"iterations"`
+	AllocsPerIt  int     `json:"allocs_per_iteration"`
+	ElapsedSec   float64 `json:"elapsed_sec"`
+	CPUSec       float64 `json:"cpu_sec"`
+	OpsPerSec    float64 `json:"ops_per_sec"`
+	AllocsPerSec float64 `json:"allocs_per_sec"`
+	GoVersion    string  `json:"go_version"`
+	GOMAXPROCS   int     `json:"gomaxprocs"`
+}
+
+type cell struct {
+	nsPerIter    float64 // the metric: CPU nanoseconds per work iteration
+	iterations   int
+	medianCPU    float64
+	medianWall   float64
+	allocsPerSec float64
+	ptopCPUSec   float64
+	runs         []float64 // CPU ns/iteration, one per repetition
+}
+
+// spread is the relative gap between the fastest and slowest repetition. It is
+// printed beside every overhead figure, because a cell whose own runs disagree
+// by more than the effect being measured has not measured anything.
+func (c cell) spread() float64 {
+	if len(c.runs) == 0 || c.nsPerIter == 0 {
+		return 0
+	}
+	lo, hi := c.runs[0], c.runs[0]
+	for _, r := range c.runs {
+		if r < lo {
+			lo = r
+		}
+		if r > hi {
+			hi = r
+		}
+	}
+	return (hi - lo) / c.nsPerIter
+}
+
+func main() {
+	workloadBin := flag.String("workload", "./workload", "path to the workload binary")
+	ptopBin := flag.String("ptop", "./ptop", "path to the ptop binary (must be an eBPF build)")
+	targetSec := flag.Float64("target-sec", 8, "calibrate the iteration count so the most expensive configuration takes at least this many CPU seconds")
+	maxIterations := flag.Int("max-iterations", 200_000_000, "calibration ceiling, so a slow host cannot run away")
+	repeats := flag.Int("repeats", 5, "runs per cell; the median is reported")
+	warmup := flag.Duration("warmup", 3*time.Second, "workload warm-up before timing")
+	computeSweepFlag := flag.String("compute-sweep", "64,640,6400,64000", "comma-separated compute-rounds values to sweep; more compute between allocations means a lower allocation rate")
+	allocs := flag.Int("allocs", 1, "allocations per iteration at each sweep point")
+	allocBytes := flag.Int("alloc-bytes", 128, "size of each allocation")
+	skipControl := flag.Bool("no-control", false, "skip the allocation-free control row")
+	flag.Parse()
+
+	computes, err := parseInts(*computeSweepFlag)
+	if err != nil {
+		fatal("--compute-sweep: %v", err)
+	}
+	var sweep []sweepPoint
+	if !*skipControl {
+		// Allocation-free control: whatever overhead shows up here belongs to
+		// the probes that are NOT per-allocation, measured with the expensive
+		// one given nothing to fire on.
+		sweep = append(sweep, sweepPoint{compute: computes[0], allocs: 0})
+	}
+	for _, c := range computes {
+		sweep = append(sweep, sweepPoint{compute: c, allocs: *allocs})
+	}
+	for _, bin := range []string{*workloadBin, *ptopBin} {
+		if _, err := os.Stat(bin); err != nil {
+			fatal("%v", err)
+		}
+	}
+
+	results := make(map[string]map[int]cell)
+	for _, c := range configs {
+		results[c.name] = make(map[int]cell)
+	}
+
+	// Allocation rate is the outer loop and configuration the inner one, so
+	// every configuration at a given rate is measured close together in time.
+	// Machine conditions drift over a sweep this long; interleaving means the
+	// drift lands on the comparison's noise rather than on its result.
+	for i, pt := range sweep {
+		fmt.Fprintf(os.Stderr, "compute=%d allocs/iter=%d\n", pt.compute, pt.allocs)
+		for _, c := range configs {
+			fmt.Fprintf(os.Stderr, "  %-24s ", c.name)
+			iters, err := calibrate(c, *workloadBin, *ptopBin, pt, *allocBytes, *warmup, *targetSec, *maxIterations)
+			if err != nil {
+				fatal("\ncalibrating %s at %+v: %v", c.name, pt, err)
+			}
+			cl, err := measure(c, *workloadBin, *ptopBin, iters, pt, *allocBytes, *repeats, *warmup)
+			if err != nil {
+				fatal("\n%v", err)
+			}
+			results[c.name][i] = cl
+			fmt.Fprintf(os.Stderr, "%9d iters  %8.1f ns/iter (spread %.0f%%)  %.0fk allocs/s\n",
+				iters, cl.nsPerIter, 100*cl.spread(), cl.allocsPerSec/1000)
+		}
+	}
+
+	report(sweep, results, *repeats, *allocBytes)
+}
+
+// calibrate grows the iteration count until THIS configuration costs at least
+// targetSec of CPU.
+//
+// Per-configuration sizing is the point: the arms differ by more than an order
+// of magnitude, so any single iteration count either starves the cheap arm of
+// resolution or makes the expensive one take minutes. Both happened; see the
+// package comment.
+//
+// The ceiling stops a fast host from running away; a run that hits it is
+// reported with whatever duration it reached rather than retried forever.
+func calibrate(c config, workloadBin, ptopBin string, pt sweepPoint, allocBytes int, warmup time.Duration, targetSec float64, maxIterations int) (int, error) {
+	iters := 50_000
+	for round := 0; round < 12; round++ {
+		res, _, err := runOnce(c, workloadBin, ptopBin, iters, pt, allocBytes, warmup)
+		if err != nil {
+			return 0, err
+		}
+		if res.CPUSec >= targetSec || iters >= maxIterations {
+			return iters, nil
+		}
+		// Scale straight to the target with headroom rather than doubling: on
+		// a fast host doubling from 50k takes a dozen rounds, each paying the
+		// warm-up again. Capped per round so one anomalously fast measurement
+		// cannot overshoot into a run that takes an hour.
+		factor := targetSec / maxf(res.CPUSec, 1e-6)
+		if factor > 20 {
+			factor = 20
+		}
+		next := int(float64(iters) * factor * 1.15)
+		if next <= iters {
+			next = iters * 2
+		}
+		if next > maxIterations {
+			next = maxIterations
+		}
+		iters = next
+	}
+	return iters, nil
+}
+
+// measure runs one cell `repeats` times and returns its median.
+func measure(c config, workloadBin, ptopBin string, iterations int, pt sweepPoint, allocBytes, repeats int, warmup time.Duration) (cell, error) {
+	var elapsed []float64
+	var allocRate, ptopCPU float64
+
+	var wall, perIter []float64
+	for i := 0; i < repeats; i++ {
+		res, cpu, err := runOnce(c, workloadBin, ptopBin, iterations, pt, allocBytes, warmup)
+		if err != nil {
+			return cell{}, err
+		}
+		elapsed = append(elapsed, res.CPUSec)
+		wall = append(wall, res.ElapsedSec)
+		perIter = append(perIter, res.CPUSec*1e9/float64(iterations))
+		allocRate += res.AllocsPerSec / float64(repeats)
+		ptopCPU += cpu / float64(repeats)
+	}
+	return cell{
+		nsPerIter:    median(perIter),
+		iterations:   iterations,
+		medianCPU:    median(elapsed),
+		medianWall:   median(wall),
+		allocsPerSec: allocRate,
+		ptopCPUSec:   ptopCPU,
+		runs:         perIter,
+	}, nil
+}
+
+// runOnce starts the workload, attaches ptop if the configuration calls for
+// it, releases the workload's timed section, and collects both results.
+func runOnce(c config, workloadBin, ptopBin string, iterations int, pt sweepPoint, allocBytes int, warmup time.Duration) (workloadResult, float64, error) {
+	tmp, err := os.MkdirTemp("", "ptopbench")
+	if err != nil {
+		return workloadResult{}, 0, err
+	}
+	defer os.RemoveAll(tmp)
+	startFile := filepath.Join(tmp, "go")
+
+	var out, errBuf strings.Builder
+	wl := exec.Command(workloadBin,
+		"-iterations", strconv.Itoa(iterations),
+		"-allocs", strconv.Itoa(pt.allocs),
+		"-compute", strconv.Itoa(pt.compute),
+		"-alloc-bytes", strconv.Itoa(allocBytes),
+		"-warmup", warmup.String(),
+		"-start-file", startFile,
+	)
+	wl.Stdout, wl.Stderr = &out, &errBuf
+	if err := wl.Start(); err != nil {
+		return workloadResult{}, 0, fmt.Errorf("start workload: %w", err)
+	}
+	defer func() {
+		if wl.ProcessState == nil {
+			_ = wl.Process.Kill()
+			_, _ = wl.Process.Wait()
+		}
+	}()
+
+	var ptop *exec.Cmd
+	var ptopErr strings.Builder
+	var cpuBefore float64
+	if c.ptop && ptopBin != "" {
+		sock := filepath.Join(tmp, "p.sock")
+		args := []string{"--pid", strconv.Itoa(wl.Process.Pid), "--serve", "unix://" + sock}
+		if c.disable != "" {
+			args = append(args, "--disable", c.disable)
+		}
+		ptop = exec.Command(ptopBin, args...)
+		ptop.Stderr = &ptopErr
+		if err := ptop.Start(); err != nil {
+			return workloadResult{}, 0, fmt.Errorf("start ptop: %w", err)
+		}
+		defer func() {
+			_ = ptop.Process.Kill()
+			_, _ = ptop.Process.Wait()
+		}()
+
+		// The socket appearing is ptop's own statement that every collector it
+		// intends to start has started. Waiting for it, rather than sleeping,
+		// is what makes "the probes were attached" a fact about this run.
+		if err := waitForFile(sock, 30*time.Second); err != nil {
+			return workloadResult{}, 0, fmt.Errorf("ptop never served (%v)\nptop stderr:\n%s", err, ptopErr.String())
+		}
+		cpuBefore = processCPUSeconds(ptop.Process.Pid)
+	}
+
+	if err := os.WriteFile(startFile, []byte("go"), 0o644); err != nil {
+		return workloadResult{}, 0, err
+	}
+	if err := wl.Wait(); err != nil {
+		return workloadResult{}, 0, fmt.Errorf("workload: %w\nstderr:\n%s", err, errBuf.String())
+	}
+
+	var cpu float64
+	if ptop != nil {
+		cpu = processCPUSeconds(ptop.Process.Pid) - cpuBefore
+	}
+
+	var res workloadResult
+	if err := json.Unmarshal([]byte(out.String()), &res); err != nil {
+		return workloadResult{}, 0, fmt.Errorf("decode workload output %q: %w", out.String(), err)
+	}
+	return res, cpu, nil
+}
+
+func waitForFile(path string, timeout time.Duration) error {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if _, err := os.Stat(path); err == nil {
+			return nil
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	return fmt.Errorf("timed out waiting for %s", path)
+}
+
+// processCPUSeconds reads utime+stime from /proc/<pid>/stat. Returns 0 when
+// the process is gone, which the caller reads as "no CPU attributable".
+func processCPUSeconds(pid int) float64 {
+	data, err := os.ReadFile(fmt.Sprintf("/proc/%d/stat", pid))
+	if err != nil {
+		return 0
+	}
+	// The comm field can contain spaces and parentheses; everything after the
+	// last ')' is positional.
+	i := strings.LastIndexByte(string(data), ')')
+	if i < 0 {
+		return 0
+	}
+	fields := strings.Fields(string(data)[i+1:])
+	// After comm and state, utime is field 11 and stime 12 in proc(5); with
+	// state at index 0 here they land at 11 and 12.
+	if len(fields) < 13 {
+		return 0
+	}
+	utime, err1 := strconv.ParseFloat(fields[11], 64)
+	stime, err2 := strconv.ParseFloat(fields[12], 64)
+	if err1 != nil || err2 != nil {
+		return 0
+	}
+	return (utime + stime) / clockTicks
+}
+
+// clockTicks is USER_HZ, 100 on every Linux port ptop supports.
+const clockTicks = 100.0
+
+func report(sweep []sweepPoint, results map[string]map[int]cell, repeats, allocBytes int) {
+	base := configs[0].name
+
+	fmt.Printf("# ptop overhead\n\n")
+	fmt.Printf("Metric: the TARGET's CPU time per unit of work (user+system, nanoseconds\n")
+	fmt.Printf("per iteration), median of %d runs, %d-byte allocations. Overhead is the\n", repeats, allocBytes)
+	fmt.Printf("increase against the identical workload with no ptop attached.\n\n")
+	fmt.Printf("`spread` is (slowest - fastest) / median across the repetitions of that\n")
+	fmt.Printf("cell. Where spread is comparable to the overhead, the cell is noise and\n")
+	fmt.Printf("should be read as such.\n\n")
+
+	header := func() {
+		fmt.Printf("| target allocation rate | ")
+		for _, c := range configs[1:] {
+			fmt.Printf("%s | ", c.name)
+		}
+		fmt.Printf("\n|---|")
+		for range configs[1:] {
+			fmt.Printf("---|")
+		}
+		fmt.Println()
+	}
+
+	header()
+	for i, pt := range sweep {
+		b := results[base][i]
+		fmt.Printf("| %s | ", rateLabel(pt, b))
+		for _, c := range configs[1:] {
+			cl := results[c.name][i]
+			over := 100 * (cl.nsPerIter - b.nsPerIter) / b.nsPerIter
+			fmt.Printf("%+.1f%% <sub>±%.0f%%</sub> | ", over, 100*maxf(cl.spread(), b.spread()))
+		}
+		fmt.Println()
+	}
+
+	// Dividing the overhead by the allocation count exposes something the
+	// percentages hide, and it is not the constant one would expect.
+	fmt.Printf("\n## Cost per allocation observed\n\n")
+	fmt.Printf("The percentages above are this cost divided by how much other work the\n")
+	fmt.Printf("target does between allocations. It would be convenient if it were a\n")
+	fmt.Printf("constant of the probe that could simply be multiplied by anyone's\n")
+	fmt.Printf("allocation rate. It is not: it RISES as allocations get sparser.\n\n")
+	fmt.Printf("The likely reason is cache and branch state. At a high allocation rate\n")
+	fmt.Printf("the trap path, the BPF program and its maps stay hot, and each firing\n")
+	fmt.Printf("reuses them; at a low one every firing is a cold path through the same\n")
+	fmt.Printf("code. That is a hypothesis this harness does not test — it is stated so\n")
+	fmt.Printf("the numbers are not mistaken for a linear model.\n\n")
+	fmt.Printf("| target allocation rate | ")
+	for _, c := range configs[1:] {
+		fmt.Printf("%s | ", c.name)
+	}
+	fmt.Printf("\n|---|")
+	for range configs[1:] {
+		fmt.Printf("---|")
+	}
+	fmt.Println()
+	for i, pt := range sweep {
+		if pt.control() {
+			continue // nothing allocated, so there is nothing to divide by
+		}
+		b := results[base][i]
+		fmt.Printf("| %s | ", rateLabel(pt, b))
+		for _, c := range configs[1:] {
+			cl := results[c.name][i]
+			perAlloc := (cl.nsPerIter - b.nsPerIter) / float64(pt.allocs)
+			fmt.Printf("%+.0f ns | ", perAlloc)
+		}
+		fmt.Println()
+	}
+
+	if floor, ok := noiseFloor(sweep, results); ok {
+		fmt.Printf("\nThe control row allocates nothing, so the per-allocation probe has\n")
+		fmt.Printf("nothing to fire on and every cell in it SHOULD read 0%%. What it reads\n")
+		fmt.Printf("instead is this host's floor: **±%.1f%%**. Attaching a probe cannot make a\n", floor)
+		fmt.Printf("process faster, so a negative or small positive figure there is the\n")
+		fmt.Printf("measurement apparatus, not the probe — and no overhead below that\n")
+		fmt.Printf("magnitude is resolved by this run.\n")
+	}
+
+	fmt.Printf("\n## ptop's own CPU, as a share of one core\n\n")
+	fmt.Printf("A separate question from the one above: this is what ptop costs the MACHINE,\n")
+	fmt.Printf("not what it costs the observed process.\n\n")
+	header()
+	for i, pt := range sweep {
+		b := results[base][i]
+		fmt.Printf("| %s | ", rateLabel(pt, b))
+		for _, c := range configs[1:] {
+			cl := results[c.name][i]
+			pct := 0.0
+			if cl.medianWall > 0 {
+				pct = 100 * cl.ptopCPUSec / cl.medianWall
+			}
+			fmt.Printf("%.0f%% | ", pct)
+		}
+		fmt.Println()
+	}
+
+	fmt.Printf("\n## Raw\n\n```\n")
+	for i, pt := range sweep {
+		fmt.Printf("compute=%d allocs/iter=%d\n", pt.compute, pt.allocs)
+		for _, c := range configs {
+			cl := results[c.name][i]
+			fmt.Printf("  %-24s %9d iters  %9.1f ns/iter  cpu_median=%.3fs  ns/iter runs=%s\n",
+				c.name, cl.iterations, cl.nsPerIter, cl.medianCPU, fmtFloats(cl.runs))
+		}
+	}
+	fmt.Printf("```\n")
+}
+
+// noiseFloor is the largest apparent overhead in the allocation-free control
+// row. Nothing there should differ from the baseline at all — the expensive
+// probe has nothing to fire on — so whatever the row reports is the host's
+// run-to-run bias, and a smaller effect elsewhere in the table has not been
+// measured.
+//
+// Publishing it beside the table is the difference between a benchmark and a
+// number: without it, a reader cannot tell an overhead of 2% from a rounding
+// artefact, and the first draft of this harness reported both.
+func noiseFloor(sweep []sweepPoint, results map[string]map[int]cell) (float64, bool) {
+	base := configs[0].name
+	var worst float64
+	var found bool
+	for i, pt := range sweep {
+		if !pt.control() {
+			continue
+		}
+		b := results[base][i]
+		if b.nsPerIter == 0 {
+			continue
+		}
+		found = true
+		for _, c := range configs[1:] {
+			cl := results[c.name][i]
+			d := math.Abs(100 * (cl.nsPerIter - b.nsPerIter) / b.nsPerIter)
+			if d > worst {
+				worst = d
+			}
+		}
+		// The cells' own repetition spread is part of the same floor.
+		if sp := 100 * b.spread(); sp > worst {
+			worst = sp
+		}
+	}
+	return worst, found
+}
+
+// rateLabel names a sweep row by the allocation rate actually achieved, not by
+// the knob setting: "4 allocations per iteration" means nothing to a reader,
+// while "2.3M allocations/sec" is the axis the cost actually scales on.
+func rateLabel(pt sweepPoint, baseline cell) string {
+	if pt.control() {
+		return "0 (no allocations)"
+	}
+	r := baseline.allocsPerSec
+	switch {
+	case r >= 1e6:
+		return fmt.Sprintf("%.1fM/s", r/1e6)
+	case r >= 1e3:
+		return fmt.Sprintf("%.0fk/s", r/1e3)
+	default:
+		return fmt.Sprintf("%.0f/s", r)
+	}
+}
+
+func maxf(a, b float64) float64 {
+	if a > b {
+		return a
+	}
+	return b
+}
+
+func median(xs []float64) float64 {
+	if len(xs) == 0 {
+		return 0
+	}
+	s := append([]float64(nil), xs...)
+	sort.Float64s(s)
+	if len(s)%2 == 1 {
+		return s[len(s)/2]
+	}
+	return (s[len(s)/2-1] + s[len(s)/2]) / 2
+}
+
+func fmtFloats(xs []float64) string {
+	parts := make([]string, len(xs))
+	for i, x := range xs {
+		parts[i] = fmt.Sprintf("%.4f", x)
+	}
+	return "[" + strings.Join(parts, " ") + "]"
+}
+
+func parseInts(spec string) ([]int, error) {
+	var out []int
+	for _, raw := range strings.Split(spec, ",") {
+		raw = strings.TrimSpace(raw)
+		if raw == "" {
+			continue
+		}
+		n, err := strconv.Atoi(raw)
+		if err != nil || n < 0 {
+			return nil, fmt.Errorf("bad value %q", raw)
+		}
+		out = append(out, n)
+	}
+	if len(out) == 0 {
+		return nil, fmt.Errorf("no values")
+	}
+	return out, nil
+}
+
+func fatal(format string, args ...interface{}) {
+	fmt.Fprintf(os.Stderr, "bench: "+format+"\n", args...)
+	os.Exit(1)
+}

--- a/bench/runner/main_test.go
+++ b/bench/runner/main_test.go
@@ -1,0 +1,156 @@
+package main
+
+import (
+	"math"
+	"os"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestMedian(t *testing.T) {
+	cases := []struct {
+		in   []float64
+		want float64
+	}{
+		{nil, 0},
+		{[]float64{4}, 4},
+		{[]float64{3, 1, 2}, 2},
+		{[]float64{4, 1, 3, 2}, 2.5},
+		// The reason the median is used at all: one descheduled run must not
+		// move the answer.
+		{[]float64{1.0, 1.02, 1.01, 0.99, 30.0}, 1.01},
+	}
+	for _, c := range cases {
+		if got := median(c.in); math.Abs(got-c.want) > 1e-9 {
+			t.Errorf("median(%v) = %v, want %v", c.in, got, c.want)
+		}
+	}
+	// The input must not be reordered: the caller keeps it for the raw dump.
+	in := []float64{3, 1, 2}
+	_ = median(in)
+	if !reflect.DeepEqual(in, []float64{3, 1, 2}) {
+		t.Errorf("median reordered its input: %v", in)
+	}
+}
+
+func TestCellSpread(t *testing.T) {
+	c := cell{nsPerIter: 100, runs: []float64{90, 100, 110}}
+	if got := c.spread(); math.Abs(got-0.2) > 1e-9 {
+		t.Errorf("spread = %v, want 0.2", got)
+	}
+	if got := (cell{}).spread(); got != 0 {
+		t.Errorf("empty cell spread = %v, want 0", got)
+	}
+	// A cell with no measurement must not divide by zero into an Inf that
+	// then renders as a plausible-looking table entry.
+	if got := (cell{runs: []float64{1, 2}}).spread(); got != 0 {
+		t.Errorf("zero-metric spread = %v, want 0", got)
+	}
+}
+
+func TestParseInts(t *testing.T) {
+	got, err := parseInts(" 64, 640 ,6400 ")
+	if err != nil || !reflect.DeepEqual(got, []int{64, 640, 6400}) {
+		t.Errorf("= %v, %v", got, err)
+	}
+	for _, bad := range []string{"", "  ", "64,x", "64,-1", ","} {
+		if _, err := parseInts(bad); err == nil {
+			t.Errorf("parseInts(%q) accepted a bad sweep", bad)
+		}
+	}
+}
+
+// processCPUSeconds parses /proc/<pid>/stat positionally, and the comm field
+// can contain spaces and parentheses — a process named "(evil) x" would shift
+// every field after it if the parse split naively.
+func TestProcessCPUSecondsOnSelf(t *testing.T) {
+	if _, err := os.Stat("/proc/self/stat"); err != nil {
+		t.Skip("no procfs")
+	}
+	// Burn CPU first: utime/stime are accounted in 10ms ticks, and a test
+	// binary that has done nothing genuinely reads 0 — which would make this
+	// assert nothing rather than assert the parse.
+	before := processCPUSeconds(os.Getpid())
+	deadline := time.Now().Add(120 * time.Millisecond)
+	var sink uint64
+	for time.Now().Before(deadline) {
+		for i := 0; i < 100000; i++ {
+			sink = sink*2654435761 + 1
+		}
+	}
+	_ = sink
+	after := processCPUSeconds(os.Getpid())
+	if after <= before {
+		t.Errorf("processCPUSeconds did not advance across ~120ms of CPU: %v -> %v", before, after)
+	}
+	if got := processCPUSeconds(-1); got != 0 {
+		t.Errorf("processCPUSeconds(-1) = %v, want 0 for a missing process", got)
+	}
+}
+
+// The first configuration is the baseline every other cell is divided by; if
+// it ever stopped being the un-instrumented one, every number in the table
+// would be wrong in a way nothing else would catch.
+func TestConfigsDecomposeTheCost(t *testing.T) {
+	// The table is only a decomposition if the three instrumented arms are
+	// "everything", "everything but heap" and "heap alone". Losing one of them
+	// turns the result back into a single unactionable number.
+	var all, noHeap, heapOnly bool
+	for _, c := range configs[1:] {
+		switch {
+		case c.disable == "":
+			all = true
+		case c.disable == "heap":
+			noHeap = true
+		default:
+			heapOnly = true
+			if containsWord(c.disable, "heap") {
+				t.Errorf("the heap-only arm disables heap: %q", c.disable)
+			}
+		}
+	}
+	if !all || !noHeap || !heapOnly {
+		t.Errorf("configs do not decompose the cost: all=%v noHeap=%v heapOnly=%v", all, noHeap, heapOnly)
+	}
+}
+
+func TestFirstConfigIsTheBaseline(t *testing.T) {
+	if configs[0].ptop {
+		t.Errorf("configs[0] = %+v, want the no-ptop baseline", configs[0])
+	}
+	for _, c := range configs[1:] {
+		if !c.ptop {
+			t.Errorf("config %q does not run ptop but is not the baseline", c.name)
+		}
+	}
+}
+
+func TestRateLabel(t *testing.T) {
+	cases := []struct {
+		pt   sweepPoint
+		cell cell
+		want string
+	}{
+		{sweepPoint{compute: 64, allocs: 0}, cell{allocsPerSec: 0}, "0 (no allocations)"},
+		{sweepPoint{compute: 64, allocs: 1}, cell{allocsPerSec: 14_400_000}, "14.4M/s"},
+		{sweepPoint{compute: 6400, allocs: 1}, cell{allocsPerSec: 110_000}, "110k/s"},
+		{sweepPoint{compute: 64000, allocs: 1}, cell{allocsPerSec: 900}, "900/s"},
+	}
+	for _, c := range cases {
+		if got := rateLabel(c.pt, c.cell); got != c.want {
+			t.Errorf("rateLabel(%+v) = %q, want %q", c.pt, got, c.want)
+		}
+	}
+}
+
+// containsWord reports whether a comma-separated list contains the exact item.
+func containsWord(list, item string) bool {
+	for _, part := range strings.Split(list, ",") {
+		if strings.TrimSpace(part) == item {
+			return true
+		}
+	}
+	return false
+}

--- a/bench/workload/clock_linux.go
+++ b/bench/workload/clock_linux.go
@@ -1,0 +1,20 @@
+//go:build linux
+
+package main
+
+import (
+	"syscall"
+	"unsafe"
+)
+
+// clockGettimeProcessCPU reads CLOCK_PROCESS_CPUTIME_ID — this process's total
+// CPU time across all threads, at nanosecond resolution.
+func clockGettimeProcessCPU(ts *syscall.Timespec) error {
+	// 2 is CLOCK_PROCESS_CPUTIME_ID; it is not exported by the syscall package.
+	const clockProcessCPUTimeID = 2
+	_, _, errno := syscall.Syscall(syscall.SYS_CLOCK_GETTIME, clockProcessCPUTimeID, uintptr(unsafe.Pointer(ts)), 0)
+	if errno != 0 {
+		return errno
+	}
+	return nil
+}

--- a/bench/workload/clock_other.go
+++ b/bench/workload/clock_other.go
@@ -1,0 +1,14 @@
+//go:build !linux
+
+package main
+
+import (
+	"errors"
+	"syscall"
+)
+
+// The benchmark only runs where eBPF does. Elsewhere this fails, and
+// selfCPUSeconds reports 0 rather than a wrong number.
+func clockGettimeProcessCPU(*syscall.Timespec) error {
+	return errors.New("CLOCK_PROCESS_CPUTIME_ID is Linux-only")
+}

--- a/bench/workload/main.go
+++ b/bench/workload/main.go
@@ -1,0 +1,167 @@
+// Command workload is the benchmark target: a program whose allocation rate is
+// a knob, so overhead can be measured as a FUNCTION of allocation rate rather
+// than as a single number.
+//
+// That shape is the point. ptop's heap lane hangs a uprobe on every allocation
+// — libc malloc/free, or runtime.mallocgc on Go — so its cost scales with how
+// often the target allocates, not with wall time. A process that allocates
+// twice as often pays twice as much. Any single "overhead is N%" figure is
+// therefore a claim about one workload, and quoting it without the workload is
+// what made the old number unfalsifiable.
+//
+// The work is deliberately mixed: a compute part that no probe can observe,
+// and an allocation part that every probe does. Sweeping the ratio separates
+// "ptop costs something" from "ptop costs something HERE".
+//
+// It measures fixed work in variable time, not the reverse: total time for a
+// fixed op count has far less run-to-run variance than ops completed in a
+// fixed window, and variance is the whole difficulty at these effect sizes.
+//
+// It reports CPU time as well as wall time, and the runner uses the CPU
+// figure. That is not a refinement, it is what makes the measurement possible
+// on a shared machine: wall time here varied 65x between identical runs,
+// because the benchmark host has two cores and ptop is competing for them. A
+// uprobe executes IN THE CONTEXT of the thread that tripped it, so its cost
+// lands in the target's own CPU accounting — which is immune to the target
+// being descheduled, and is precisely the quantity "how much does observing
+// this process cost the process" is asking about.
+//
+// ptop's own CPU is a different question, reported separately by the runner.
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+	"runtime"
+	"syscall"
+	"time"
+)
+
+type result struct {
+	Iterations    int     `json:"iterations"`
+	ComputeRounds int     `json:"compute_rounds"`
+	AllocsPerIt   int     `json:"allocs_per_iteration"`
+	AllocBytes    int     `json:"alloc_bytes"`
+	ElapsedSec    float64 `json:"elapsed_sec"`
+	CPUSec        float64 `json:"cpu_sec"`
+	OpsPerSec     float64 `json:"ops_per_sec"`
+	AllocsPerSec  float64 `json:"allocs_per_sec"`
+	Checksum      uint64  `json:"checksum"`
+	GoVersion     string  `json:"go_version"`
+	GOMAXPROCS    int     `json:"gomaxprocs"`
+}
+
+func main() {
+	iters := flag.Int("iterations", 2_000_000, "compute iterations to run")
+	allocsPerIt := flag.Int("allocs", 1, "heap allocations per iteration (0 = compute only)")
+	allocBytes := flag.Int("alloc-bytes", 128, "size of each allocation")
+	computeRounds := flag.Int("compute", 64, "unobservable mixing steps per iteration — the knob that sets how much OTHER work sits between allocations, and therefore the allocation RATE at a given throughput")
+	warmup := flag.Duration("warmup", 2*time.Second, "run un-timed for at least this long before the clock starts")
+	startFile := flag.String("start-file", "", "if set, warm up until this file exists before timing (the orchestrator creates it once ptop has attached)")
+	startTimeout := flag.Duration("start-timeout", 30*time.Second, "give up waiting for --start-file after this long")
+	flag.Parse()
+
+	fmt.Fprintf(os.Stderr, "workload pid %d\n", os.Getpid())
+
+	// The warm-up exists so the measurement does not include process start,
+	// the orchestrator attaching ptop, or the first GC cycles. Without it the
+	// attached runs pay for setup the baseline runs never do, which inflates
+	// the overhead by an amount that has nothing to do with the probe.
+	//
+	// --start-file makes that ordering a fact rather than a hope. A fixed
+	// warm-up is a bet that ptop finishes attaching inside it; the file makes
+	// the orchestrator say so. Every probe must be live before the first timed
+	// iteration, or the run silently measures a partly-instrumented process
+	// and reports it as instrumented.
+	deadline := time.Now().Add(*warmup)
+	giveUp := time.Now().Add(*startTimeout)
+	for {
+		run(50_000, *computeRounds, *allocsPerIt, *allocBytes)
+		if time.Now().Before(deadline) {
+			continue
+		}
+		if *startFile == "" {
+			break
+		}
+		if _, err := os.Stat(*startFile); err == nil {
+			break
+		}
+		if time.Now().After(giveUp) {
+			fmt.Fprintf(os.Stderr, "workload: --start-file %s never appeared\n", *startFile)
+			os.Exit(2)
+		}
+	}
+	runtime.GC()
+
+	cpuBefore := selfCPUSeconds()
+	start := time.Now()
+	sum := run(*iters, *computeRounds, *allocsPerIt, *allocBytes)
+	elapsed := time.Since(start)
+	cpu := selfCPUSeconds() - cpuBefore
+
+	totalAllocs := float64(*iters) * float64(*allocsPerIt)
+	res := result{
+		Iterations:    *iters,
+		ComputeRounds: *computeRounds,
+		AllocsPerIt:   *allocsPerIt,
+		AllocBytes:    *allocBytes,
+		ElapsedSec:    elapsed.Seconds(),
+		CPUSec:        cpu,
+		OpsPerSec:     float64(*iters) / elapsed.Seconds(),
+		AllocsPerSec:  totalAllocs / elapsed.Seconds(),
+		Checksum:      sum,
+		GoVersion:     runtime.Version(),
+		GOMAXPROCS:    runtime.GOMAXPROCS(0),
+	}
+	enc := json.NewEncoder(os.Stdout)
+	if err := enc.Encode(res); err != nil {
+		os.Exit(1)
+	}
+}
+
+// run does `iters` units of work, each with `rounds` mixing steps and
+// `allocs` heap allocations of `size` bytes. The checksum is returned and
+// printed so the compiler cannot eliminate any of it — a benchmark whose work
+// is optimized away measures the probe against nothing.
+//
+//go:noinline
+func run(iters, rounds, allocs, size int) uint64 {
+	var sum uint64
+	for i := 0; i < iters; i++ {
+		// Compute: unobservable to any uprobe, so it dilutes the allocation
+		// signal in a controlled way.
+		x := uint64(i)
+		for r := 0; r < rounds; r++ {
+			x = x*2654435761 + 1
+			x ^= x >> 13
+		}
+		sum += x
+
+		for a := 0; a < allocs; a++ {
+			b := make([]byte, size)
+			b[0] = byte(x)
+			b[size-1] = byte(a)
+			sum += uint64(b[0]) + uint64(b[size-1])
+		}
+	}
+	return sum
+}
+
+// selfCPUSeconds is this process's CPU time, the metric the runner compares.
+// It counts time actually spent executing — including the uprobe bodies, which
+// run on the tripping thread — and excludes time descheduled, which on a
+// contended host is most of the variance.
+//
+// CLOCK_PROCESS_CPUTIME_ID rather than getrusage: getrusage is tick-accounted
+// on kernels without precise CPU accounting, giving millisecond granularity.
+// The runner sizes work so the cheapest configuration is short, so the clock
+// has to resolve tens of milliseconds without quantising them into steps.
+func selfCPUSeconds() float64 {
+	var ts syscall.Timespec
+	if err := clockGettimeProcessCPU(&ts); err != nil {
+		return 0
+	}
+	return float64(ts.Sec) + float64(ts.Nsec)/1e9
+}

--- a/cmd/ptop/main.go
+++ b/cmd/ptop/main.go
@@ -44,6 +44,7 @@ func main() {
 	cgroupSpec := flag.String("cgroup", "", "Target a cgroup subtree instead of one PID — a cgroup path or a container id (requires --serve and eBPF)")
 	tls := flag.Bool("tls", false, "Capture TLS payload metadata (direction/fd/byte count) via libssl uprobes — OFF by default (#55)")
 	tlsBytes := flag.Int("tls-bytes", 0, "Also capture up to N bytes of PLAINTEXT per TLS call (implies --tls; 0=metadata only, max 4096). Sensitive: may include credentials/PII")
+	disableSpec := flag.String("disable", "", "Comma-separated subsystems NOT to collect, e.g. --disable heap. Known: "+collector.KnownSubsystems())
 	pprofAddr := flag.String("pprof", "", "Dev: serve net/http/pprof on this addr (e.g. localhost:6060) for profiling ptop itself")
 	showVer := flag.Bool("version", false, "Print version and exit")
 	flag.Parse()
@@ -51,6 +52,14 @@ func main() {
 	if *showVer {
 		fmt.Printf("ptop %s (commit %s, built %s)\n", version, commit, buildDate)
 		os.Exit(0)
+	}
+
+	// Rejected here, before anything attaches: a typo in --disable must not
+	// leave the subsystem running while the operator believes it is off.
+	disable, err := collector.ParseDisable(*disableSpec)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: --disable: %v\n", err)
+		os.Exit(1)
 	}
 
 	// One target, named one of two ways (#94). Everything that cannot hold for a
@@ -185,15 +194,15 @@ func main() {
 				fmt.Fprintln(os.Stderr, "error: --export needs a fixed target (--pid): an event export names one target in its header")
 				os.Exit(1)
 			}
-			runServeOnDemand(*serveAddr, *noEBPF, tlsEnabled, tlsCap, opts)
+			runServeOnDemand(*serveAddr, *noEBPF, tlsEnabled, tlsCap, disable, opts)
 			return
 		}
 
 		var tuiCfg *tui.Config
 		if *withTUI {
-			tuiCfg = &tui.Config{PID: *pid, FPS: *fps, NoEBPF: *noEBPF, TLS: tlsEnabled, TLSMaxBytes: tlsCap}
+			tuiCfg = &tui.Config{PID: *pid, FPS: *fps, NoEBPF: *noEBPF, TLS: tlsEnabled, TLSMaxBytes: tlsCap, Disable: disable}
 		}
-		runServe(*serveAddr, target, *noEBPF, tlsEnabled, tlsCap, opts, tuiCfg)
+		runServe(*serveAddr, target, *noEBPF, tlsEnabled, tlsCap, disable, opts, tuiCfg)
 		return
 	}
 
@@ -204,6 +213,7 @@ func main() {
 		Export:      *export,
 		TLS:         tlsEnabled,
 		TLSMaxBytes: tlsCap,
+		Disable:     disable,
 	})
 }
 
@@ -211,13 +221,14 @@ func main() {
 // until someone subscribes to a pid, and a target's collectors are released
 // when its last subscriber disconnects. Everything about a single target is
 // built exactly as runServe builds its one — same Set config, same resolver.
-func runServeOnDemand(addr string, noEBPF, tlsEnabled bool, tlsBytes int, opts serve.Options) {
+func runServeOnDemand(addr string, noEBPF, tlsEnabled bool, tlsBytes int, disable map[string]bool, opts serve.Options) {
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
 
 	factory := func(ctx context.Context, pid int) (*collector.Feed, serve.StackResolver, error) {
 		feed := collector.StartFeed(ctx, collector.SetConfig{
 			PID: pid, NoEBPF: noEBPF, TLS: tlsEnabled, TLSMaxBytes: tlsBytes,
+			Disable: disable,
 		})
 		return feed, stackResolverFor(feed.Set), nil
 	}
@@ -348,7 +359,7 @@ func checkPIDExists(pid int) error {
 // of collectors, watched live and streamed at once. The TUI then runs in the
 // foreground and quitting it shuts the server down; without it this is headless
 // as before.
-func runServe(addr string, target serve.Target, noEBPF, tlsEnabled bool, tlsBytes int, opts serve.Options, tuiCfg *tui.Config) {
+func runServe(addr string, target serve.Target, noEBPF, tlsEnabled bool, tlsBytes int, disable map[string]bool, opts serve.Options, tuiCfg *tui.Config) {
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
 
@@ -358,6 +369,7 @@ func runServe(addr string, target serve.Target, noEBPF, tlsEnabled bool, tlsByte
 	feed := collector.StartFeed(ctx, collector.SetConfig{
 		PID: target.PID, Cgroup: target.CgroupPath,
 		NoEBPF: noEBPF, TLS: tlsEnabled, TLSMaxBytes: tlsBytes,
+		Disable: disable,
 	})
 	defer feed.Stop()
 	set := feed.Set

--- a/internal/bpf/goalloc.go
+++ b/internal/bpf/goalloc.go
@@ -1,0 +1,286 @@
+//go:build linux && ebpf
+
+package bpf
+
+import (
+	"bytes"
+	_ "embed"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/cilium/ebpf"
+	"github.com/cilium/ebpf/link"
+	"github.com/cilium/ebpf/ringbuf"
+	"github.com/cilium/ebpf/rlimit"
+	"github.com/trentas/ptop/pkg/symbol"
+)
+
+//go:embed programs/goalloc.bpf.o
+var goallocBPFObj []byte
+
+// goallocStackDepth mirrors GOALLOC_STACK_DEPTH in programs/goalloc.bpf.c.
+const goallocStackDepth = 32
+
+// GoAllocFlagLarge mirrors GOALLOC_FLAG_LARGE: the allocation is ≥ 32KB, Go's
+// large-object boundary (maxSmallSize).
+const GoAllocFlagLarge uint32 = 1
+
+// goMallocSymbol is the single funnel every Go heap allocation passes through.
+// newobject, makeslice, growslice and reflect.unsafe_New all call it, and the
+// size-specialised fast paths are dispatched from inside its body — so one
+// entry probe sees every allocation exactly once.
+//
+// Its signature is load-bearing and the runtime says so: mallocgc is marked
+// //go:linkname with a "Do not remove or change the type signature" comment
+// (go.dev/issue/67401) because packages in the wild link against it. That makes
+// it a far more stable attach point than any of the internal fast paths, whose
+// names and arities have changed within the 1.2x series.
+const goMallocSymbol = "runtime.mallocgc"
+
+// GoAllocEvent is the 1:1 layout of struct go_alloc_event in
+// programs/goalloc.bpf.c. Fixed 32 bytes.
+type GoAllocEvent struct {
+	TsNs    uint64
+	Size    uint64
+	StackID int32
+	Flags   uint32
+	TGID    uint32
+	_       uint32
+}
+
+// GoAllocCallSiteRaw mirrors struct go_callsite_stat — the kernel-maintained
+// per-call-site aggregate. Everything here is monotonic: no counter decrements,
+// because no free is observable (see goalloc.bpf.c).
+type GoAllocCallSiteRaw struct {
+	AllocCount uint64
+	AllocBytes uint64
+	LargeCount uint64
+}
+
+// GoAllocTracer loads goalloc.bpf.o and attaches one uprobe to
+// runtime.mallocgc in the target's own executable, exposing the per-call-site
+// allocation aggregate and the event stream.
+//
+// It reports allocation rate and volume per site, never live bytes or
+// lifetime — see the header comment in goalloc.bpf.c for why that is the
+// honest surface rather than a missing feature.
+type GoAllocTracer struct {
+	coll        *ebpf.Collection
+	links       []link.Link
+	rb          *ringbuf.Reader
+	callsiteMap *ebpf.Map
+	stacksMap   *ebpf.Map
+}
+
+// ErrNotGo reports that the target's executable is not a Go image, so the Go
+// allocation lane does not apply. Callers fall back to the libc lane.
+var ErrNotGo = errors.New("target is not a Go binary")
+
+// OpenGoAllocTracer attaches the Go allocation probe to pid.
+//
+// Returns ErrNotGo when the target's executable carries no Go line table, so
+// the caller can fall back to the libc heap lane without treating it as a
+// failure.
+func OpenGoAllocTracer(pid int) (*GoAllocTracer, error) {
+	if pid <= 0 {
+		return nil, errors.New("invalid pid")
+	}
+	if err := rlimit.RemoveMemlock(); err != nil {
+		return nil, fmt.Errorf("rlimit: %w", err)
+	}
+
+	// /proc/<pid>/exe rather than the mapped path from /proc/<pid>/maps: the
+	// magic link resolves to the running image even when the target lives in
+	// another mount namespace (a container), and it cannot go stale the way a
+	// path can after an upgrade replaces the file on disk.
+	exePath := fmt.Sprintf("/proc/%d/exe", pid)
+	mallocOff, err := goMallocFileOffset(exePath)
+	if err != nil {
+		return nil, err
+	}
+
+	spec, err := ebpf.LoadCollectionSpecFromReader(bytes.NewReader(goallocBPFObj))
+	if err != nil {
+		return nil, fmt.Errorf("parse goalloc BPF object: %w", err)
+	}
+	coll, err := ebpf.NewCollection(spec)
+	if err != nil {
+		return nil, fmt.Errorf("load goalloc collection: %w", err)
+	}
+	t := &GoAllocTracer{coll: coll}
+
+	targetMap := coll.Maps["goalloc_target_pid"]
+	if targetMap == nil {
+		t.Close()
+		return nil, errors.New("goalloc_target_pid map missing")
+	}
+	tf, err := resolveTarget(TargetPID(pid))
+	if err != nil {
+		t.Close()
+		return nil, err
+	}
+	if err := writeTargetFilter(targetMap, tf); err != nil {
+		t.Close()
+		return nil, fmt.Errorf("set goalloc_target_pid: %w", err)
+	}
+
+	t.callsiteMap = coll.Maps["goalloc_callsite"]
+	t.stacksMap = coll.Maps["goalloc_stacks"]
+	if t.callsiteMap == nil || t.stacksMap == nil {
+		t.Close()
+		return nil, errors.New("goalloc maps missing")
+	}
+
+	prog := coll.Programs["uprobe_go_mallocgc"]
+	if prog == nil {
+		t.Close()
+		return nil, errors.New("program uprobe_go_mallocgc missing")
+	}
+
+	ex, err := link.OpenExecutable(exePath)
+	if err != nil {
+		t.Close()
+		return nil, fmt.Errorf("open executable %s: %w", exePath, err)
+	}
+	// Address is supplied rather than letting the library resolve the symbol:
+	// its resolver reads .symtab/.dynsym only, which a release build stripped
+	// with -ldflags="-s -w" does not have. goMallocFileOffset falls back to
+	// .gopclntab, which survives stripping.
+	l, err := ex.Uprobe(goMallocSymbol, prog, &link.UprobeOptions{
+		PID:     pid,
+		Address: mallocOff,
+	})
+	if err != nil {
+		t.Close()
+		return nil, fmt.Errorf("attach uprobe %s at file offset %#x: %w", goMallocSymbol, mallocOff, err)
+	}
+	t.links = append(t.links, l)
+
+	eventsMap := coll.Maps["goalloc_events"]
+	if eventsMap == nil {
+		t.Close()
+		return nil, errors.New("goalloc_events ringbuf missing")
+	}
+	rb, err := ringbuf.NewReader(eventsMap)
+	if err != nil {
+		t.Close()
+		return nil, fmt.Errorf("ringbuf reader: %w", err)
+	}
+	t.rb = rb
+
+	return t, nil
+}
+
+// goMallocFileOffset locates runtime.mallocgc in the ELF image at path and
+// returns its offset within the file, which is the form a uprobe takes.
+//
+// Returns ErrNotGo when the image has no Go line table.
+func goMallocFileOffset(path string) (uint64, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return 0, fmt.Errorf("open %s: %w", path, err)
+	}
+	defer f.Close()
+
+	mod, err := symbol.OpenModule(f, path)
+	if err != nil {
+		return 0, fmt.Errorf("parse %s: %w", path, err)
+	}
+	if !mod.IsGo() {
+		return 0, ErrNotGo
+	}
+	vaddr, _, ok := mod.FuncStart(goMallocSymbol)
+	if !ok {
+		// A Go image whose line table does not name mallocgc is either far
+		// older than the register ABI this probe reads, or so heavily
+		// rewritten that guessing would be worse than declining.
+		return 0, fmt.Errorf("%s not found in %s (unsupported Go build)", goMallocSymbol, path)
+	}
+	off, ok := mod.FileOffset(vaddr)
+	if !ok {
+		return 0, fmt.Errorf("%s at %#x is in no file-backed segment of %s", goMallocSymbol, vaddr, path)
+	}
+	return off, nil
+}
+
+// Next blocks until the next allocation event arrives. Returns io.EOF when the
+// tracer is closed.
+func (t *GoAllocTracer) Next() (GoAllocEvent, error) {
+	var ev GoAllocEvent
+	if t == nil || t.rb == nil {
+		return ev, errors.New("tracer not initialized")
+	}
+	rec, err := t.rb.Read()
+	if err != nil {
+		if errors.Is(err, ringbuf.ErrClosed) {
+			return ev, io.EOF
+		}
+		return ev, err
+	}
+	if len(rec.RawSample) < 32 {
+		return ev, fmt.Errorf("short event: %d bytes", len(rec.RawSample))
+	}
+	if err := binary.Read(bytes.NewReader(rec.RawSample), binary.LittleEndian, &ev); err != nil {
+		return ev, fmt.Errorf("decode event: %w", err)
+	}
+	return ev, nil
+}
+
+// CallSites snapshots goalloc_callsite: stack_id → running aggregate.
+func (t *GoAllocTracer) CallSites() (map[int32]GoAllocCallSiteRaw, error) {
+	if t == nil || t.callsiteMap == nil {
+		return nil, errors.New("tracer not initialized")
+	}
+	out := make(map[int32]GoAllocCallSiteRaw, 64)
+	var k int32
+	var v GoAllocCallSiteRaw
+	iter := t.callsiteMap.Iterate()
+	for iter.Next(&k, &v) {
+		out[k] = v
+	}
+	return out, iter.Err()
+}
+
+// ResolveStack returns the user-stack frames captured for stackID (leaf first),
+// trailing zero slots trimmed. A negative id (capture failed) yields nil.
+func (t *GoAllocTracer) ResolveStack(stackID int32) ([]uint64, error) {
+	if stackID < 0 {
+		return nil, nil
+	}
+	if t == nil || t.stacksMap == nil {
+		return nil, errors.New("tracer not initialized")
+	}
+	var frames [goallocStackDepth]uint64
+	if err := t.stacksMap.Lookup(uint32(stackID), &frames); err != nil {
+		return nil, err
+	}
+	n := len(frames)
+	for n > 0 && frames[n-1] == 0 {
+		n--
+	}
+	return frames[:n], nil
+}
+
+func (t *GoAllocTracer) Close() error {
+	if t == nil {
+		return nil
+	}
+	if t.rb != nil {
+		_ = t.rb.Close()
+		t.rb = nil
+	}
+	for _, l := range t.links {
+		_ = l.Close()
+	}
+	t.links = nil
+	if t.coll != nil {
+		t.coll.Close()
+		t.coll = nil
+		t.callsiteMap = nil
+		t.stacksMap = nil
+	}
+	return nil
+}

--- a/internal/bpf/programs/goalloc.bpf.c
+++ b/internal/bpf/programs/goalloc.bpf.c
@@ -1,0 +1,193 @@
+// SPDX-License-Identifier: GPL-2.0
+//
+// goalloc.bpf.c — Go heap allocation tracking for the target PID.
+//
+// Why this exists at all: heap.bpf.c hangs its uprobes on the libc allocator,
+// and the Go runtime does not route through it. `runtime.mallocgc` carves out
+// of per-P caches backed by mmap'd spans, so a Go target produces an entirely
+// EMPTY heap call-site axis under heap.bpf.c — not a sparse one, an empty one.
+// The axis is the only thing in the signature that carries func/file/line, so
+// for a Go fleet the whole behaviour → code link is missing.
+//
+// Probe: one uprobe on `runtime.mallocgc`, the single funnel every Go heap
+// allocation passes through. `newobject`, `makeslice`, `growslice` and
+// `reflect.unsafe_New` all call it, and the size-specialised fast paths
+// (mallocgcTiny / mallocgcSmallNoscan / mallocgcSmallScanHeader /
+// mallocgcLarge, plus the generated SC1..N variants) are dispatched from
+// INSIDE its body — so probing the entry catches all of them exactly once.
+//
+// ─── Entry only, and why that is a design choice, not a shortcut ────────────
+//
+// There is no uretprobe here and no free pairing, so this program reports
+// allocation RATE and VOLUME per call site, never live bytes or lifetime.
+// Two independent reasons, either one sufficient:
+//
+//  1. A uretprobe on a Go function is unsafe. The kernel implements it by
+//     patching the return address on the stack; the Go runtime copies and
+//     moves goroutine stacks when they grow, and walks them during GC and
+//     traceback. The patched address is not one it can relocate or recognise.
+//     Production Go tracers avoid uretprobes on runtime functions for exactly
+//     this reason.
+//  2. Nothing frees a Go allocation at a point a probe could observe. The GC
+//     sweeper reclaims spans in bulk, asynchronously, with no per-object call
+//     naming the object. Pairing alloc→free the way heap.bpf.c does has no
+//     counterpart to attach to.
+//
+// So the honest surface is alloc_count / alloc_bytes per site. The userspace
+// side marks live/lifetime UNMEASURED rather than publishing a zero, because a
+// zero would read as "nothing is live", which is false, and would diff against
+// a libc-lane baseline as a collapse to zero.
+//
+// Register ABI: Go uses ABIInternal (register-based) since Go 1.17, NOT the
+// SysV C ABI that BPF_KPROBE/PT_REGS_PARM1 assume. mallocgc's first argument
+// (size uintptr) arrives in RAX on x86-64 and in X0 on arm64. libbpf's
+// PT_REGS_RC macro names precisely those two registers (__PT_RC_REG is `rax`
+// / `regs[0]`), so it — not PT_REGS_PARM1 — is the portable way to read Go's
+// first argument. See GO_ARG0 below.
+//
+// Maps:
+//   goalloc_target_pid  ARRAY[1]     struct target_filter (Go loader writes it)
+//   goalloc_callsite    HASH         stack_id → aggregate (alloc count/bytes,
+//                                    large count), summed in the kernel so
+//                                    userspace iterates one entry per distinct
+//                                    call site instead of per event.
+//   goalloc_stacks      STACK_TRACE  user stacks captured at alloc time; the Go
+//                                    side resolves a stack_id to the
+//                                    application frame and symbolizes it
+//                                    through .gopclntab (func + file:line).
+//   goalloc_events      RINGBUF      per-allocation stream to userspace
+//                                    (struct go_alloc_event, fixed layout,
+//                                    LittleEndian).
+
+#include <linux/bpf.h>
+#include <linux/ptrace.h>
+#include <bpf/bpf_helpers.h>
+#include <bpf/bpf_tracing.h>
+#include "target.bpf.h"
+
+char LICENSE[] SEC("license") = "GPL";
+
+// GO_ARG0 reads the Go ABIInternal first argument register.
+//
+// PT_REGS_RC expands to the ABI's return register — `rax` on x86-64,
+// `regs[0]` on arm64 (see __PT_RC_REG in bpf_tracing.h). Those are the same
+// two registers Go's register ABI uses for the first integer argument, which
+// is why this aliases the return macro instead of PT_REGS_PARM1: PT_REGS_PARM1
+// would read `rdi` on x86-64, a register mallocgc does not use.
+#define GO_ARG0(ctx) PT_REGS_RC(ctx)
+
+// Go's large-object boundary: allocations above maxSmallSize (32KB) skip the
+// per-P cache and are served straight from the heap by mallocgcLarge. That is
+// the size boundary that means something in a Go process — deliberately NOT
+// glibc's 128KB M_MMAP_THRESHOLD, which describes a different allocator.
+#define GOALLOC_LARGE_THRESHOLD (32 * 1024)
+#define GOALLOC_FLAG_LARGE 1
+
+// User-stack depth captured per call site. Matches HEAP_STACK_DEPTH: enough to
+// step over the runtime's allocation frames and reach application code.
+#define GOALLOC_STACK_DEPTH 32
+
+// Per-call-site running aggregate. Mirrored by GoAllocCallSiteRaw in
+// internal/bpf/goalloc.go. All unsigned and monotonic — nothing decrements
+// these, because nothing observes a free.
+struct go_callsite_stat {
+    __u64 alloc_count;
+    __u64 alloc_bytes;
+    __u64 large_count;
+};
+
+// Event published to userspace via ring buffer. Fixed 32-byte layout, read
+// with binary.LittleEndian on the Go side — keep in sync with GoAllocEvent in
+// internal/bpf/goalloc.go.
+struct go_alloc_event {
+    __u64 ts_ns;
+    __u64 size;
+    __s32 stack_id; // alloc-site stack (<0 → unknown)
+    __u32 flags;    // bit0 = large (size ≥ GOALLOC_LARGE_THRESHOLD)
+    __u32 tgid;
+    __u32 _pad;
+};
+
+struct {
+    __uint(type, BPF_MAP_TYPE_ARRAY);
+    __type(key, __u32);
+    __type(value, struct target_filter);
+    __uint(max_entries, 1);
+} goalloc_target_pid SEC(".maps");
+
+struct {
+    __uint(type, BPF_MAP_TYPE_HASH);
+    __type(key, __s32);
+    __type(value, struct go_callsite_stat);
+    __uint(max_entries, 8192);
+} goalloc_callsite SEC(".maps");
+
+struct {
+    __uint(type, BPF_MAP_TYPE_STACK_TRACE);
+    __uint(key_size, sizeof(__u32));
+    __uint(value_size, GOALLOC_STACK_DEPTH * sizeof(__u64));
+    __uint(max_entries, 16384);
+} goalloc_stacks SEC(".maps");
+
+struct {
+    __uint(type, BPF_MAP_TYPE_RINGBUF);
+    __uint(max_entries, 1 << 20); // 1MB
+} goalloc_events SEC(".maps");
+
+static __always_inline int is_goalloc_target(void)
+{
+    return pid_is_target(&goalloc_target_pid);
+}
+
+static __always_inline struct go_callsite_stat *get_or_init_site(__s32 sid)
+{
+    struct go_callsite_stat *cs = bpf_map_lookup_elem(&goalloc_callsite, &sid);
+    if (cs)
+        return cs;
+    struct go_callsite_stat zero = {};
+    bpf_map_update_elem(&goalloc_callsite, &sid, &zero, BPF_NOEXIST);
+    return bpf_map_lookup_elem(&goalloc_callsite, &sid);
+}
+
+// uprobe_go_mallocgc fires on entry to runtime.mallocgc.
+//
+// mallocgc(size uintptr, typ *_type, needzero bool) unsafe.Pointer
+//          ^^^^ GO_ARG0
+//
+// A size of 0 is a real call (Go short-circuits it to &zerobase) but allocates
+// nothing, so it is dropped rather than inflating the site's alloc_count with
+// allocations that never happened.
+SEC("uprobe/runtime.mallocgc")
+int uprobe_go_mallocgc(struct pt_regs *ctx)
+{
+    if (!is_goalloc_target())
+        return 0;
+
+    __u64 size = (__u64)GO_ARG0(ctx);
+    if (size == 0)
+        return 0;
+
+    __s32 sid = (__s32)bpf_get_stackid(ctx, &goalloc_stacks, BPF_F_USER_STACK);
+    __u32 flags = (size >= GOALLOC_LARGE_THRESHOLD) ? GOALLOC_FLAG_LARGE : 0;
+
+    struct go_callsite_stat *cs = get_or_init_site(sid);
+    if (cs) {
+        __sync_fetch_and_add(&cs->alloc_count, 1);
+        __sync_fetch_and_add(&cs->alloc_bytes, size);
+        if (flags & GOALLOC_FLAG_LARGE)
+            __sync_fetch_and_add(&cs->large_count, 1);
+    }
+
+    struct go_alloc_event *e =
+        bpf_ringbuf_reserve(&goalloc_events, sizeof(*e), 0);
+    if (!e)
+        return 0;
+    e->ts_ns    = bpf_ktime_get_ns();
+    e->size     = size;
+    e->stack_id = sid;
+    e->flags    = flags;
+    e->tgid     = (__u32)(bpf_get_current_pid_tgid() >> 32);
+    e->_pad     = 0;
+    bpf_ringbuf_submit(e, 0);
+    return 0;
+}

--- a/internal/serve/mapper.go
+++ b/internal/serve/mapper.go
@@ -76,8 +76,11 @@ func toEvent(pid int, buildID string, v interface{}) *pb.Event {
 		ev.Payload = &pb.Event_Heap{Heap: &pb.HeapSnapshot{
 			LiveHeapBytes:      x.LiveHeapBytes,
 			AllocRate:          x.AllocRate,
+			AllocBytesRate:     x.AllocBytesRate,
 			SuspectedLeakBytes: x.SuspectedLeakBytes,
 			TopCallSites:       heapCallSites(x.TopCallSites),
+			Lane:               x.Lane,
+			LiveMeasured:       x.LiveMeasured,
 		}}
 
 	case collector.HeapEvent:
@@ -225,6 +228,7 @@ func heapCallSites(in []collector.HeapCallSite) []*pb.HeapCallSite {
 	for i, s := range in {
 		out[i] = &pb.HeapCallSite{
 			CallSite: s.CallSite, AddrHex: s.AddrHex, LiveBytes: s.LiveBytes,
+			AllocBytes: s.AllocBytes,
 			AllocCount: s.AllocCount, AvgLifetimeMs: s.AvgLifetimeMs, Suspected: s.Suspected,
 			Func: s.Func, File: s.File, Line: int32(s.Line), Module: s.Module, Offset: s.Offset,
 			StackId: taggedStackID(StackSourceHeap, s.StackID),

--- a/internal/serve/mapper_test.go
+++ b/internal/serve/mapper_test.go
@@ -173,3 +173,66 @@ func TestToEventTimestamp(t *testing.T) {
 		t.Errorf("ts = %d, expected >= %d (now)", ev.GetTsUnixNano(), before)
 	}
 }
+
+// The lane and live_measured flags are the wire contract that stops a consumer
+// from reading an unmeasured 0 as a measurement. A Witness diffing two deploys
+// would otherwise report the live heap collapsing to nothing the moment a
+// target switched lanes — so assert they survive the mapping, in both states.
+func TestMapHeapSnapshotCarriesLaneAndLiveMeasured(t *testing.T) {
+	cases := []struct {
+		name         string
+		in           collector.HeapStats
+		wantLane     string
+		wantMeasured bool
+		wantBytes    uint64
+	}{
+		{
+			name: "go lane reports live as unmeasured",
+			in: collector.HeapStats{
+				Lane: collector.HeapLaneGo, LiveMeasured: false,
+				AllocRate: 259943, AllocBytesRate: 2.08e8,
+				TopCallSites: []collector.HeapCallSite{{
+					CallSite: 0x82e50, Func: "main.allocBig",
+					File: "/build/main.go", Line: 22,
+					AllocBytes: 1 << 30, AllocCount: 15678,
+				}},
+				Timestamp: time.Unix(9, 0),
+			},
+			wantLane: "go", wantMeasured: false, wantBytes: 1 << 30,
+		},
+		{
+			name: "libc lane reports live as measured",
+			in: collector.HeapStats{
+				Lane: collector.HeapLaneLibc, LiveMeasured: true,
+				LiveHeapBytes: 4096, AllocRate: 12.5,
+				TopCallSites: []collector.HeapCallSite{{CallSite: 0xabc, LiveBytes: 4096}},
+				Timestamp:    time.Unix(9, 0),
+			},
+			wantLane: "libc", wantMeasured: true, wantBytes: 0,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			ev := toEvent(1, "", c.in)
+			if ev == nil {
+				t.Fatal("mapEvent returned nil")
+			}
+			h := ev.GetHeap()
+			if h == nil {
+				t.Fatal("payload is not a HeapSnapshot")
+			}
+			if h.GetLane() != c.wantLane {
+				t.Errorf("lane = %q, want %q", h.GetLane(), c.wantLane)
+			}
+			if h.GetLiveMeasured() != c.wantMeasured {
+				t.Errorf("live_measured = %v, want %v", h.GetLiveMeasured(), c.wantMeasured)
+			}
+			if h.GetAllocBytesRate() != c.in.AllocBytesRate {
+				t.Errorf("alloc_bytes_rate = %v, want %v", h.GetAllocBytesRate(), c.in.AllocBytesRate)
+			}
+			if got := h.GetTopCallSites()[0].GetAllocBytes(); got != c.wantBytes {
+				t.Errorf("call site alloc_bytes = %d, want %d", got, c.wantBytes)
+			}
+		})
+	}
+}

--- a/internal/tui/heap_view_test.go
+++ b/internal/tui/heap_view_test.go
@@ -93,3 +93,57 @@ func TestMemPanelClassicWithoutHeap(t *testing.T) {
 		t.Errorf("F1 overview missing the Memory panel entirely")
 	}
 }
+
+// On the Go lane nothing observes a free, so live bytes, leak suspicion and
+// lifetime are not measured. The panel must say so rather than render the
+// zeros as findings — "Live heap 0 B" and "Leaks ✓ none" would both be false
+// all-clears on a process that is allocating 200 MB/s.
+func TestHeapPanelDoesNotClaimLiveFiguresOnGoLane(t *testing.T) {
+	m := NewModel(Config{PID: 1, FPS: 5, NoEBPF: true})
+	hs := collector.HeapStats{
+		Lane:           collector.HeapLaneGo,
+		LiveMeasured:   false,
+		AllocRate:      259943,
+		AllocBytesRate: 208 << 20,
+		TopCallSites: []collector.HeapCallSite{
+			{CallSite: 0x82e50, AddrHex: "0x82e50", Func: "main.allocBig",
+				File: "/build/app/main.go", Line: 22, Module: "app",
+				AllocBytes: 1 << 30, AllocCount: 15678},
+		},
+	}
+	nm, _ := m.Update(HeapMsg(hs))
+	mm := nm.(Model)
+	mm.Width, mm.Height = 180, 50
+	mm.ActiveTab = TabOverview
+	out := mm.View()
+
+	for _, unwanted := range []string{"Live heap", "✓ none"} {
+		if strings.Contains(out, unwanted) {
+			t.Errorf("go lane presents %q, which it did not measure", unwanted)
+		}
+	}
+	for _, want := range []string{"Alloc bytes", "main.allocBig", "n/a on the go lane", "cumulative"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("go lane panel missing %q", want)
+		}
+	}
+
+	// The sparkline tracks the quantity shown beside it, not the unmeasured one.
+	if n := len(mm.HeapLiveHist); n == 0 || mm.HeapLiveHist[n-1] != hs.AllocBytesRate {
+		t.Errorf("HeapLiveHist = %v, want the alloc-byte rate %v", mm.HeapLiveHist, hs.AllocBytesRate)
+	}
+}
+
+// An empty snapshot has no lane yet. It must keep the live layout rather than
+// flipping into the go-lane presentation and back once the first sample lands.
+func TestHeapPanelEmptySnapshotKeepsLiveLayout(t *testing.T) {
+	if !heapLiveShown(collector.HeapStats{}) {
+		t.Error("empty HeapStats treated as the go lane")
+	}
+	if !heapLiveShown(collector.HeapStats{Lane: collector.HeapLaneLibc, LiveMeasured: true}) {
+		t.Error("libc lane treated as unmeasured")
+	}
+	if heapLiveShown(collector.HeapStats{Lane: collector.HeapLaneGo}) {
+		t.Error("go lane treated as measured")
+	}
+}

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -424,7 +424,14 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case HeapMsg:
 		m.HeapStats = collector.HeapStats(v)
-		m.HeapLiveHist = appendCapped(m.HeapLiveHist, float64(m.HeapStats.LiveHeapBytes), 60)
+		// The sparkline plots whatever the lane measures, matching the
+		// headline value beside it (see renderMemHeap): the live set where
+		// frees are observable, allocation throughput where they are not.
+		trend := float64(m.HeapStats.LiveHeapBytes)
+		if !heapLiveShown(m.HeapStats) {
+			trend = m.HeapStats.AllocBytesRate
+		}
+		m.HeapLiveHist = appendCapped(m.HeapLiveHist, trend, 60)
 		return m, m.waitBus()
 
 	case IOWaitMsg:

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -71,6 +71,8 @@ type Config struct {
 	// TLS payload capture (#55) — opt-in, stream/export-only (no live panel).
 	TLS         bool
 	TLSMaxBytes int
+	// Disable names subsystems not to collect; see collector.SetConfig.
+	Disable map[string]bool
 
 	// Feed, when set, is an already-running Set plus the Bus fanning it out
 	// (#71) — how `--serve --tui` drives the TUI and the gRPC stream from ONE
@@ -289,6 +291,7 @@ func NewModel(cfg Config) Model {
 		m.ownsFeed = true
 		m.feed = collector.StartFeed(ctx, collector.SetConfig{
 			PID: cfg.PID, NoEBPF: cfg.NoEBPF, TLS: cfg.TLS, TLSMaxBytes: cfg.TLSMaxBytes,
+			Disable: cfg.Disable,
 		})
 	}
 	m.collectors = m.feed.Set

--- a/internal/tui/panels.go
+++ b/internal/tui/panels.go
@@ -578,26 +578,52 @@ func renderMemMini(s collector.MemStats, heap collector.HeapStats, liveHist []fl
 	return renderMemHeap(s, heap, liveHist, w, h)
 }
 
+// heapLiveShown reports whether the live-set fields (live heap, per-site live
+// bytes, leak suspicion) should be presented as measurements.
+//
+// It keys on the lane rather than reading HeapStats.LiveMeasured directly so
+// that the EMPTY snapshot — before any sample has arrived, when Lane is "" —
+// keeps the live layout. Reading the bool there would flip the panel into "not
+// measured on the go lane" for a target whose lane is not yet known, and flip
+// it back a moment later.
+func heapLiveShown(heap collector.HeapStats) bool {
+	return heap.Lane != collector.HeapLaneGo
+}
+
 func renderMemHeap(s collector.MemStats, heap collector.HeapStats, liveHist []float64, w, h int) string {
 	lines := []string{
 		kvLine("RSS", fmt.Sprintf("%.0f MB", float64(s.RSSBytes)/(1<<20)), ColorCyan, w),
 		kvLine("Heap", fmt.Sprintf("%.0f MB", float64(s.HeapBytes)/(1<<20)), ColorPurple, w),
 	}
 
-	// Live heap: sparkline of the kernel live-set sum + its current value.
+	// The headline row is whichever quantity this lane actually measures: the
+	// live set where allocations are paired with their frees, allocation
+	// throughput where they are not. Rendering "Live heap 0 B" on the Go lane
+	// would be a measurement the collector never took, shown as a fact.
 	label := MutedStyle.Render("Live heap")
 	val := TealStyle.Render(fmtBytes(heap.LiveHeapBytes))
+	if !heapLiveShown(heap) {
+		label = MutedStyle.Render("Alloc bytes")
+		val = TealStyle.Render(fmtBytesPerSec(heap.AllocBytesRate))
+	}
 	sparkW := w - lipgloss.Width(label) - lipgloss.Width(val) - 2
 	if sparkW < 4 {
 		sparkW = 4
 	}
 	lines = append(lines, label+panelSp1+Sparkline(liveHist, sparkW, ColorTeal)+panelSp1+val)
 
-	// Real allocation rate from malloc/free events (not the /proc fault proxy).
+	// Real allocation rate from allocator events (not the /proc fault proxy).
 	lines = append(lines, kvLine("Alloc rate", fmtRate(heap.AllocRate), ColorGreen, w))
 
-	// Suspected-leak summary — live allocations older than the leak threshold.
-	if heap.SuspectedLeakBytes > 0 {
+	switch {
+	case !heapLiveShown(heap):
+		// Leak detection needs to know an allocation is still live, which
+		// needs a free to observe. The Go GC frees in bulk from the sweeper,
+		// naming no object — so this is not "no leaks", it is "no answer", and
+		// saying "✓ none" here would be a false all-clear.
+		lines = append(lines, kvGap(MutedStyle.Render("Leaks"),
+			MutedStyle.Render("— n/a on the go lane"), w))
+	case heap.SuspectedLeakBytes > 0:
 		nLeak := 0
 		for _, cs := range heap.TopCallSites {
 			if cs.Suspected {
@@ -606,34 +632,47 @@ func renderMemHeap(s collector.MemStats, heap collector.HeapStats, liveHist []fl
 		}
 		lines = append(lines, kvGap(MutedStyle.Render("Suspected leak"),
 			RedStyle.Render(fmt.Sprintf("⚠ %s · %d site%s", fmtBytes(heap.SuspectedLeakBytes), nLeak, plural(nLeak))), w))
-	} else {
+	default:
 		lines = append(lines, kvGap(MutedStyle.Render("Leaks"), GreenStyle.Render("✓ none"), w))
 	}
 
 	// Top allocating call sites — fill whatever vertical room is left (one line
 	// reserved for the header).
 	if avail := h - len(lines) - 1; avail >= 1 {
-		lines = append(lines, DimStyle.Render(truncate("─ top alloc sites ───────────────────────────────", w)))
+		header := "─ top alloc sites (live) ────────────────────────"
+		if !heapLiveShown(heap) {
+			header = "─ top alloc sites (cumulative) ──────────────────"
+		}
+		lines = append(lines, DimStyle.Render(truncate(header, w)))
 		sites := heap.TopCallSites
 		if len(sites) > avail {
 			sites = sites[:avail]
 		}
 		for _, cs := range sites {
-			lines = append(lines, renderHeapSiteRow(cs, w))
+			lines = append(lines, renderHeapSiteRow(cs, w, heapLiveShown(heap)))
 		}
 	}
 	return strings.Join(lines, "\n")
 }
 
 // renderHeapSiteRow lays out one call site: leak marker, symbolized site label
-// (#54), live bytes, and cumulative allocation count.
-func renderHeapSiteRow(cs collector.HeapCallSite, w int) string {
+// (#54), a byte figure, and the cumulative allocation count.
+//
+// The byte column is live bytes when the lane pairs frees, and bytes ever
+// allocated when it does not — the same reason the headline row switches. Both
+// answer "how much of the heap does this line account for"; only the second is
+// available on the Go lane.
+func renderHeapSiteRow(cs collector.HeapCallSite, w int, liveMeasured bool) string {
 	leak := MutedStyle.Render("  ")
 	if cs.Suspected {
 		leak = RedStyle.Render("⚠ ")
 	}
 	const bytesW, countW = 8, 7
-	bytesSpan := BrightStyle.Width(bytesW).Align(lipgloss.Right).Render(fmtBytes(cs.LiveBytes))
+	bytes := cs.LiveBytes
+	if !liveMeasured {
+		bytes = cs.AllocBytes
+	}
+	bytesSpan := BrightStyle.Width(bytesW).Align(lipgloss.Right).Render(fmtBytes(bytes))
 	countSpan := MutedStyle.Width(countW).Align(lipgloss.Right).Render(fmt.Sprintf("×%d", cs.AllocCount))
 
 	siteW := w - lipgloss.Width(leak) - bytesW - countW - 2

--- a/internal/tui/panels.go
+++ b/internal/tui/panels.go
@@ -686,7 +686,7 @@ func renderHeapSiteRow(cs collector.HeapCallSite, w int, liveMeasured bool) stri
 // heapSiteLabel renders a call site as the most specific form available:
 //
 //	func (file:line)  — resolved with a line table (Go)
-//	func              — resolved by symbol name only (C; no DWARF line info)
+//	func              — resolved by symbol name only (no line info in the module)
 //	module+0xoffset   — stripped module, located by load offset
 //	0x… / unknown     — stack walk failed or address fell outside every module
 func heapSiteLabel(cs collector.HeapCallSite) string {

--- a/internal/tui/view_threads.go
+++ b/internal/tui/view_threads.go
@@ -99,7 +99,7 @@ func renderLockLine(e collector.LockEntry, w int) string {
 // heapSiteLabel:
 //
 //	func (file:line)  — contention site resolved with a line table (Go)
-//	func              — resolved by symbol name only (C; no DWARF line info)
+//	func              — resolved by symbol name only (no line info in the module)
 //	module+0xoffset   — stripped module, located by load offset
 //	futex@0xADDR      — no site: stack walk failed, /proc mode, or cgroup mode
 //

--- a/pkg/collector/disable.go
+++ b/pkg/collector/disable.go
@@ -1,0 +1,91 @@
+package collector
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// Turning individual subsystems off.
+//
+// Every collector has a cost, and they are not remotely equal. A tracepoint
+// fires when the kernel reaches it; a uprobe on the allocator fires as often
+// as the target allocates, which on a busy service is orders of magnitude more
+// often than anything else ptop attaches. An operator watching a hot allocator
+// may well want everything EXCEPT that, and until now the only choices were
+// all of it or --no-ebpf.
+//
+// It is also what makes the overhead question answerable. "ptop costs N%" is
+// not a fact about ptop, it is a fact about ptop's most expensive probe on one
+// workload; measuring with and without a named subsystem is the only way to
+// say which part the N% actually is.
+
+// Subsystem names accepted by SetConfig.Disable. They match the names in
+// ptop's own warnings, so a message about a subsystem tells you what to pass
+// to switch it off.
+const (
+	SubsystemCPU       = "cpu"
+	SubsystemThreads   = "threads"
+	SubsystemMemory    = "memory"
+	SubsystemHeap      = "heap"
+	SubsystemSyscalls  = "syscalls"
+	SubsystemIO        = "io"
+	SubsystemNetwork   = "network"
+	SubsystemFutex     = "futex"
+	SubsystemSignals   = "signals"
+	SubsystemLifecycle = "lifecycle"
+	SubsystemSecurity  = "security"
+	SubsystemTLS       = "tls"
+	SubsystemFD        = "fd"
+)
+
+// knownSubsystems is the full set, used to reject a typo rather than let it
+// silently disable nothing — the failure mode of a misspelled --disable is a
+// benchmark that measures the wrong configuration and reports it confidently.
+var knownSubsystems = map[string]bool{
+	SubsystemCPU: true, SubsystemThreads: true, SubsystemMemory: true,
+	SubsystemHeap: true, SubsystemSyscalls: true, SubsystemIO: true,
+	SubsystemNetwork: true, SubsystemFutex: true, SubsystemSignals: true,
+	SubsystemLifecycle: true, SubsystemSecurity: true, SubsystemTLS: true,
+	SubsystemFD: true,
+}
+
+// ParseDisable turns a comma-separated subsystem list into the set
+// SetConfig.Disable takes. An empty or whitespace-only string yields nil.
+//
+// An unknown name is an error, not a warning: the whole point of the flag is
+// to be sure which probes are running.
+func ParseDisable(spec string) (map[string]bool, error) {
+	spec = strings.TrimSpace(spec)
+	if spec == "" {
+		return nil, nil
+	}
+	out := make(map[string]bool)
+	for _, raw := range strings.Split(spec, ",") {
+		name := strings.ToLower(strings.TrimSpace(raw))
+		if name == "" {
+			continue
+		}
+		if !knownSubsystems[name] {
+			return nil, fmt.Errorf("unknown subsystem %q; known: %s", name, KnownSubsystems())
+		}
+		out[name] = true
+	}
+	if len(out) == 0 {
+		return nil, nil
+	}
+	return out, nil
+}
+
+// KnownSubsystems lists every accepted name, sorted, for help text and errors.
+func KnownSubsystems() string {
+	names := make([]string, 0, len(knownSubsystems))
+	for n := range knownSubsystems {
+		names = append(names, n)
+	}
+	sort.Strings(names)
+	return strings.Join(names, ", ")
+}
+
+// off reports whether a subsystem was disabled.
+func (cfg SetConfig) off(name string) bool { return cfg.Disable[name] }

--- a/pkg/collector/disable_test.go
+++ b/pkg/collector/disable_test.go
@@ -1,0 +1,111 @@
+package collector
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestParseDisable(t *testing.T) {
+	cases := []struct {
+		in   string
+		want map[string]bool
+	}{
+		{"", nil},
+		{"   ", nil},
+		{",,", nil},
+		{"heap", map[string]bool{"heap": true}},
+		{"heap,tls", map[string]bool{"heap": true, "tls": true}},
+		{" HEAP , Tls ", map[string]bool{"heap": true, "tls": true}},
+		{"heap,heap", map[string]bool{"heap": true}},
+	}
+	for _, c := range cases {
+		got, err := ParseDisable(c.in)
+		if err != nil {
+			t.Errorf("ParseDisable(%q): %v", c.in, err)
+			continue
+		}
+		if !reflect.DeepEqual(got, c.want) {
+			t.Errorf("ParseDisable(%q) = %v, want %v", c.in, got, c.want)
+		}
+	}
+}
+
+// A typo must be an error. Accepting it would leave the subsystem running
+// while the operator believes it is off — and in the benchmark, would measure
+// one configuration and label it another.
+func TestParseDisableRejectsUnknown(t *testing.T) {
+	for _, bad := range []string{"heapp", "heap,tsl", "everything"} {
+		_, err := ParseDisable(bad)
+		if err == nil {
+			t.Errorf("ParseDisable(%q) accepted an unknown subsystem", bad)
+			continue
+		}
+		// The error must say what IS accepted; a bare rejection leaves the
+		// operator guessing at the spelling.
+		if !strings.Contains(err.Error(), "heap") {
+			t.Errorf("ParseDisable(%q) error does not list the known names: %v", bad, err)
+		}
+	}
+}
+
+func TestKnownSubsystemsIsSortedAndComplete(t *testing.T) {
+	got := KnownSubsystems()
+	for _, name := range []string{
+		SubsystemCPU, SubsystemThreads, SubsystemMemory, SubsystemHeap,
+		SubsystemSyscalls, SubsystemIO, SubsystemNetwork, SubsystemFutex,
+		SubsystemSignals, SubsystemLifecycle, SubsystemSecurity, SubsystemTLS,
+		SubsystemFD,
+	} {
+		if !strings.Contains(got, name) {
+			t.Errorf("KnownSubsystems() omits %q: %s", name, got)
+		}
+		if _, err := ParseDisable(name); err != nil {
+			t.Errorf("ParseDisable rejects its own constant %q: %v", name, err)
+		}
+	}
+	parts := strings.Split(got, ", ")
+	for i := 1; i < len(parts); i++ {
+		if parts[i-1] > parts[i] {
+			t.Errorf("KnownSubsystems() is not sorted: %s", got)
+			break
+		}
+	}
+}
+
+func TestSetConfigOff(t *testing.T) {
+	cfg := SetConfig{Disable: map[string]bool{SubsystemHeap: true}}
+	if !cfg.off(SubsystemHeap) {
+		t.Error("off(heap) = false with heap disabled")
+	}
+	if cfg.off(SubsystemCPU) {
+		t.Error("off(cpu) = true with only heap disabled")
+	}
+	// The nil map is the default and must mean "nothing disabled", not panic.
+	if (SetConfig{}).off(SubsystemHeap) {
+		t.Error("off() on a zero SetConfig disabled something")
+	}
+}
+
+// NewSet must honour Disable even in the no-eBPF path, where the /proc
+// collectors are the ones that would otherwise start.
+func TestNewSetHonoursDisableWithoutEBPF(t *testing.T) {
+	full := NewSet(SetConfig{PID: 1, NoEBPF: true})
+	defer full.Stop()
+
+	off := NewSet(SetConfig{PID: 1, NoEBPF: true, Disable: map[string]bool{
+		SubsystemCPU: true, SubsystemFD: true,
+	}})
+	defer off.Stop()
+
+	if off.CPUProc != nil || off.CPUEBPF != nil {
+		t.Error("cpu collector started despite --disable cpu")
+	}
+	if off.FD != nil {
+		t.Error("fd collector started despite --disable fd")
+	}
+	if len(off.Collectors()) >= len(full.Collectors()) {
+		t.Errorf("disabling subsystems did not reduce the collector set: %d vs %d",
+			len(off.Collectors()), len(full.Collectors()))
+	}
+}

--- a/pkg/collector/heap_agg.go
+++ b/pkg/collector/heap_agg.go
@@ -3,6 +3,7 @@ package collector
 import (
 	"fmt"
 	"sort"
+	"strings"
 
 	"github.com/trentas/ptop/internal/bpf"
 )
@@ -18,15 +19,24 @@ func isSuspectedLeak(ageNs, thresholdNs uint64) bool {
 	return ageNs > thresholdNs
 }
 
-// chooseTopCallSites returns the n call sites with the most live bytes,
-// descending. Ties break by AllocCount then CallSite for a deterministic order.
+// chooseTopCallSites returns the n most significant call sites, descending.
 // n < 0 keeps all.
+//
+// Live bytes rank first, then bytes ever allocated, then allocation count,
+// then the address for a deterministic tie-break. The AllocBytes tier is what
+// makes this work unchanged on the Go lane: there LiveBytes is 0 for every
+// site (nothing observes a free), so the comparison falls straight through to
+// allocation volume — the ranking that means something there — instead of
+// collapsing into an address sort.
 func chooseTopCallSites(sites []HeapCallSite, n int) []HeapCallSite {
 	out := make([]HeapCallSite, len(sites))
 	copy(out, sites)
 	sort.Slice(out, func(i, j int) bool {
 		if out[i].LiveBytes != out[j].LiveBytes {
 			return out[i].LiveBytes > out[j].LiveBytes
+		}
+		if out[i].AllocBytes != out[j].AllocBytes {
+			return out[i].AllocBytes > out[j].AllocBytes
 		}
 		if out[i].AllocCount != out[j].AllocCount {
 			return out[i].AllocCount > out[j].AllocCount
@@ -57,6 +67,50 @@ func pickAppFrame(frames []uint64, libcLo, libcHi uint64) uint64 {
 		return frames[0]
 	}
 	return 0
+}
+
+// pickGoAppFrame returns the first stack frame outside the Go runtime — the
+// application site that allocated. Frames are leaf-first (runtime.mallocgc and
+// its callers first); nameAt resolves a frame address to a function name, or
+// "" when it cannot.
+//
+// The libc lane can filter by address range because libc is a separate mapped
+// module. On the Go lane the runtime and the application are the SAME module,
+// linked into one binary, so there is no range to exclude — the only thing
+// separating them is the package a function belongs to. Hence a name filter.
+//
+// An unresolvable frame ("") is treated as application code rather than
+// skipped: on a stripped module every name is empty, and skipping them all
+// would walk the whole stack and return the leaf — reporting runtime.mallocgc
+// itself as the call site, which is the one answer that is never useful.
+//
+// Falls back to the leaf frame when every frame is runtime code, and to 0 when
+// there are no frames.
+func pickGoAppFrame(frames []uint64, nameAt func(uint64) string) uint64 {
+	for _, f := range frames {
+		if f == 0 {
+			continue
+		}
+		if isGoRuntimeFunc(nameAt(f)) {
+			continue // still inside the allocator — keep walking toward the caller
+		}
+		return f
+	}
+	if len(frames) > 0 {
+		return frames[0]
+	}
+	return 0
+}
+
+// isGoRuntimeFunc reports whether a symbolized function name belongs to the Go
+// runtime rather than to code someone wrote.
+//
+// "internal/runtime/" covers the packages the runtime was split into (maps,
+// atomic, sys, math), which allocate on the runtime's behalf and would
+// otherwise be reported as the application call site for every map growth.
+func isGoRuntimeFunc(name string) bool {
+	return strings.HasPrefix(name, "runtime.") ||
+		strings.HasPrefix(name, "internal/runtime/")
 }
 
 // heapAddrHex formats a call-site address for display; 0 means the stack walk

--- a/pkg/collector/heap_agg_test.go
+++ b/pkg/collector/heap_agg_test.go
@@ -102,3 +102,104 @@ func TestHeapOpName(t *testing.T) {
 		}
 	}
 }
+
+// On the Go lane every site has LiveBytes 0 (nothing observes a free), so the
+// ranking has to fall through to allocation volume. Without the AllocBytes
+// tier this degenerates into a sort by address and the "top call sites" list
+// stops meaning anything for an entire runtime family.
+func TestChooseTopCallSitesRanksByAllocBytesWhenLiveIsUnmeasured(t *testing.T) {
+	sites := []HeapCallSite{
+		{CallSite: 0x40, AllocBytes: 1_000, AllocCount: 50},
+		{CallSite: 0x10, AllocBytes: 9_000, AllocCount: 3},
+		{CallSite: 0x30, AllocBytes: 4_000, AllocCount: 7},
+		{CallSite: 0x20, AllocBytes: 4_000, AllocCount: 90}, // ties bytes, more allocs
+	}
+	got := chooseTopCallSites(sites, 3)
+	wantOrder := []uint64{0x10, 0x20, 0x30}
+	for i, cs := range wantOrder {
+		if got[i].CallSite != cs {
+			t.Errorf("position %d: CallSite = %#x, want %#x (order: %+v)", i, got[i].CallSite, cs, got)
+		}
+	}
+}
+
+// Live bytes still outrank allocation volume where both are measured — the new
+// tier must not reorder the libc lane.
+func TestChooseTopCallSitesPrefersLiveBytesOverAllocBytes(t *testing.T) {
+	sites := []HeapCallSite{
+		{CallSite: 1, LiveBytes: 10, AllocBytes: 1_000_000},
+		{CallSite: 2, LiveBytes: 20, AllocBytes: 1},
+	}
+	if got := chooseTopCallSites(sites, 1); got[0].CallSite != 2 {
+		t.Errorf("CallSite = %d, want 2 (live bytes rank first)", got[0].CallSite)
+	}
+}
+
+func TestPickGoAppFrame(t *testing.T) {
+	names := map[uint64]string{
+		0x10: "runtime.mallocgc",
+		0x20: "runtime.newobject",
+		0x30: "internal/runtime/maps.(*Map).Put",
+		0x40: "main.handleRequest",
+		0x50: "main.main",
+	}
+	nameAt := func(a uint64) string { return names[a] }
+
+	cases := []struct {
+		name   string
+		frames []uint64
+		want   uint64
+	}{
+		{"skips the allocator and its runtime callers",
+			[]uint64{0x10, 0x20, 0x40, 0x50}, 0x40},
+		{"skips internal/runtime packages too",
+			[]uint64{0x10, 0x30, 0x40}, 0x40},
+		{"ignores zero padding in the captured stack",
+			[]uint64{0, 0x10, 0, 0x40}, 0x40},
+		{"all-runtime stack falls back to the leaf",
+			[]uint64{0x10, 0x20}, 0x10},
+		{"empty stack yields 0",
+			nil, 0},
+		// A stripped module resolves to no name at all. Treating "" as runtime
+		// would skip every frame and hand back the leaf — reporting
+		// runtime.mallocgc as the call site of every allocation in the process.
+		{"unresolvable frames count as application code",
+			[]uint64{0x10, 0x99}, 0x99},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := pickGoAppFrame(c.frames, nameAt); got != c.want {
+				t.Errorf("pickGoAppFrame = %#x, want %#x", got, c.want)
+			}
+		})
+	}
+}
+
+func TestIsGoRuntimeFunc(t *testing.T) {
+	runtimeNames := []string{
+		"runtime.mallocgc",
+		"runtime.newobject",
+		"internal/runtime/maps.(*Map).Put",
+	}
+	for _, n := range runtimeNames {
+		if !isGoRuntimeFunc(n) {
+			t.Errorf("isGoRuntimeFunc(%q) = false, want true", n)
+		}
+	}
+	// Application and library frames are the answer we want, not noise to
+	// skip: the first non-runtime frame IS the call site, even when it is in a
+	// dependency rather than in main.
+	appNames := []string{
+		"main.handleRequest",
+		"fmt.Sprintf",
+		"github.com/x/y.(*Client).Do",
+		"", // unresolvable
+		// Not the runtime: a user package that merely starts with the letters.
+		"runtimecheck.Verify",
+	}
+	for _, n := range appNames {
+		if isGoRuntimeFunc(n) {
+			t.Errorf("isGoRuntimeFunc(%q) = true, want false", n)
+		}
+	}
+}

--- a/pkg/collector/heap_ebpf.go
+++ b/pkg/collector/heap_ebpf.go
@@ -3,6 +3,7 @@
 package collector
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -14,29 +15,46 @@ import (
 	"github.com/trentas/ptop/pkg/symbol"
 )
 
-// HeapEBPFCollector tracks libc heap allocations via the uprobe-based eBPF
-// tracer (#53). Two goroutines:
+// HeapEBPFCollector tracks heap allocations via uprobes (#53). Two goroutines:
 //
-//   - readLoop drains the per-event ring buffer, forwarding each alloc/free as
-//     a HeapEvent (best-effort, dropped under backpressure like every other
+//   - readLoop drains the per-event ring buffer, forwarding each event as a
+//     HeapEvent (best-effort, dropped under backpressure like every other
 //     collector) and counting allocations for the rate.
 //   - publishLoop, every 500ms, reads the kernel's per-call-site aggregate and
-//     runs a bounded leak scan over the live set, publishing a HeapStats
-//     snapshot.
+//     publishes a HeapStats snapshot.
 //
-// Live-heap and leak figures come from the kernel's LRU-bounded live set, so
-// they UNDERCOUNT on alloc-heavy targets (documented in heap.bpf.c) — never
-// presented as exact.
+// ─── Two lanes, chosen by what the target actually allocates through ────────
+//
+// HeapLaneLibc attaches to malloc/calloc/realloc/free and pairs each
+// allocation with its free, so it measures live bytes and lifetimes. Those
+// figures come from the kernel's LRU-bounded live set, so they UNDERCOUNT on
+// alloc-heavy targets (documented in heap.bpf.c) — never presented as exact.
+//
+// HeapLaneGo attaches to runtime.mallocgc. A Go process does not allocate
+// through libc at all, so on the libc lane its call-site axis comes back
+// EMPTY — and that axis is the only part of the signature carrying
+// func/file/line, so an entire runtime family loses the behaviour → code link.
+// The Go lane measures allocation rate and volume per site and reports
+// LiveMeasured=false, because nothing frees at a point a probe can observe
+// (see goalloc.bpf.c).
+//
+// The Go lane is preferred whenever the target is a Go image, including a cgo
+// build with libc mapped: the Go allocator is where a Go program's allocations
+// overwhelmingly are, and running both lanes at once would pay for two probe
+// sets to produce one axis with two incompatible definitions of "live".
 type HeapEBPFCollector struct {
-	tracer *bpf.HeapTracer
-	sym    *symbol.Symbolizer // nil if /proc maps couldn't be parsed
-	ch     chan interface{}
-	stop   chan struct{}
-	pid    int
+	tracer   *bpf.HeapTracer    // libc lane; nil on the Go lane
+	goTracer *bpf.GoAllocTracer // Go lane; nil on the libc lane
+	lane     string             // HeapLaneLibc | HeapLaneGo
+	sym      *symbol.Symbolizer // nil if /proc maps couldn't be parsed
+	ch       chan interface{}
+	stop     chan struct{}
+	pid      int
 
 	leakThreshold time.Duration
 
 	allocCount uint64 // atomic; allocations since the last publish (rate)
+	allocBytes uint64 // atomic; bytes allocated since the last publish (rate)
 
 	mu         sync.Mutex
 	siteCache  map[int32]heapSite       // stack_id → resolved app call-site (cache)
@@ -69,11 +87,23 @@ func NewHeapEBPFCollector() *HeapEBPFCollector {
 }
 
 func (c *HeapEBPFCollector) Start(pid int) error {
-	tracer, err := bpf.OpenHeapTracer(pid)
-	if err != nil {
-		return fmt.Errorf("heap eBPF: %w", err)
+	// Try the Go lane first and fall back on ErrNotGo. The reverse order does
+	// not work: a Go binary built with cgo HAS a libc mapped, so the libc
+	// tracer attaches happily and then reports an empty axis forever — a
+	// silent wrong answer, which is worse than a loud missing one.
+	goTracer, err := bpf.OpenGoAllocTracer(pid)
+	switch {
+	case err == nil:
+		c.goTracer, c.lane = goTracer, HeapLaneGo
+	case errors.Is(err, bpf.ErrNotGo):
+		tracer, lerr := bpf.OpenHeapTracer(pid)
+		if lerr != nil {
+			return fmt.Errorf("heap eBPF: %w", lerr)
+		}
+		c.tracer, c.lane = tracer, HeapLaneLibc
+	default:
+		return fmt.Errorf("heap eBPF (go lane): %w", err)
 	}
-	c.tracer = tracer
 	c.pid = pid
 	// Symbolize call sites best-effort: without /proc maps (or off Linux) the
 	// sites degrade to hex, exactly as before #54 — never fail Start over it.
@@ -93,6 +123,10 @@ func (c *HeapEBPFCollector) Stop() {
 		_ = c.tracer.Close()
 		c.tracer = nil
 	}
+	if c.goTracer != nil {
+		_ = c.goTracer.Close()
+		c.goTracer = nil
+	}
 	if c.sym != nil {
 		_ = c.sym.Close()
 		c.sym = nil
@@ -102,6 +136,14 @@ func (c *HeapEBPFCollector) Stop() {
 func (c *HeapEBPFCollector) Subscribe() <-chan interface{} { return c.ch }
 
 func (c *HeapEBPFCollector) readLoop() {
+	if c.lane == HeapLaneGo {
+		c.readLoopGo()
+		return
+	}
+	c.readLoopLibc()
+}
+
+func (c *HeapEBPFCollector) readLoopLibc() {
 	for {
 		ev, err := c.tracer.Next()
 		if err != nil {
@@ -112,6 +154,7 @@ func (c *HeapEBPFCollector) readLoop() {
 		}
 		if ev.Op != bpf.HeapOpFree {
 			atomic.AddUint64(&c.allocCount, 1)
+			atomic.AddUint64(&c.allocBytes, ev.Size)
 		}
 		he := HeapEvent{
 			Op:         heapOpName(ev.Op),
@@ -121,6 +164,35 @@ func (c *HeapEBPFCollector) readLoop() {
 			CallSite:   c.resolveSite(ev.StackID).addr,
 			StackID:    ev.StackID,
 			Large:      ev.Flags&bpf.HeapFlagLarge != 0,
+		}
+		select {
+		case c.ch <- he:
+		default:
+		}
+	}
+}
+
+// readLoopGo drains the Go allocation ring buffer. Every event is an
+// allocation — the lane emits no free, and Addr stays 0 because the entry
+// probe runs before mallocgc has an address to return (see goalloc.bpf.c on
+// why there is no return probe).
+func (c *HeapEBPFCollector) readLoopGo() {
+	for {
+		ev, err := c.goTracer.Next()
+		if err != nil {
+			if err == io.EOF {
+				return
+			}
+			continue // transient; keep reading
+		}
+		atomic.AddUint64(&c.allocCount, 1)
+		atomic.AddUint64(&c.allocBytes, ev.Size)
+		he := HeapEvent{
+			Op:       "alloc",
+			Size:     ev.Size,
+			CallSite: c.resolveSite(ev.StackID).addr,
+			StackID:  ev.StackID,
+			Large:    ev.Flags&bpf.GoAllocFlagLarge != 0,
 		}
 		select {
 		case c.ch <- he:
@@ -143,12 +215,21 @@ func (c *HeapEBPFCollector) resolveSite(stackID int32) heapSite {
 	}
 	c.mu.Unlock()
 
-	frames, err := c.tracer.ResolveStack(stackID)
+	frames, err := c.stackFrames(stackID)
 	if err != nil {
 		return heapSite{}
 	}
-	lo, hi := c.tracer.LibcRange()
-	site := heapSite{addr: pickAppFrame(frames, lo, hi)}
+
+	var addr uint64
+	if c.lane == HeapLaneGo {
+		// The runtime and the application are one module here, so the app
+		// frame is found by function name, not by address range.
+		addr = pickGoAppFrame(frames, c.funcNameAt)
+	} else {
+		lo, hi := c.tracer.LibcRange()
+		addr = pickAppFrame(frames, lo, hi)
+	}
+	site := heapSite{addr: addr}
 	if c.sym != nil && site.addr != 0 {
 		site.frame = c.sym.Symbolize(site.addr)
 	}
@@ -159,6 +240,25 @@ func (c *HeapEBPFCollector) resolveSite(stackID int32) heapSite {
 	return site
 }
 
+// stackFrames reads the raw leaf-first stack for stackID from whichever lane
+// is active.
+func (c *HeapEBPFCollector) stackFrames(stackID int32) ([]uint64, error) {
+	if c.lane == HeapLaneGo {
+		return c.goTracer.ResolveStack(stackID)
+	}
+	return c.tracer.ResolveStack(stackID)
+}
+
+// funcNameAt resolves a frame address to its function name, or "" when there
+// is no symbolizer or the address does not resolve. Used to tell Go runtime
+// frames from application frames.
+func (c *HeapEBPFCollector) funcNameAt(addr uint64) string {
+	if c.sym == nil {
+		return ""
+	}
+	return c.sym.Symbolize(addr).Func
+}
+
 // ResolveStack returns the full leaf-first symbolized frames of a captured
 // stack id, or ok=false when the id is unknown (negative sentinel, evicted from
 // the kernel map, or empty). Results are cached (stacks are immutable for the
@@ -166,7 +266,7 @@ func (c *HeapEBPFCollector) resolveSite(stackID int32) heapSite {
 // from gRPC handlers while readLoop/publishLoop run. Implements the resolver the
 // EventStreamService.ResolveStack RPC is built on (#54).
 func (c *HeapEBPFCollector) ResolveStack(stackID uint64) ([]symbol.Frame, bool) {
-	if c.tracer == nil || int32(stackID) < 0 {
+	if (c.tracer == nil && c.goTracer == nil) || int32(stackID) < 0 {
 		return nil, false
 	}
 	sid := int32(stackID)
@@ -177,7 +277,7 @@ func (c *HeapEBPFCollector) ResolveStack(stackID uint64) ([]symbol.Frame, bool) 
 	}
 	c.mu.Unlock()
 
-	addrs, err := c.tracer.ResolveStack(sid)
+	addrs, err := c.stackFrames(sid)
 	if err != nil || len(addrs) == 0 {
 		return nil, false
 	}
@@ -225,6 +325,53 @@ func (c *HeapEBPFCollector) publishLoop() {
 }
 
 func (c *HeapEBPFCollector) snapshot() (HeapStats, error) {
+	if c.lane == HeapLaneGo {
+		return c.snapshotGo()
+	}
+	return c.snapshotLibc()
+}
+
+// snapshotGo builds a HeapStats from the Go allocation aggregate. It fills
+// only what mallocgc can tell us — count and bytes per site — and leaves
+// LiveHeapBytes, LiveBytes, AvgLifetimeMs, SuspectedLeakBytes and Suspected at
+// their zero values, flagged by LiveMeasured=false so a consumer cannot
+// mistake "not measured" for "measured, and zero".
+func (c *HeapEBPFCollector) snapshotGo() (HeapStats, error) {
+	agg, err := c.goTracer.CallSites()
+	if err != nil {
+		return HeapStats{}, err
+	}
+
+	sites := make([]HeapCallSite, 0, len(agg))
+	for sid, raw := range agg {
+		site := c.resolveSite(sid)
+		sites = append(sites, HeapCallSite{
+			CallSite:   site.addr,
+			AddrHex:    heapAddrHex(site.addr),
+			Func:       site.frame.Func,
+			File:       site.frame.File,
+			Line:       site.frame.Line,
+			Module:     site.frame.Module,
+			Offset:     site.frame.Offset,
+			StackID:    sid,
+			AllocBytes: raw.AllocBytes,
+			AllocCount: raw.AllocCount,
+		})
+	}
+
+	now := time.Now()
+	allocRate, byteRate := c.rates(now)
+	return HeapStats{
+		Timestamp:      now,
+		AllocRate:      allocRate,
+		AllocBytesRate: byteRate,
+		TopCallSites:   chooseTopCallSites(sites, heapTopCallSites),
+		Lane:           HeapLaneGo,
+		LiveMeasured:   false,
+	}, nil
+}
+
+func (c *HeapEBPFCollector) snapshotLibc() (HeapStats, error) {
 	live, err := c.tracer.LiveCallSites()
 	if err != nil {
 		return HeapStats{}, err
@@ -267,27 +414,46 @@ func (c *HeapEBPFCollector) snapshot() (HeapStats, error) {
 			StackID:       sid,
 			LiveBytes:     uint64(lb),
 			AllocCount:    raw.AllocCount,
+			AllocBytes:    0, // the libc aggregate counts live bytes, not cumulative ones
 			AvgLifetimeMs: avgLifeMs,
 			Suspected:     leakBytes[sid] > 0,
 		})
 	}
 
 	now := time.Now()
-	var rate float64
-	if !c.lastAt.IsZero() {
-		if elapsed := now.Sub(c.lastAt).Seconds(); elapsed > 0 {
-			rate = float64(atomic.SwapUint64(&c.allocCount, 0)) / elapsed
-		}
-	} else {
-		atomic.StoreUint64(&c.allocCount, 0) // discard the warm-up interval
-	}
-	c.lastAt = now
+	rate, byteRate := c.rates(now)
 
 	return HeapStats{
 		Timestamp:          now,
 		LiveHeapBytes:      liveTotal,
 		AllocRate:          rate,
+		AllocBytesRate:     byteRate,
 		TopCallSites:       chooseTopCallSites(sites, heapTopCallSites),
 		SuspectedLeakBytes: suspectedTotal,
+		Lane:               HeapLaneLibc,
+		LiveMeasured:       true,
 	}, nil
+}
+
+// rates converts the counters readLoop has been accumulating into per-second
+// figures and resets them. The first interval is discarded rather than
+// reported: it spans process attach, so it would divide a partial count by a
+// full interval and understate the rate at exactly the moment someone is
+// watching the tool start up.
+//
+// publishLoop-only (c.lastAt is not guarded), matching the libc lane's
+// original contract.
+func (c *HeapEBPFCollector) rates(now time.Time) (allocRate, byteRate float64) {
+	if c.lastAt.IsZero() {
+		atomic.StoreUint64(&c.allocCount, 0)
+		atomic.StoreUint64(&c.allocBytes, 0)
+		c.lastAt = now
+		return 0, 0
+	}
+	if elapsed := now.Sub(c.lastAt).Seconds(); elapsed > 0 {
+		allocRate = float64(atomic.SwapUint64(&c.allocCount, 0)) / elapsed
+		byteRate = float64(atomic.SwapUint64(&c.allocBytes, 0)) / elapsed
+	}
+	c.lastAt = now
+	return allocRate, byteRate
 }

--- a/pkg/collector/set.go
+++ b/pkg/collector/set.go
@@ -22,6 +22,12 @@ type SetConfig struct {
 	// (0 = metadata only: direction/fd/byte count, no payload bytes).
 	TLS         bool
 	TLSMaxBytes int
+
+	// Disable names subsystems to skip entirely, keyed by the constants in
+	// disable.go. Nil starts everything the platform supports. See disable.go
+	// for why this exists — chiefly that probe costs differ by orders of
+	// magnitude, and the expensive one is nameable.
+	Disable map[string]bool
 }
 
 // Sources records where each subsystem's real data came from. The value is
@@ -89,14 +95,14 @@ func NewSet(cfg SetConfig) *Set {
 		return s
 	}
 
-	if c := NewFDCollector(); c.Start(cfg.PID) == nil {
+	if c := NewFDCollector(); !cfg.off(SubsystemFD) && c.Start(cfg.PID) == nil {
 		s.FD = c
 	} else if !cfg.NoEBPF {
 		fmt.Fprintf(os.Stderr, "warning: FD collector unavailable\n")
 	}
 
 	// CPU: eBPF perf_event @ 100Hz/CPU first, /proc polling as fallback.
-	if !cfg.NoEBPF {
+	if !cfg.NoEBPF && !cfg.off(SubsystemCPU) {
 		c := NewCPUEBPFCollector()
 		if err := c.Start(cfg.PID); err == nil {
 			s.CPUEBPF = c
@@ -105,7 +111,7 @@ func NewSet(cfg SetConfig) *Set {
 			warnEBPFFailure("cpu", err)
 		}
 	}
-	if s.CPUEBPF == nil {
+	if s.CPUEBPF == nil && !cfg.off(SubsystemCPU) {
 		if c := NewCPUCollector(); c.Start(cfg.PID) == nil {
 			s.CPUProc = c
 			s.Sources.CPU = SourceProc
@@ -114,7 +120,7 @@ func NewSet(cfg SetConfig) *Set {
 
 	// Threads: eBPF (sched_switch → real-time CPU% + ctx switches) preferred,
 	// /proc as fallback.
-	if !cfg.NoEBPF {
+	if !cfg.NoEBPF && !cfg.off(SubsystemThreads) {
 		c := NewThreadsEBPFCollector()
 		if err := c.Start(cfg.PID); err == nil {
 			s.ThreadsEBPF = c
@@ -165,96 +171,99 @@ func NewSet(cfg SetConfig) *Set {
 
 	// eBPF-only subsystems: only with -tags=ebpf, kernel >= 5.8 and
 	// CAP_BPF/CAP_PERFMON. No /proc fallback — they stay mock otherwise.
+	//
+	// Each goes through startEBPF so "disabled" and "failed to attach" are
+	// handled the same way everywhere: a disabled subsystem is silent (it was
+	// asked for), a failed one warns.
 	if !cfg.NoEBPF {
+		startEBPF := func(name string, c ebpfStarter, onOK func()) {
+			if cfg.off(name) {
+				return
+			}
+			if err := c.Start(cfg.PID); err != nil {
+				warnEBPFFailure(name, err)
+				return
+			}
+			onOK()
+		}
+
 		c := NewSyscallsEBPFCollector()
-		if err := c.Start(cfg.PID); err == nil {
+		startEBPF(SubsystemSyscalls, c, func() {
 			s.SyscallsEBPF = c
 			s.Sources.Syscalls = "eBPF"
-		} else {
-			warnEBPFFailure("syscalls", err)
-		}
+		})
 
 		c2 := NewIOEBPFCollector()
-		if err := c2.Start(cfg.PID); err == nil {
+		startEBPF(SubsystemIO, c2, func() {
 			s.IOEBPF = c2
 			s.Sources.IOFiles = "eBPF"
-		} else {
-			warnEBPFFailure("io", err)
-		}
+		})
 
 		c3 := NewNetworkEBPFCollector()
-		if err := c3.Start(cfg.PID); err == nil {
+		startEBPF(SubsystemNetwork, c3, func() {
 			s.NetworkEBPF = c3
 			s.Sources.Net = SourceNetworkRich
-		} else {
-			warnEBPFFailure("network", err)
-		}
+		})
 
 		c4 := NewFutexEBPFCollector()
-		if err := c4.Start(cfg.PID); err == nil {
+		startEBPF(SubsystemFutex, c4, func() {
 			s.FutexEBPF = c4
 			s.Sources.Locks = "eBPF"
-		} else {
-			warnEBPFFailure("futex", err)
-		}
+		})
 
-		// Heap (libc malloc/free pairing) augments the memory subsystem. No
-		// /proc fallback and no simulation — absent unless eBPF can attach the
-		// libc uprobes (so static / non-libc targets simply have no heap data).
+		// Heap allocation tracking augments the memory subsystem: libc
+		// malloc/free pairing, or runtime.mallocgc on a Go target. No /proc
+		// fallback and no simulation — absent unless eBPF can attach.
+		//
+		// This is also the expensive one, by a wide margin: its probe fires
+		// once per allocation, where the others fire on comparatively rare
+		// kernel events. It is the subsystem --disable exists for.
 		c5 := NewHeapEBPFCollector()
-		if err := c5.Start(cfg.PID); err == nil {
+		startEBPF(SubsystemHeap, c5, func() {
 			s.HeapEBPF = c5
 			s.Sources.Heap = "eBPF"
-		} else {
-			warnEBPFFailure("heap", err)
-		}
+		})
 
-		// Signals delivered to the target with their origin (#58). eBPF-only:
-		// no /proc fallback and no simulation — absent unless the signal_generate
-		// tracepoint attaches.
+		// Signals delivered to the target with their origin (#58).
 		c6 := NewSignalEBPFCollector()
-		if err := c6.Start(cfg.PID); err == nil {
+		startEBPF(SubsystemSignals, c6, func() {
 			s.SignalEBPF = c6
 			s.Sources.Signals = "eBPF"
-		} else {
-			warnEBPFFailure("signals", err)
-		}
+		})
 
-		// Exec lineage: fork/exec/exit across the target's descendant subtree
-		// (#60). eBPF-only — no /proc fallback, never simulated.
+		// Exec lineage: fork/exec/exit across the target's descendant subtree (#60).
 		c8 := NewProcLifecycleEBPFCollector()
-		if err := c8.Start(cfg.PID); err == nil {
+		startEBPF(SubsystemLifecycle, c8, func() {
 			s.ProcLifecycleEBPF = c8
 			s.Sources.Lifecycle = "eBPF"
-		} else {
-			warnEBPFFailure("lifecycle", err)
-		}
+		})
 
 		// Security: runtime PROT_EXEC mappings + best-effort SELinux LSM
-		// denials (#59). eBPF-only — no /proc fallback, never simulated.
+		// denials (#59).
 		c9 := NewSecurityEBPFCollector()
-		if err := c9.Start(cfg.PID); err == nil {
+		startEBPF(SubsystemSecurity, c9, func() {
 			s.SecurityEBPF = c9
 			s.Sources.Security = "eBPF"
-		} else {
-			warnEBPFFailure("security", err)
-		}
+		})
 
 		// TLS payload capture (#55) — OFF unless explicitly opted in (--tls),
-		// because it observes plaintext. eBPF-only (libssl uprobes), no /proc
-		// fallback, never simulated.
+		// because it observes plaintext.
 		if cfg.TLS {
 			c7 := NewTLSEBPFCollector(cfg.TLSMaxBytes)
-			if err := c7.Start(cfg.PID); err == nil {
+			startEBPF(SubsystemTLS, c7, func() {
 				s.TLSEBPF = c7
 				s.Sources.TLS = "eBPF"
-			} else {
-				warnEBPFFailure("tls", err)
-			}
+			})
 		}
 	}
 
 	return s
+}
+
+// ebpfStarter is the shape every eBPF collector shares: attach to a pid, or
+// explain why not.
+type ebpfStarter interface {
+	Start(pid int) error
 }
 
 // startCgroup starts the collectors that can observe a whole cgroup subtree

--- a/pkg/collector/types.go
+++ b/pkg/collector/types.go
@@ -95,13 +95,14 @@ type HeapEvent struct {
 // CallSite is the raw instruction pointer; Func/File/Line/Module/Offset are its
 // symbolization (#54). Func is "" when the address can't be resolved to a
 // function (stripped non-Go module — Module+Offset still locate it); File/Line
-// are set only for Go modules in this cut (C/C++ file:line needs DWARF). AddrHex
+// come from the Go line table, or from DWARF for C/C++ built with debug info; they
+// stay empty for a module with neither. AddrHex
 // is the raw-address fallback ("0x…", or "unknown" when the stack walk failed).
 type HeapCallSite struct {
 	CallSite      uint64  // raw application instruction pointer
 	AddrHex       string  // "0x…" raw-address fallback ("unknown" when unresolved)
 	Func          string  // resolved function name ("" if unresolved)
-	File          string  // source file (Go only in this cut; "" otherwise)
+	File          string  // source file ("" when the module carries no line info)
 	Line          int     // source line (0 if unknown)
 	Module        string  // backing module basename ("" if unresolved)
 	Offset        uint64  // module-relative offset of the call site
@@ -198,7 +199,7 @@ type LockEntry struct {
 	// no single memory map to symbolize against, so these stay zero there.
 	CallSite uint64 // raw instruction pointer (0 when the stack walk failed)
 	Func     string // resolved function name ("" if unresolved)
-	File     string // source file (Go only in this cut; "" otherwise)
+	File     string // source file ("" when the module carries no line info)
 	Line     int    // source line (0 if unknown)
 	Module   string // backing module basename ("" if unresolved)
 	Offset   uint64 // module-relative offset — comparable across runs/ASLR

--- a/pkg/collector/types.go
+++ b/pkg/collector/types.go
@@ -106,9 +106,10 @@ type HeapCallSite struct {
 	Module        string  // backing module basename ("" if unresolved)
 	Offset        uint64  // module-relative offset of the call site
 	StackID       int32   // kernel stack-map id (<0 unknown); resolves to full frames
-	LiveBytes     uint64  // bytes still live from this site
+	LiveBytes     uint64  // bytes still live from this site (0 when unmeasured — see HeapStats.LiveMeasured)
+	AllocBytes    uint64  // total bytes ever allocated from this site
 	AllocCount    uint64  // total allocations ever from this site
-	AvgLifetimeMs float64 // mean lifetime of freed allocations from this site
+	AvgLifetimeMs float64 // mean lifetime of freed allocations from this site (0 when unmeasured)
 	Suspected     bool    // has live allocations older than the leak threshold
 }
 
@@ -120,9 +121,32 @@ type HeapStats struct {
 	Timestamp          time.Time
 	LiveHeapBytes      uint64
 	AllocRate          float64
+	AllocBytesRate     float64
 	TopCallSites       []HeapCallSite
 	SuspectedLeakBytes uint64
+
+	// Lane names the mechanism that produced this snapshot: HeapLaneLibc
+	// (uprobes on the libc allocator) or HeapLaneGo (a uprobe on
+	// runtime.mallocgc). Diagnostic — LiveMeasured is the field to branch on.
+	Lane string
+
+	// LiveMeasured reports whether LiveHeapBytes, LiveBytes,
+	// SuspectedLeakBytes and AvgLifetimeMs mean anything in this snapshot.
+	//
+	// False on the Go lane, where nothing frees at an observable point (the GC
+	// sweeper reclaims spans in bulk, asynchronously, naming no object), so
+	// those fields carry 0 as "not measured", NOT as "measured, and zero". A
+	// consumer that diffs deploys must branch on this: reading an unmeasured 0
+	// against a libc-lane baseline would report a total collapse of the live
+	// heap where nothing changed at all.
+	LiveMeasured bool
 }
+
+// Heap collection lanes — see HeapStats.Lane.
+const (
+	HeapLaneLibc = "libc" // uprobes on malloc/calloc/realloc/free
+	HeapLaneGo   = "go"   // uprobe on runtime.mallocgc
+)
 
 // ─── Threads ─────────────────────────────────────────────────────────────────
 

--- a/pkg/streampb/event.pb.go
+++ b/pkg/streampb/event.pb.go
@@ -1343,7 +1343,12 @@ type HeapCallSite struct {
 	// Kernel stack-map id of the alloc site, for EventStreamService.ResolveStack
 	// (the full leaf-first stack). A sentinel (resolves to not-found) when the
 	// stack walk failed.
-	StackId       uint64 `protobuf:"varint,12,opt,name=stack_id,json=stackId,proto3" json:"stack_id,omitempty"`
+	StackId uint64 `protobuf:"varint,12,opt,name=stack_id,json=stackId,proto3" json:"stack_id,omitempty"`
+	// Total bytes ever allocated from this site. Unlike live_bytes this only
+	// grows, so it is comparable across a capture window regardless of what the
+	// GC or free() did in between — and it is the ranking signal on the Go lane,
+	// where live_bytes is not measured at all.
+	AllocBytes    uint64 `protobuf:"varint,13,opt,name=alloc_bytes,json=allocBytes,proto3" json:"alloc_bytes,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -1462,6 +1467,13 @@ func (x *HeapCallSite) GetStackId() uint64 {
 	return 0
 }
 
+func (x *HeapCallSite) GetAllocBytes() uint64 {
+	if x != nil {
+		return x.AllocBytes
+	}
+	return 0
+}
+
 // HeapSnapshot is the periodic heap aggregate. live_heap_bytes and
 // suspected_leak_bytes derive from the kernel's LRU-bounded live set, so they
 // undercount on alloc-heavy targets — never exact. alloc_rate is allocations
@@ -1472,8 +1484,27 @@ type HeapSnapshot struct {
 	AllocRate          float64                `protobuf:"fixed64,2,opt,name=alloc_rate,json=allocRate,proto3" json:"alloc_rate,omitempty"`
 	SuspectedLeakBytes uint64                 `protobuf:"varint,3,opt,name=suspected_leak_bytes,json=suspectedLeakBytes,proto3" json:"suspected_leak_bytes,omitempty"`
 	TopCallSites       []*HeapCallSite        `protobuf:"bytes,4,rep,name=top_call_sites,json=topCallSites,proto3" json:"top_call_sites,omitempty"`
-	unknownFields      protoimpl.UnknownFields
-	sizeCache          protoimpl.SizeCache
+	// Bytes allocated per second over the last window. Measured on every lane.
+	AllocBytesRate float64 `protobuf:"fixed64,5,opt,name=alloc_bytes_rate,json=allocBytesRate,proto3" json:"alloc_bytes_rate,omitempty"`
+	// Which mechanism produced this snapshot: "libc" (uprobes on
+	// malloc/calloc/realloc/free) or "go" (a uprobe on runtime.mallocgc). A Go
+	// process allocates through neither malloc nor free, so on the libc lane its
+	// call-site axis comes back empty; the go lane is what makes func/file/line
+	// — and therefore attribution to a commit — reachable for a Go target.
+	// Diagnostic: branch on live_measured, not on this.
+	Lane string `protobuf:"bytes,6,opt,name=lane,proto3" json:"lane,omitempty"`
+	// Whether live_heap_bytes, suspected_leak_bytes, HeapCallSite.live_bytes and
+	// HeapCallSite.avg_lifetime_ms mean anything in this snapshot.
+	//
+	// False on the "go" lane: nothing frees a Go allocation at a point a probe
+	// can observe (the GC sweeper reclaims spans in bulk, asynchronously, naming
+	// no object), so those fields carry 0 as "NOT MEASURED", not as "measured,
+	// and zero". A consumer diffing two deploys must check this before comparing
+	// them — an unmeasured 0 read against a libc-lane baseline reports the live
+	// heap collapsing to nothing when in fact nothing changed.
+	LiveMeasured  bool `protobuf:"varint,7,opt,name=live_measured,json=liveMeasured,proto3" json:"live_measured,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
 }
 
 func (x *HeapSnapshot) Reset() {
@@ -1532,6 +1563,27 @@ func (x *HeapSnapshot) GetTopCallSites() []*HeapCallSite {
 		return x.TopCallSites
 	}
 	return nil
+}
+
+func (x *HeapSnapshot) GetAllocBytesRate() float64 {
+	if x != nil {
+		return x.AllocBytesRate
+	}
+	return 0
+}
+
+func (x *HeapSnapshot) GetLane() string {
+	if x != nil {
+		return x.Lane
+	}
+	return ""
+}
+
+func (x *HeapSnapshot) GetLiveMeasured() bool {
+	if x != nil {
+		return x.LiveMeasured
+	}
+	return false
 }
 
 // ─── Threads ────────────────────────────────────────────────────────────────
@@ -3076,7 +3128,7 @@ const file_event_proto_rawDesc = "" +
 	"\vlifetime_ms\x18\x04 \x01(\x01R\n" +
 	"lifetimeMs\x12\x1b\n" +
 	"\tcall_site\x18\x05 \x01(\x04R\bcallSite\x12\x14\n" +
-	"\x05large\x18\x06 \x01(\bR\x05large\"\xd3\x02\n" +
+	"\x05large\x18\x06 \x01(\bR\x05large\"\xf4\x02\n" +
 	"\fHeapCallSite\x12\x1b\n" +
 	"\tcall_site\x18\x01 \x01(\x04R\bcallSite\x12\x19\n" +
 	"\baddr_hex\x18\x02 \x01(\tR\aaddrHex\x12\x1d\n" +
@@ -3092,13 +3144,18 @@ const file_event_proto_rawDesc = "" +
 	"\x06module\x18\n" +
 	" \x01(\tR\x06module\x12\x16\n" +
 	"\x06offset\x18\v \x01(\x04R\x06offset\x12\x19\n" +
-	"\bstack_id\x18\f \x01(\x04R\astackId\"\xc4\x01\n" +
+	"\bstack_id\x18\f \x01(\x04R\astackId\x12\x1f\n" +
+	"\valloc_bytes\x18\r \x01(\x04R\n" +
+	"allocBytes\"\xa7\x02\n" +
 	"\fHeapSnapshot\x12&\n" +
 	"\x0flive_heap_bytes\x18\x01 \x01(\x04R\rliveHeapBytes\x12\x1d\n" +
 	"\n" +
 	"alloc_rate\x18\x02 \x01(\x01R\tallocRate\x120\n" +
 	"\x14suspected_leak_bytes\x18\x03 \x01(\x04R\x12suspectedLeakBytes\x12;\n" +
-	"\x0etop_call_sites\x18\x04 \x03(\v2\x15.ptop.v1.HeapCallSiteR\ftopCallSites\"\xbe\x01\n" +
+	"\x0etop_call_sites\x18\x04 \x03(\v2\x15.ptop.v1.HeapCallSiteR\ftopCallSites\x12(\n" +
+	"\x10alloc_bytes_rate\x18\x05 \x01(\x01R\x0eallocBytesRate\x12\x12\n" +
+	"\x04lane\x18\x06 \x01(\tR\x04lane\x12#\n" +
+	"\rlive_measured\x18\a \x01(\bR\fliveMeasured\"\xbe\x01\n" +
 	"\n" +
 	"ThreadInfo\x12\x10\n" +
 	"\x03tid\x18\x01 \x01(\x05R\x03tid\x12\x12\n" +

--- a/pkg/streampb/event.pb.go
+++ b/pkg/streampb/event.pb.go
@@ -162,7 +162,7 @@ func (x *StackRef) GetBuildId() string {
 // StackFrame is one symbolized frame of a captured stack (#54), leaf-first.
 // func is "" when the address couldn't be resolved to a function (stripped
 // non-Go module — module+offset still locate it); file/line are populated only
-// for Go modules in this cut (C/C++ file:line needs DWARF). offset is
+// from the Go line table, or from DWARF for C/C++ built with debug info. offset is
 // module-relative, so it is comparable across runs/ASLR.
 type StackFrame struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
@@ -1325,7 +1325,8 @@ func (x *HeapEvent) GetLarge() bool {
 // call_site is the raw instruction pointer; func/file/line/module/offset are its
 // symbolization (#54). func is "" when the address can't be resolved to a
 // function (stripped non-Go module — module+offset still locate it); file/line
-// are set only for Go modules in this cut (C/C++ file:line needs DWARF). addr_hex
+// come from the Go line table, or from DWARF for C/C++ built with debug info; they
+// stay empty for a module with neither. addr_hex
 // is the raw-address fallback ("0x…", or "unknown" when the stack walk failed).
 type HeapCallSite struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
@@ -1336,7 +1337,7 @@ type HeapCallSite struct {
 	AvgLifetimeMs float64                `protobuf:"fixed64,5,opt,name=avg_lifetime_ms,json=avgLifetimeMs,proto3" json:"avg_lifetime_ms,omitempty"`
 	Suspected     bool                   `protobuf:"varint,6,opt,name=suspected,proto3" json:"suspected,omitempty"` // has live allocations older than the leak threshold
 	Func          string                 `protobuf:"bytes,7,opt,name=func,proto3" json:"func,omitempty"`            // resolved function name ("" if unresolved)
-	File          string                 `protobuf:"bytes,8,opt,name=file,proto3" json:"file,omitempty"`            // source file (Go only in this cut; "" otherwise)
+	File          string                 `protobuf:"bytes,8,opt,name=file,proto3" json:"file,omitempty"`            // source file ("" when the module carries no line info)
 	Line          int32                  `protobuf:"varint,9,opt,name=line,proto3" json:"line,omitempty"`           // source line (0 if unknown)
 	Module        string                 `protobuf:"bytes,10,opt,name=module,proto3" json:"module,omitempty"`       // backing module basename ("" if unresolved)
 	Offset        uint64                 `protobuf:"varint,11,opt,name=offset,proto3" json:"offset,omitempty"`      // module-relative offset of the call site

--- a/pkg/symbol/doc.go
+++ b/pkg/symbol/doc.go
@@ -14,6 +14,10 @@
 // a stripped module degrades gracefully to "module+0xoffset". Modules are
 // parsed once and cached.
 //
+// An address in no file-backed mapping is JIT'd code rather than junk, and is
+// resolved from the runtime's perf map (perfmap.go) — the /tmp/perf-<pid>.map
+// side file Node and the JVM already write for perf(1).
+//
 // Name → address lookup (lookup.go) is the inverse direction, used to place a
 // uprobe on a named function such as runtime.mallocgc.
 //

--- a/pkg/symbol/doc.go
+++ b/pkg/symbol/doc.go
@@ -9,9 +9,14 @@
 //
 // Per-module resolution order: the Go line table (.gopclntab) yields func +
 // file:line for Go binaries and survives symbol stripping; the ELF symbol
-// table (.symtab/.dynsym) yields function names for C/C++; a stripped module
-// degrades gracefully to "module+0xoffset". Modules are parsed once and cached.
+// table (.symtab/.dynsym) yields function names for C/C++, and DWARF line info
+// (dwarf.go) fills in their file:line where the image carries debug sections;
+// a stripped module degrades gracefully to "module+0xoffset". Modules are
+// parsed once and cached.
 //
-// Deferred (see #54): C/C++ file:line (DWARF), C++ demangling, and kernel-stack
-// resolution via /proc/kallsyms.
+// Name → address lookup (lookup.go) is the inverse direction, used to place a
+// uprobe on a named function such as runtime.mallocgc.
+//
+// Deferred (see #54): C++ demangling, and kernel-stack resolution via
+// /proc/kallsyms.
 package symbol

--- a/pkg/symbol/dwarf.go
+++ b/pkg/symbol/dwarf.go
@@ -1,0 +1,171 @@
+package symbol
+
+import (
+	"debug/dwarf"
+	"debug/elf"
+)
+
+// DWARF line resolution — file:line for C/C++, the follow-up this package's
+// doc comment has been deferring.
+//
+// Go binaries already get file:line from .gopclntab, which is compact and
+// always present. Nothing equivalent exists for C/C++: the function name comes
+// from .symtab, and the source location lives only in DWARF. Without it a
+// contended lock or a hot allocation site in a C service resolves to a bare
+// function name — enough to say WHAT, never enough to point at a line, and a
+// line is what a consumer needs to cross the behaviour against a code diff.
+//
+// ─── Why the sections are copied in, and why there is a budget ──────────────
+//
+// A Module deliberately retains no open file handle, so it stays cheap to
+// cache and safe to share. Keeping that property means the DWARF bytes have to
+// be copied in while the file is open, and parsed later on demand.
+//
+// Copying is bounded because it is unbounded in principle: a large C++ binary
+// built with -g carries debug sections far larger than its code. Past the
+// budget the module simply resolves without file:line — the same answer it
+// gave before this file existed, which is a real degradation but a safe one.
+// The alternative (holding a file handle per mapped module for the life of the
+// process) trades a bounded memory cost for an unbounded fd cost.
+//
+// .debug_frame and the location lists are not copied: they carry unwind and
+// variable-location data, they are often the largest sections present, and the
+// line table needs neither.
+
+// dwarfBudget caps the total debug bytes copied into one Module. Sized so an
+// ordinary service binary with -g fits comfortably while a debug-info-heavy
+// C++ image degrades to func-only instead of pinning hundreds of megabytes.
+const dwarfBudget = 256 << 20
+
+// dwarfSections are the sections a line lookup needs: the DIE tree to find the
+// compile unit covering an address (info/abbrev/ranges/rnglists/addr), the
+// line program itself (line), and the string tables DWARF 5 splits names into
+// (str/line_str/str_offsets).
+var dwarfSections = []string{
+	".debug_abbrev",
+	".debug_addr",
+	".debug_info",
+	".debug_line",
+	".debug_line_str",
+	".debug_ranges",
+	".debug_rnglists",
+	".debug_str",
+	".debug_str_offsets",
+}
+
+// loadDWARFSections copies the line-resolution sections out of f, or returns
+// nil when the image has no debug info or exceeds the budget.
+func loadDWARFSections(f *elf.File) map[string][]byte {
+	var total uint64
+	for _, name := range dwarfSections {
+		if sec := f.Section(name); sec != nil {
+			total += sec.Size
+		}
+	}
+	if total == 0 || total > dwarfBudget {
+		return nil
+	}
+	// .debug_info and .debug_line are the two that must be there; without
+	// either there is no line program to read and the copy is wasted.
+	if f.Section(".debug_info") == nil || f.Section(".debug_line") == nil {
+		return nil
+	}
+
+	out := make(map[string][]byte, len(dwarfSections))
+	for _, name := range dwarfSections {
+		sec := f.Section(name)
+		if sec == nil {
+			continue
+		}
+		data, err := sec.Data()
+		if err != nil {
+			continue // a compressed or truncated section: skip it, not the lot
+		}
+		out[name] = data
+	}
+	if out[".debug_info"] == nil || out[".debug_line"] == nil {
+		return nil
+	}
+	return out
+}
+
+// dwarfData builds the DWARF reader on first use. Parsing is deferred because
+// most modules in a process never have a frame land in them.
+func (m *Module) dwarfData() *dwarf.Data {
+	m.dwarfOnce.Do(func() {
+		if len(m.dwarfSecs) == 0 {
+			return
+		}
+		sec := func(name string) []byte { return m.dwarfSecs[name] }
+		d, err := dwarf.New(
+			sec(".debug_abbrev"),
+			nil, // .debug_aranges: an index we don't use; SeekPC walks the DIEs
+			nil, // .debug_frame: unwind data, not line data
+			sec(".debug_info"),
+			sec(".debug_line"),
+			nil, // .debug_pubnames: superseded, and not needed for a line lookup
+			sec(".debug_ranges"),
+			sec(".debug_str"),
+		)
+		if err != nil {
+			return
+		}
+		// DWARF 5 moved parts of the line program's strings and the address
+		// and range lists into their own sections. dwarf.New predates them, so
+		// they are attached separately; a failure here is not fatal, it just
+		// limits which units resolve.
+		for _, name := range []string{".debug_line_str", ".debug_str_offsets", ".debug_addr", ".debug_rnglists"} {
+			if data := sec(name); len(data) > 0 {
+				_ = d.AddSection(name, data)
+			}
+		}
+		m.dw = d
+	})
+	return m.dw
+}
+
+// dwarfLine resolves a link-time virtual address to its source file and line
+// via the DWARF line program. ok is false when the module carries no usable
+// debug info or no line covers the address.
+//
+// Serialized on m.dwarfMu: dwarf.Reader and dwarf.LineReader are stateful
+// cursors, and Module.Resolve is documented safe for concurrent use.
+func (m *Module) dwarfLine(fileVaddr uint64) (file string, line int, ok bool) {
+	d := m.dwarfData()
+	if d == nil {
+		return "", 0, false
+	}
+
+	m.dwarfMu.Lock()
+	defer m.dwarfMu.Unlock()
+
+	cu, err := d.Reader().SeekPC(fileVaddr)
+	if err != nil || cu == nil {
+		return "", 0, false
+	}
+
+	// The line program is parsed once per compile unit and the cursor reused:
+	// re-reading the header for every frame that lands in the same unit is the
+	// difference between a lookup and a re-parse, and stacks cluster heavily
+	// into a handful of units.
+	lr, cached := m.lineReaders[cu.Offset]
+	if !cached {
+		lr, err = d.LineReader(cu)
+		if err != nil || lr == nil {
+			return "", 0, false
+		}
+		if m.lineReaders == nil {
+			m.lineReaders = make(map[dwarf.Offset]*dwarf.LineReader, 4)
+		}
+		m.lineReaders[cu.Offset] = lr
+	}
+
+	var ent dwarf.LineEntry
+	if err := lr.SeekPC(fileVaddr, &ent); err != nil {
+		return "", 0, false
+	}
+	if ent.File == nil || ent.File.Name == "" || ent.Line <= 0 {
+		return "", 0, false
+	}
+	return ent.File.Name, ent.Line, true
+}

--- a/pkg/symbol/dwarf_test.go
+++ b/pkg/symbol/dwarf_test.go
@@ -1,0 +1,179 @@
+package symbol
+
+import (
+	"bufio"
+	"debug/elf"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// buildCFixture compiles testdata/cfixture with the host C compiler and
+// returns the ELF path. Skips when no compiler is available — the DWARF path
+// is Linux/C tooling, and a machine without cc simply cannot exercise it.
+func buildCFixture(t *testing.T, extraFlags ...string) string {
+	t.Helper()
+	cc := ""
+	for _, cand := range []string{"cc", "clang", "gcc"} {
+		if p, err := exec.LookPath(cand); err == nil {
+			cc = p
+			break
+		}
+	}
+	if cc == "" {
+		t.Skip("no C compiler on PATH; DWARF fixture cannot be built")
+	}
+	out := filepath.Join(t.TempDir(), "cfixture")
+	args := append([]string{"-O0", "-o", out}, extraFlags...)
+	args = append(args, "testdata/cfixture/main.c")
+	if o, err := exec.Command(cc, args...).CombinedOutput(); err != nil {
+		t.Skipf("compile fixture with %s: %v\n%s", cc, err, o)
+	}
+	return out
+}
+
+// fixtureLine finds the 1-based line number of the source line carrying the
+// given marker comment, so the expected value tracks the file instead of being
+// a constant that silently rots when the fixture is edited.
+func fixtureLine(t *testing.T, marker string) int {
+	t.Helper()
+	f, err := os.Open("testdata/cfixture/main.c")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+	sc := bufio.NewScanner(f)
+	for n := 1; sc.Scan(); n++ {
+		if strings.Contains(sc.Text(), "LINE:"+marker) {
+			return n
+		}
+	}
+	t.Fatalf("marker %q not found in the fixture", marker)
+	return 0
+}
+
+func openCModule(t *testing.T, path string) *Module {
+	t.Helper()
+	f, err := os.Open(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { f.Close() })
+	m, err := OpenModule(f, path)
+	if err != nil {
+		t.Fatalf("OpenModule: %v", err)
+	}
+	return m
+}
+
+// The gap this closes: before DWARF, a C frame resolved to a function name and
+// nothing else, so a delta could say which function moved but never which
+// line — and a line is what crosses against a code diff.
+func TestResolveCGivesFileAndLine(t *testing.T) {
+	path := buildCFixture(t, "-g")
+	m := openCModule(t, path)
+
+	for _, c := range []struct{ fn, marker string }{
+		{"alloc_small", "alloc_small_body"},
+		{"alloc_big", "alloc_big_body"},
+	} {
+		t.Run(c.fn, func(t *testing.T) {
+			// Resolve the address of the malloc call inside the function, not
+			// the function entry: the entry maps to the declaration line,
+			// while the body line is the one a call site actually reports.
+			addr := symValue(t, path, c.fn)
+			var fr Frame
+			// Walk forward a little to land inside the body. The prologue is a
+			// handful of instructions; 64 bytes covers it on both arm64 and
+			// x86-64 at -O0.
+			wantLine := fixtureLine(t, c.marker)
+			for off := uint64(0); off <= 64; off += 4 {
+				got := m.Resolve(addr + off)
+				if got.Line == wantLine {
+					fr = got
+					break
+				}
+				if fr.Func == "" {
+					fr = got
+				}
+			}
+			if fr.Func != c.fn {
+				t.Errorf("Func = %q, want %q", fr.Func, c.fn)
+			}
+			if !strings.HasSuffix(fr.File, "main.c") {
+				t.Errorf("File = %q, want …/main.c", fr.File)
+			}
+			if fr.Line != wantLine {
+				t.Errorf("Line = %d, want %d (the malloc call in %s)", fr.Line, wantLine, c.fn)
+			}
+		})
+	}
+}
+
+// Without -g there is no debug info at all. The module must still resolve the
+// function name from .symtab and simply leave file:line empty — the behaviour
+// that shipped before DWARF, which most production binaries still get.
+func TestResolveCWithoutDebugInfoKeepsFuncOnly(t *testing.T) {
+	path := buildCFixture(t)
+	m := openCModule(t, path)
+
+	if m.dwarfSecs != nil {
+		t.Skip("compiler emitted debug info without -g; nothing to test here")
+	}
+	fr := m.Resolve(symValue(t, path, "alloc_small"))
+	if fr.Func != "alloc_small" {
+		t.Errorf("Func = %q, want alloc_small", fr.Func)
+	}
+	if fr.File != "" || fr.Line != 0 {
+		t.Errorf("file:line = %q:%d, want empty without debug info", fr.File, fr.Line)
+	}
+}
+
+// A Go binary must keep taking the .gopclntab path: it is compact, always
+// present, and authoritative. DWARF must not shadow it — a Go build with
+// debug info would otherwise get its file:line from the slower source.
+func TestGoModuleStillPrefersLineTable(t *testing.T) {
+	path := buildGoFixture(t, "")
+	m := openCModule(t, path)
+	fr := m.Resolve(symValue(t, path, "main.leakyAlloc"))
+	if fr.Func != "main.leakyAlloc" {
+		t.Errorf("Func = %q, want main.leakyAlloc", fr.Func)
+	}
+	if !strings.HasSuffix(fr.File, "gofixture/main.go") {
+		t.Errorf("File = %q, want …/gofixture/main.go", fr.File)
+	}
+}
+
+// The address is outside every compile unit: the lookup must decline rather
+// than return the nearest line it happened to find.
+func TestDwarfLineRejectsUnknownPC(t *testing.T) {
+	m := openCModule(t, buildCFixture(t, "-g"))
+	if _, _, ok := m.dwarfLine(0xdeadbeef0000); ok {
+		t.Error("dwarfLine resolved an address in no compile unit")
+	}
+}
+
+func TestDwarfLineOnModuleWithoutSections(t *testing.T) {
+	m := &Module{name: "stripped.so"}
+	if _, _, ok := m.dwarfLine(0x1000); ok {
+		t.Error("dwarfLine resolved on a module with no debug sections")
+	}
+}
+
+// loadDWARFSections must decline an image whose debug info would blow the
+// budget, and must not half-load one that is missing the line program.
+func TestLoadDWARFSectionsRequiresInfoAndLine(t *testing.T) {
+	path := buildCFixture(t, "-g")
+	f, err := elf.Open(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+	if secs := loadDWARFSections(f); secs == nil {
+		t.Fatal("loadDWARFSections declined a -g binary")
+	} else if secs[".debug_info"] == nil || secs[".debug_line"] == nil {
+		t.Error("loaded sections missing .debug_info or .debug_line")
+	}
+}

--- a/pkg/symbol/elf.go
+++ b/pkg/symbol/elf.go
@@ -1,6 +1,7 @@
 package symbol
 
 import (
+	"debug/dwarf"
 	"debug/elf"
 	"debug/gosym"
 	"encoding/binary"
@@ -16,8 +17,9 @@ import (
 //
 //   - Func is "" when the address couldn't be resolved to a function (a stripped
 //     non-Go module); Module + Offset still locate it as "lib+0xNN".
-//   - File/Line are populated only for Go modules (via .gopclntab) in this cut.
-//     C/C++ file:line needs DWARF, which is deferred (#54 follow-up).
+//   - File/Line come from .gopclntab for Go modules and from DWARF line info
+//     for C/C++. They stay empty for a module built without debug info, which
+//     is most shipped C/C++ binaries.
 //   - Offset is module-relative (file vaddr − the module's load base), so it is
 //     comparable across runs/ASLR.
 type Frame struct {
@@ -58,6 +60,14 @@ type Module struct {
 	gotab     *gosym.Table
 	pclnData  []byte
 	textAddr  uint64
+
+	// DWARF line info for C/C++ file:line, built lazily for the same reason
+	// (see dwarf.go). dwarfMu guards the stateful readers.
+	dwarfSecs   map[string][]byte
+	dwarfOnce   sync.Once
+	dw          *dwarf.Data
+	dwarfMu     sync.Mutex
+	lineReaders map[dwarf.Offset]*dwarf.LineReader
 }
 
 // OpenModule parses the ELF image in r. name is used for Frame.Module (its
@@ -86,6 +96,7 @@ func OpenModule(r io.ReaderAt, name string) (*Module, error) {
 
 	m.buildID = readBuildID(f)
 	m.funcs = collectFuncs(f)
+	m.dwarfSecs = loadDWARFSections(f)
 
 	// Stash the Go line table inputs for lazy gosym construction.
 	if sec := f.Section(".gopclntab"); sec != nil {
@@ -107,8 +118,15 @@ func (m *Module) Name() string { return m.name }
 func (m *Module) BuildID() string { return m.buildID }
 
 // Resolve maps a file virtual address to a Frame. It tries, in order: the Go
-// line table (func + file:line), the ELF symbol table (func name only), then a
-// module+offset fallback for stripped binaries.
+// line table (func + file:line), the ELF symbol table plus DWARF (func name,
+// and file:line where debug info is present), then a module+offset fallback
+// for stripped binaries.
+//
+// The two file:line sources are kept apart on purpose. .gopclntab is compact,
+// always present in a Go image, and authoritative there — it is consulted
+// first and short-circuits. DWARF is the C/C++ path: optional, much larger,
+// and absent from most shipped binaries, so it runs only after a name has
+// already been found and only fills in what is missing.
 func (m *Module) Resolve(fileVaddr uint64) Frame {
 	fr := Frame{Module: m.name, BuildID: m.buildID, Offset: fileVaddr - m.loadBase}
 
@@ -120,7 +138,9 @@ func (m *Module) Resolve(fileVaddr uint64) Frame {
 	}
 	if name, ok := lookupFunc(m.funcs, fileVaddr); ok {
 		fr.Func = name
-		return fr
+	}
+	if file, line, ok := m.dwarfLine(fileVaddr); ok {
+		fr.File, fr.Line = file, line
 	}
 	return fr
 }

--- a/pkg/symbol/lookup.go
+++ b/pkg/symbol/lookup.go
@@ -1,0 +1,61 @@
+package symbol
+
+// Name → address lookup, the inverse of Resolve.
+//
+// Resolve answers "what code is at this address", which is what stack
+// symbolization needs. Attaching a uprobe needs the opposite: "where does this
+// named function start", and then where that lands in the FILE, since a uprobe
+// is expressed as a path plus a file offset.
+//
+// Both directions must agree about stripped Go binaries. A release build with
+// -ldflags="-s -w" has no .symtab at all, but it still carries .gopclntab —
+// the Go runtime needs it for tracebacks, so it survives stripping. That is
+// why the lookup below falls back to the line table rather than giving up: a
+// production Go binary is very often exactly this case, and refusing it would
+// mean the Go allocation axis only lit up for debug builds.
+
+// IsGo reports whether the module carries a Go line table (.gopclntab), which
+// is the reliable marker of a Go-compiled image: the runtime needs it for
+// tracebacks, so it is present in stripped release builds too.
+func (m *Module) IsGo() bool { return len(m.pclnData) > 0 }
+
+// FuncStart returns the link-time virtual address and size of the named
+// function.
+//
+// The ELF symbol table is consulted first (it carries a size, which the line
+// table's entry/end pair only approximates), then the Go line table for
+// stripped binaries. size is 0 when only the line table knew the symbol and
+// its extent could not be derived.
+func (m *Module) FuncStart(name string) (vaddr, size uint64, ok bool) {
+	for _, f := range m.funcs {
+		if f.name == name {
+			return f.value, f.size, true
+		}
+	}
+	if tab := m.gosym(); tab != nil {
+		if fn := tab.LookupFunc(name); fn != nil {
+			var sz uint64
+			if fn.End > fn.Entry {
+				sz = fn.End - fn.Entry
+			}
+			return fn.Entry, sz, true
+		}
+	}
+	return 0, 0, false
+}
+
+// FileOffset converts a link-time virtual address to its offset within the
+// file, which is the form a uprobe attachment takes (perf_event_open names a
+// probe by inode + offset, not by runtime address).
+//
+// Returns ok=false for an address in no PT_LOAD segment, or in one whose
+// content is not backed by the file at all (.bss — filesz < memsz), where a
+// file offset would be meaningless.
+func (m *Module) FileOffset(vaddr uint64) (uint64, bool) {
+	for _, l := range m.loads {
+		if vaddr >= l.vaddr && vaddr < l.vaddr+l.filesz {
+			return vaddr - l.vaddr + l.off, true
+		}
+	}
+	return 0, false
+}

--- a/pkg/symbol/lookup_test.go
+++ b/pkg/symbol/lookup_test.go
@@ -1,0 +1,175 @@
+package symbol
+
+import (
+	"debug/elf"
+	"os"
+	"testing"
+)
+
+// openFixtureModule builds the Go fixture and parses it as a Module.
+func openFixtureModule(t *testing.T, ldflags string) (*Module, string) {
+	t.Helper()
+	path := buildGoFixture(t, ldflags)
+	f, err := os.Open(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { f.Close() })
+	m, err := OpenModule(f, path)
+	if err != nil {
+		t.Fatalf("OpenModule: %v", err)
+	}
+	return m, path
+}
+
+func TestIsGo(t *testing.T) {
+	m, _ := openFixtureModule(t, "")
+	if !m.IsGo() {
+		t.Error("IsGo = false for a Go binary")
+	}
+
+	// A module with no line table is the non-Go case (a C library, or an ELF
+	// we failed to find .gopclntab in).
+	if (&Module{name: "libc.so.6"}).IsGo() {
+		t.Error("IsGo = true for a module with no line table")
+	}
+}
+
+// A stripped build is the one that matters: -ldflags="-s -w" is the norm for a
+// release binary, it removes .symtab entirely, and if the lookup did not fall
+// back to .gopclntab the Go allocation probe would only ever attach to debug
+// builds.
+func TestIsGoSurvivesStripping(t *testing.T) {
+	m, _ := openFixtureModule(t, "-s -w")
+	if !m.IsGo() {
+		t.Error("IsGo = false for a stripped Go binary (.gopclntab should survive -s -w)")
+	}
+}
+
+func TestFuncStartFromSymbolTable(t *testing.T) {
+	m, path := openFixtureModule(t, "")
+	want := symValue(t, path, "main.leakyAlloc")
+
+	got, size, ok := m.FuncStart("main.leakyAlloc")
+	if !ok {
+		t.Fatal("FuncStart(main.leakyAlloc) not found")
+	}
+	if got != want {
+		t.Errorf("FuncStart = %#x, want %#x", got, want)
+	}
+	if size == 0 {
+		t.Error("FuncStart size = 0, want the symbol's extent from .symtab")
+	}
+}
+
+func TestFuncStartFallsBackToLineTable(t *testing.T) {
+	m, path := openFixtureModule(t, "-s -w")
+
+	// Precondition: the fallback is only under test if .symtab is really gone.
+	f, err := elf.Open(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+	if _, err := f.Symbols(); err == nil {
+		t.Skip("toolchain kept .symtab under -s -w; nothing to fall back from")
+	}
+
+	addr, _, ok := m.FuncStart("main.leakyAlloc")
+	if !ok {
+		t.Fatal("FuncStart(main.leakyAlloc) not found on a stripped binary")
+	}
+	// Cross-check against the other direction: the address must resolve back
+	// to the function we asked for.
+	if fr := m.Resolve(addr); fr.Func != "main.leakyAlloc" {
+		t.Errorf("FuncStart(%#x) resolves back to %q, want main.leakyAlloc", addr, fr.Func)
+	}
+}
+
+// runtime.mallocgc is the actual attach point of the Go allocation probe. If
+// this stops resolving on a supported toolchain, the axis goes dark — so it is
+// asserted by name rather than left implicit in the fixture's own functions.
+func TestFuncStartFindsMallocgc(t *testing.T) {
+	for _, ldflags := range []string{"", "-s -w"} {
+		name := "plain"
+		if ldflags != "" {
+			name = "stripped"
+		}
+		t.Run(name, func(t *testing.T) {
+			m, _ := openFixtureModule(t, ldflags)
+			addr, _, ok := m.FuncStart("runtime.mallocgc")
+			if !ok {
+				t.Fatal("FuncStart(runtime.mallocgc) not found")
+			}
+			if addr == 0 {
+				t.Error("runtime.mallocgc resolved to address 0")
+			}
+			if _, ok := m.FileOffset(addr); !ok {
+				t.Error("runtime.mallocgc is in no file-backed segment")
+			}
+		})
+	}
+}
+
+func TestFuncStartMissingSymbol(t *testing.T) {
+	m, _ := openFixtureModule(t, "")
+	if _, _, ok := m.FuncStart("main.thisDoesNotExist"); ok {
+		t.Error("FuncStart reported a symbol that is not there")
+	}
+}
+
+// FileOffset must agree with the ELF program headers, because a uprobe is
+// registered by file offset — an off-by-one segment here attaches the probe to
+// whatever unrelated instruction lives at that offset.
+func TestFileOffsetMatchesProgramHeaders(t *testing.T) {
+	m, path := openFixtureModule(t, "")
+	addr := symValue(t, path, "main.leakyAlloc")
+
+	got, ok := m.FileOffset(addr)
+	if !ok {
+		t.Fatal("FileOffset not found for a function address")
+	}
+
+	f, err := elf.Open(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+	var want uint64
+	var found bool
+	for _, p := range f.Progs {
+		if p.Type != elf.PT_LOAD {
+			continue
+		}
+		if addr >= p.Vaddr && addr < p.Vaddr+p.Filesz {
+			want, found = addr-p.Vaddr+p.Off, true
+			break
+		}
+	}
+	if !found {
+		t.Fatal("test setup: function address in no PT_LOAD segment")
+	}
+	if got != want {
+		t.Errorf("FileOffset = %#x, want %#x", got, want)
+	}
+
+	// Independent check: the bytes at that offset are the function's first
+	// instruction, i.e. reading the file there lands inside .text.
+	if sec := f.Section(".text"); sec != nil {
+		if got < sec.Offset || got >= sec.Offset+sec.Size {
+			t.Errorf("FileOffset %#x is outside .text [%#x,%#x)", got, sec.Offset, sec.Offset+sec.Size)
+		}
+	}
+}
+
+func TestFileOffsetRejectsUnmappedAddress(t *testing.T) {
+	m := &Module{loads: []progLoad{{off: 0x1000, vaddr: 0x400000, filesz: 0x2000}}}
+	if _, ok := m.FileOffset(0x500000); ok {
+		t.Error("FileOffset accepted an address in no segment")
+	}
+	// Past filesz but within a hypothetical memsz (.bss): no file bytes back
+	// it, so there is no offset to give.
+	if _, ok := m.FileOffset(0x402000); ok {
+		t.Error("FileOffset accepted an address past the segment's file content")
+	}
+}

--- a/pkg/symbol/perfmap.go
+++ b/pkg/symbol/perfmap.go
@@ -1,0 +1,287 @@
+package symbol
+
+import (
+	"bufio"
+	"io"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+// JIT frame resolution via the perf map file.
+//
+// A JIT'd frame has no ELF behind it. V8 and the JVM compile methods into
+// anonymous executable memory at runtime, so /proc/<pid>/maps shows an
+// unnamed region and every symbolization path in elf.go has nothing to read.
+// Without this, a Node or JVM stack resolves to bare addresses — the runtimes
+// where "which line allocated this" matters most are the ones that answer it
+// least.
+//
+// The convention both ecosystems already implement is a plain text side file,
+// /tmp/perf-<pid>.map, one line per compiled region:
+//
+//	<start-hex> <size-hex> <name>
+//
+// Node writes it under --perf-basic-prof; the JVM under perf-map-agent. It is
+// the mechanism perf(1) itself uses, which is why it is worth supporting
+// rather than inventing something.
+//
+// ─── The tier marker is the part that matters ───────────────────────────────
+//
+// V8 emits the SAME function repeatedly as it re-optimizes, distinguished only
+// by a marker character:
+//
+//	JS:~hotSmall /app/server.js:2:18     interpreted
+//	JS:+hotSmall /app/server.js:2:18     baseline
+//	JS:^hotSmall /app/server.js:2:18     optimized
+//
+// Those are one function at three addresses, not three functions. A consumer
+// diffing two deploys by call-site name would otherwise see functions appear
+// and vanish purely because V8 decided to re-tier them under a slightly
+// different load — noise indistinguishable from a real change, and produced by
+// every warm-up. So the marker is stripped and the three normalize to one
+// identity.
+
+// perfSym is one compiled region from a perf map.
+type perfSym struct {
+	start, size uint64
+	fn          string
+	file        string
+	line        int
+}
+
+// perfMap is a parsed perf map, sorted by start address for binary search.
+type perfMap struct {
+	syms []perfSym
+	// size of the file when parsed; a JIT map only ever grows, so a change in
+	// size is the cheap signal that there is more to read.
+	size int64
+}
+
+// v8TierMarkers are the characters V8 puts before a function name to record
+// which tier compiled it. See the header comment: they are re-tiering noise,
+// not identity.
+const v8TierMarkers = "~*+^-"
+
+// parsePerfMap reads perf map lines from r.
+//
+// A malformed line is skipped rather than failing the parse: these files are
+// written by a live process with no locking, so the last line can be torn
+// mid-write, and losing one region is much better than losing the map.
+func parsePerfMap(r io.Reader, size int64) *perfMap {
+	pm := &perfMap{size: size}
+	// Later entries supersede earlier ones at the same address: V8 reuses
+	// regions after a deopt or a GC, and the newest line is the truth.
+	byStart := make(map[uint64]perfSym, 512)
+
+	sc := bufio.NewScanner(r)
+	sc.Buffer(make([]byte, 0, 64*1024), 1<<20) // JIT names can be long
+	for sc.Scan() {
+		line := sc.Text()
+		start, sz, name, ok := splitPerfMapLine(line)
+		if !ok {
+			continue
+		}
+		fn, file, ln := parsePerfMapName(name)
+		byStart[start] = perfSym{start: start, size: sz, fn: fn, file: file, line: ln}
+	}
+
+	pm.syms = make([]perfSym, 0, len(byStart))
+	for _, s := range byStart {
+		pm.syms = append(pm.syms, s)
+	}
+	sort.Slice(pm.syms, func(i, j int) bool { return pm.syms[i].start < pm.syms[j].start })
+	return pm
+}
+
+// splitPerfMapLine splits "<start-hex> <size-hex> <name>". The name is the
+// remainder of the line and may contain spaces — it routinely does, since V8
+// appends a source path.
+func splitPerfMapLine(line string) (start, size uint64, name string, ok bool) {
+	i := strings.IndexByte(line, ' ')
+	if i <= 0 {
+		return 0, 0, "", false
+	}
+	j := strings.IndexByte(line[i+1:], ' ')
+	if j < 0 {
+		return 0, 0, "", false
+	}
+	j += i + 1
+
+	start, err := strconv.ParseUint(line[:i], 16, 64)
+	if err != nil {
+		return 0, 0, "", false
+	}
+	size, err = strconv.ParseUint(line[i+1:j], 16, 64)
+	if err != nil {
+		return 0, 0, "", false
+	}
+	name = strings.TrimSpace(line[j+1:])
+	if name == "" {
+		return 0, 0, "", false
+	}
+	return start, size, name, true
+}
+
+// parsePerfMapName splits a perf map symbol into a normalized function name
+// and, where the runtime supplied one, a source location.
+//
+//	"JS:^hotSmall /app/server.js:2:18"  → "JS:hotSmall", "/app/server.js", 2
+//	"JS:~ /app/server.js:6:23"          → "JS:<anonymous>", "/app/server.js", 6
+//	"Builtin:RecordWriteSaveFP"         → "Builtin:RecordWriteSaveFP", "", 0
+//	"Ljava/lang/String;::indexOf"       → "Ljava/lang/String;::indexOf", "", 0
+func parsePerfMapName(name string) (fn, file string, line int) {
+	fn = name
+
+	if head, f, l, ok := splitTrailingLocation(fn); ok {
+		fn, file, line = head, f, l
+	}
+
+	kind, rest, hasKind := splitJITKind(fn)
+	if !hasKind {
+		return fn, file, line
+	}
+	rest = strings.TrimLeft(rest, v8TierMarkers)
+	if rest == "" {
+		rest = "<anonymous>"
+	}
+	return kind + ":" + rest, file, line
+}
+
+// splitTrailingLocation separates a symbol's name from the source location V8
+// appends to it.
+//
+// The obvious rule — split on the last space — breaks on a path containing a
+// space ("JS:*h /app/my project/x.js:10:1" would keep "/app/my" as part of the
+// name). The opposite rule, split on the first space, breaks on the names that
+// legitimately contain one: V8 writes accessors as "get foo" and "set foo".
+//
+// So: prefer the LEFTMOST split whose remainder looks like a rooted path
+// ("/…", "./…", or a scheme like "node:…"), which gets both of those right,
+// and fall back to the rightmost parsable split for locations that are rooted
+// in nothing — V8's "evalmachine.<anonymous>:1:1" and bare filenames.
+func splitTrailingLocation(s string) (head, file string, line int, ok bool) {
+	for i := 0; i < len(s); i++ {
+		if s[i] != ' ' {
+			continue
+		}
+		rest := s[i+1:]
+		if !looksRooted(rest) {
+			continue
+		}
+		if f, l, good := splitFileLineCol(rest); good {
+			return strings.TrimSpace(s[:i]), f, l, true
+		}
+	}
+	if i := strings.LastIndexByte(s, ' '); i > 0 {
+		if f, l, good := splitFileLineCol(s[i+1:]); good {
+			return strings.TrimSpace(s[:i]), f, l, true
+		}
+	}
+	return s, "", 0, false
+}
+
+// looksRooted reports whether a location candidate starts the way a path does:
+// absolute, explicitly relative, or scheme-qualified (node:, file:, webpack:).
+func looksRooted(s string) bool {
+	switch {
+	case strings.HasPrefix(s, "/"), strings.HasPrefix(s, "./"), strings.HasPrefix(s, "../"):
+		return true
+	}
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if c == ':' {
+			return i > 0
+		}
+		if c < 'a' || c > 'z' {
+			return false
+		}
+	}
+	return false
+}
+
+// splitJITKind separates a V8 kind prefix ("JS", "Builtin", "LazyCompile", …)
+// from the rest of the symbol.
+//
+// The prefix is recognised structurally rather than from a fixed list, so a
+// V8 version that adds a kind still parses: everything before the first colon
+// must be plain letters, and the colon must not be doubled. That second
+// condition is what keeps a JVM symbol like "Ljava/lang/String;::indexOf"
+// intact — and so would a C++ "std::vector", were one ever to appear here.
+func splitJITKind(s string) (kind, rest string, ok bool) {
+	i := strings.IndexByte(s, ':')
+	if i <= 0 || i+1 >= len(s) {
+		return "", s, false
+	}
+	if s[i+1] == ':' {
+		return "", s, false
+	}
+	for k := 0; k < i; k++ {
+		if c := s[k]; c < 'A' || (c > 'Z' && c < 'a') || c > 'z' {
+			return "", s, false
+		}
+	}
+	return s[:i], s[i+1:], true
+}
+
+// splitFileLineCol parses "<path>:<line>" or "<path>:<line>:<col>". The path
+// must be non-empty and the numeric parts must really be numeric, so an
+// ordinary symbol containing a colon is not mistaken for a location.
+func splitFileLineCol(s string) (file string, line int, ok bool) {
+	i := strings.LastIndexByte(s, ':')
+	if i <= 0 {
+		return "", 0, false
+	}
+	n, err := strconv.Atoi(s[i+1:])
+	if err != nil || n < 0 {
+		return "", 0, false
+	}
+	head := s[:i]
+
+	// "path:line:col" — the number just parsed was the column; take the line
+	// from the next field left.
+	if j := strings.LastIndexByte(head, ':'); j > 0 {
+		if l, err := strconv.Atoi(head[j+1:]); err == nil && l > 0 {
+			return head[:j], l, true
+		}
+	}
+	if n <= 0 || head == "" {
+		return "", 0, false
+	}
+	return head, n, true
+}
+
+// lookup resolves an address to its compiled region.
+func (p *perfMap) lookup(addr uint64) (perfSym, bool) {
+	if p == nil || len(p.syms) == 0 {
+		return perfSym{}, false
+	}
+	i := sort.Search(len(p.syms), func(i int) bool { return p.syms[i].start > addr })
+	if i == 0 {
+		return perfSym{}, false
+	}
+	s := p.syms[i-1]
+	if addr >= s.start+s.size {
+		return perfSym{}, false // in the gap after a region, not in it
+	}
+	return s, true
+}
+
+// frame renders a resolved JIT symbol.
+//
+// Module is the literal "[jit]" rather than a filename because there is no
+// file: the code was generated into anonymous memory and exists nowhere on
+// disk. Saying so is more useful than leaving it blank, which would read as
+// "we failed to identify the module".
+func (s perfSym) frame(addr uint64) Frame {
+	return Frame{
+		Func:   s.fn,
+		File:   s.file,
+		Line:   s.line,
+		Module: jitModuleName,
+		Offset: addr - s.start,
+	}
+}
+
+// jitModuleName marks a frame as runtime-generated code with no backing file.
+const jitModuleName = "[jit]"

--- a/pkg/symbol/perfmap_linux.go
+++ b/pkg/symbol/perfmap_linux.go
@@ -1,0 +1,126 @@
+//go:build linux
+
+package symbol
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// Locating a live process's perf map.
+//
+// Two things make the path less obvious than /tmp/perf-<pid>.map:
+//
+//  1. The runtime names the file with the pid it can see, which inside a
+//     container is its pid in its OWN namespace, not the one ptop observes it
+//     by. /proc/<pid>/status carries the whole chain in NSpid.
+//  2. The file is in the target's /tmp, which in a container is not ours.
+//     /proc/<pid>/root crosses into its mount namespace.
+//
+// Getting either wrong does not fail loudly — it silently finds no map and
+// every JIT frame stays a bare address, which is exactly the state this is
+// meant to fix. So both are resolved explicitly, and the host path is tried
+// too for the ordinary uncontainerized case.
+
+// perfMapReloadInterval bounds how often a miss re-reads the file. A JIT map
+// grows for the life of the process, so a miss can always mean "compiled since
+// we last read" — without a bound, a stream of genuinely unresolvable
+// addresses would re-read the file on every single frame.
+const perfMapReloadInterval = 2 * time.Second
+
+// perfMapFor returns the parsed perf map for the target, reloading it when the
+// file has grown since the last read. nil when the process has none, which is
+// the normal case for anything that is not a JIT runtime.
+func (s *Symbolizer) perfMapFor() *perfMap {
+	s.jitMu.Lock()
+	defer s.jitMu.Unlock()
+
+	now := time.Now()
+	if s.jitMap != nil && now.Sub(s.jitCheckedAt) < perfMapReloadInterval {
+		return s.jitMap
+	}
+	// A process with no map is the common case; do not stat it on every frame.
+	if s.jitMap == nil && !s.jitCheckedAt.IsZero() && now.Sub(s.jitCheckedAt) < perfMapReloadInterval {
+		return nil
+	}
+	s.jitCheckedAt = now
+
+	path, fi := s.findPerfMap()
+	if path == "" {
+		return s.jitMap
+	}
+	if s.jitMap != nil && fi.Size() == s.jitMap.size {
+		return s.jitMap // unchanged since the last read
+	}
+	f, err := os.Open(path)
+	if err != nil {
+		return s.jitMap
+	}
+	defer f.Close()
+	s.jitMap = parsePerfMap(bufio.NewReader(f), fi.Size())
+	return s.jitMap
+}
+
+// findPerfMap locates the map file, preferring the target's own mount
+// namespace so a containerized runtime is found at all.
+func (s *Symbolizer) findPerfMap() (string, os.FileInfo) {
+	for _, pid := range s.perfMapPIDs() {
+		for _, cand := range []string{
+			fmt.Sprintf("/proc/%d/root/tmp/perf-%d.map", s.pid, pid),
+			fmt.Sprintf("/tmp/perf-%d.map", pid),
+		} {
+			if fi, err := os.Stat(cand); err == nil && fi.Mode().IsRegular() {
+				return cand, fi
+			}
+		}
+	}
+	return "", nil
+}
+
+// perfMapPIDs returns the pids the target may have named its map file with:
+// the innermost namespace pid first (what a containerized runtime writes),
+// then the pid we observe it by.
+func (s *Symbolizer) perfMapPIDs() []int {
+	pids := nsPIDs(s.pid)
+	// Innermost namespace last in NSpid; that is the one the process sees as
+	// its own getpid(), so try it first.
+	for i, j := 0, len(pids)-1; i < j; i, j = i+1, j-1 {
+		pids[i], pids[j] = pids[j], pids[i]
+	}
+	for _, p := range pids {
+		if p == s.pid {
+			return pids
+		}
+	}
+	return append(pids, s.pid)
+}
+
+// nsPIDs reads the NSpid line of /proc/<pid>/status: the process's pid in each
+// nested pid namespace, outermost first. Returns nil when the kernel does not
+// report it (pre-4.1) or the file is unreadable.
+func nsPIDs(pid int) []int {
+	f, err := os.Open(fmt.Sprintf("/proc/%d/status", pid))
+	if err != nil {
+		return nil
+	}
+	defer f.Close()
+	sc := bufio.NewScanner(f)
+	for sc.Scan() {
+		line := sc.Text()
+		if !strings.HasPrefix(line, "NSpid:") {
+			continue
+		}
+		var out []int
+		for _, fld := range strings.Fields(line[len("NSpid:"):]) {
+			if n, err := strconv.Atoi(fld); err == nil {
+				out = append(out, n)
+			}
+		}
+		return out
+	}
+	return nil
+}

--- a/pkg/symbol/perfmap_linux_test.go
+++ b/pkg/symbol/perfmap_linux_test.go
@@ -1,0 +1,136 @@
+//go:build linux
+
+package symbol
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// A live Node process, end to end: start it with --perf-basic-prof, find the
+// map the way the Symbolizer does, and resolve a JIT address through the
+// public API. This is the part unit tests over a fixture cannot cover — that
+// the file is located at all for a running process.
+func TestSymbolizeResolvesLiveNodeJITFrame(t *testing.T) {
+	node, err := exec.LookPath("node")
+	if err != nil {
+		t.Skip("node not on PATH")
+	}
+
+	dir := t.TempDir()
+	script := filepath.Join(dir, "hot.js")
+	src := "function hotLoop(n){let s=0;for(let i=0;i<n;i++)s+=i*7;return s}\n" +
+		"let a=0;const t=setInterval(()=>{a+=hotLoop(300000)},2);\n" +
+		"setTimeout(()=>{clearInterval(t);console.error(a)},60000);\n"
+	if err := os.WriteFile(script, []byte(src), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := exec.Command(node, "--perf-basic-prof", script)
+	cmd.Dir = dir
+	if err := cmd.Start(); err != nil {
+		t.Skipf("start node: %v", err)
+	}
+	pid := cmd.Process.Pid
+	t.Cleanup(func() {
+		_ = cmd.Process.Kill()
+		_, _ = cmd.Process.Wait()
+		_ = os.Remove(fmt.Sprintf("/tmp/perf-%d.map", pid))
+	})
+
+	// Wait for V8 to compile hotLoop and flush it to the map. The tier does
+	// not matter — any entry naming the function proves the plumbing.
+	var entry string
+	deadline := time.Now().Add(30 * time.Second)
+	for time.Now().Before(deadline) && entry == "" {
+		entry = findMapEntry(fmt.Sprintf("/tmp/perf-%d.map", pid), "hotLoop")
+		if entry == "" {
+			time.Sleep(200 * time.Millisecond)
+		}
+	}
+	if entry == "" {
+		t.Skip("node did not emit a hotLoop entry; --perf-basic-prof may be unsupported in this build")
+	}
+
+	start, _, _, ok := splitPerfMapLine(entry)
+	if !ok {
+		t.Fatalf("unparsable map line from a real node: %q", entry)
+	}
+
+	s, err := NewSymbolizer(pid)
+	if err != nil {
+		t.Fatalf("NewSymbolizer: %v", err)
+	}
+	defer s.Close()
+
+	fr := s.Symbolize(start + 1)
+	if fr.Func != "JS:hotLoop" {
+		t.Errorf("Func = %q, want JS:hotLoop (line was %q)", fr.Func, entry)
+	}
+	if !strings.HasSuffix(fr.File, "hot.js") {
+		t.Errorf("File = %q, want …/hot.js", fr.File)
+	}
+	if fr.Line != 1 {
+		t.Errorf("Line = %d, want 1", fr.Line)
+	}
+	if fr.Module != jitModuleName {
+		t.Errorf("Module = %q, want %q", fr.Module, jitModuleName)
+	}
+
+	// An address in no JIT region and no mapped module must still degrade
+	// rather than borrow a neighbouring symbol.
+	if bad := s.Symbolize(0x10); bad.Func != "" {
+		t.Errorf("bogus address resolved to %q", bad.Func)
+	}
+}
+
+func findMapEntry(path, needle string) string {
+	f, err := os.Open(path)
+	if err != nil {
+		return ""
+	}
+	defer f.Close()
+	sc := bufio.NewScanner(f)
+	sc.Buffer(make([]byte, 0, 64*1024), 1<<20)
+	for sc.Scan() {
+		if strings.Contains(sc.Text(), needle) {
+			return sc.Text()
+		}
+	}
+	return ""
+}
+
+func TestNSPIDsReadsOwnStatus(t *testing.T) {
+	pids := nsPIDs(os.Getpid())
+	if len(pids) == 0 {
+		t.Skip("kernel does not report NSpid")
+	}
+	if pids[0] != os.Getpid() {
+		t.Errorf("NSpid[0] = %d, want our own pid %d", pids[0], os.Getpid())
+	}
+}
+
+func TestNSPIDsMissingProcess(t *testing.T) {
+	if got := nsPIDs(-1); got != nil {
+		t.Errorf("nsPIDs(-1) = %v, want nil", got)
+	}
+}
+
+// The innermost namespace pid is what a containerized runtime names its file
+// with, so it must be tried first.
+func TestPerfMapPIDsPrefersInnermostNamespace(t *testing.T) {
+	s := &Symbolizer{pid: os.Getpid()}
+	pids := s.perfMapPIDs()
+	if len(pids) == 0 {
+		t.Fatal("perfMapPIDs returned nothing")
+	}
+	if pids[len(pids)-1] != os.Getpid() {
+		t.Errorf("outermost pid = %d, want %d last", pids[len(pids)-1], os.Getpid())
+	}
+}

--- a/pkg/symbol/perfmap_test.go
+++ b/pkg/symbol/perfmap_test.go
@@ -1,0 +1,193 @@
+package symbol
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+func loadFixtureMap(t *testing.T) *perfMap {
+	t.Helper()
+	f, err := os.Open("testdata/perfmap/node22.map")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+	fi, err := f.Stat()
+	if err != nil {
+		t.Fatal(err)
+	}
+	return parsePerfMap(f, fi.Size())
+}
+
+// The single most important property. V8 emits one function once per
+// optimization tier, marked ~ + ^ *. Left alone, a deploy diff keyed on
+// function name would show functions appearing and disappearing every time V8
+// re-tiered them under a slightly different load — churn produced by warm-up,
+// indistinguishable from a real change. The fixture is a real Node 22 map and
+// contains all four tiers of the same function.
+func TestPerfMapNormalizesV8Tiers(t *testing.T) {
+	pm := loadFixtureMap(t)
+
+	var tiers []perfSym
+	for _, s := range pm.syms {
+		if strings.HasSuffix(s.fn, "hotSmall") {
+			tiers = append(tiers, s)
+		}
+	}
+	if len(tiers) < 3 {
+		t.Fatalf("fixture should carry several tiers of hotSmall, got %d", len(tiers))
+	}
+	for _, s := range tiers {
+		if s.fn != "JS:hotSmall" {
+			t.Errorf("Func = %q, want JS:hotSmall (tier marker not stripped)", s.fn)
+		}
+		if s.file != "/app/jittarget.js" || s.line != 2 {
+			t.Errorf("location = %s:%d, want /app/jittarget.js:2", s.file, s.line)
+		}
+	}
+	// They are distinct compiled regions, so they must remain distinct
+	// entries — normalizing the NAME must not collapse the address ranges.
+	seen := map[uint64]bool{}
+	for _, s := range tiers {
+		if seen[s.start] {
+			t.Errorf("duplicate start %#x: distinct tiers were merged", s.start)
+		}
+		seen[s.start] = true
+	}
+}
+
+func TestParsePerfMapName(t *testing.T) {
+	cases := []struct {
+		in       string
+		fn, file string
+		line     int
+	}{
+		{"JS:^hotSmall /app/server.js:2:18", "JS:hotSmall", "/app/server.js", 2},
+		{"JS:~hotSmall /app/server.js:2:18", "JS:hotSmall", "/app/server.js", 2},
+		{"JS:*handler /app/a b/x.js:10:1", "JS:handler", "/app/a b/x.js", 10},
+		// V8 spells accessors with a space in the NAME, so the location
+		// cannot simply be "everything after the first space".
+		{"JS:^get length /app/x.js:5:1", "JS:get length", "/app/x.js", 5},
+		{"JS:^set value ./lib/y.js:9:3", "JS:set value", "./lib/y.js", 9},
+		// Node's builtins are scheme-qualified, not absolute paths.
+		{"JS:^requireBuiltin node:internal/bootstrap/realm:420:24",
+			"JS:requireBuiltin", "node:internal/bootstrap/realm", 420},
+		{"JS:^normalizeString node:path:92:25", "JS:normalizeString", "node:path", 92},
+		// Rooted in nothing: the rightmost-parsable fallback.
+		{"Eval:~ evalmachine.<anonymous>:1:1", "Eval:<anonymous>", "evalmachine.<anonymous>", 1},
+		// Anonymous function: V8 emits the marker with no name at all.
+		{"JS:~ /app/server.js:6:23", "JS:<anonymous>", "/app/server.js", 6},
+		{"Eval:~ /app/server.js:1:1", "Eval:<anonymous>", "/app/server.js", 1},
+		// No location at all.
+		{"Builtin:RecordWriteSaveFP", "Builtin:RecordWriteSaveFP", "", 0},
+		{"Stub:CEntryStub", "Stub:CEntryStub", "", 0},
+		// Older V8 spelling.
+		{"LazyCompile:*parse /app/p.js:44:9", "LazyCompile:parse", "/app/p.js", 44},
+		// line only, no column.
+		{"JS:^f /app/s.js:7", "JS:f", "/app/s.js", 7},
+		// A JVM symbol: no kind prefix to strip, and the doubled colon must
+		// survive intact.
+		{"Ljava/lang/String;::indexOf", "Ljava/lang/String;::indexOf", "", 0},
+		{"Lcom/acme/Svc;::handle", "Lcom/acme/Svc;::handle", "", 0},
+		// A bare name with no colon at all.
+		{"my_native_thunk", "my_native_thunk", "", 0},
+		// A colon that is not a kind prefix (digits before it).
+		{"0x42:thing", "0x42:thing", "", 0},
+	}
+	for _, c := range cases {
+		t.Run(c.in, func(t *testing.T) {
+			fn, file, line := parsePerfMapName(c.in)
+			if fn != c.fn || file != c.file || line != c.line {
+				t.Errorf("= %q, %q, %d; want %q, %q, %d", fn, file, line, c.fn, c.file, c.line)
+			}
+		})
+	}
+}
+
+func TestSplitPerfMapLine(t *testing.T) {
+	start, size, name, ok := splitPerfMapLine("edfc50005260 488 JS:+hotSmall /app/x.js:2:18")
+	if !ok || start != 0xedfc50005260 || size != 0x488 || name != "JS:+hotSmall /app/x.js:2:18" {
+		t.Errorf("= %#x, %#x, %q, %v", start, size, name, ok)
+	}
+
+	// A perf map is written by a live process with no locking, so the tail can
+	// be torn mid-write. A bad line must be skipped, never fail the parse.
+	for _, bad := range []string{"", "onlyonefield", "notahex 10 name", "1000 nothex name", "1000 20", "1000 20   "} {
+		if _, _, _, ok := splitPerfMapLine(bad); ok {
+			t.Errorf("accepted malformed line %q", bad)
+		}
+	}
+}
+
+func TestPerfMapTornTailStillParses(t *testing.T) {
+	in := "1000 100 JS:^a /x.js:1:1\n2000 200 JS:^b /x.js:2:1\n3000 10"
+	pm := parsePerfMap(strings.NewReader(in), int64(len(in)))
+	if len(pm.syms) != 2 {
+		t.Fatalf("len = %d, want 2 (the torn last line dropped, the rest kept)", len(pm.syms))
+	}
+	if _, ok := pm.lookup(0x2050); !ok {
+		t.Error("the complete entries before the torn line were lost")
+	}
+}
+
+func TestPerfMapLookup(t *testing.T) {
+	in := "1000 100 JS:^a /x.js:1:1\n3000 100 JS:^b /x.js:9:1\n"
+	pm := parsePerfMap(strings.NewReader(in), int64(len(in)))
+
+	cases := []struct {
+		addr uint64
+		want string
+	}{
+		{0x0fff, ""},     // before the first region
+		{0x1000, "JS:a"}, // first byte
+		{0x10ff, "JS:a"}, // last byte
+		{0x1100, ""},     // one past the end — the gap, not the region
+		{0x2000, ""},     // between regions
+		{0x3050, "JS:b"},
+		{0x3100, ""}, // past the last region
+	}
+	for _, c := range cases {
+		sym, ok := pm.lookup(c.addr)
+		if c.want == "" {
+			if ok {
+				t.Errorf("lookup(%#x) resolved to %q, want a miss", c.addr, sym.fn)
+			}
+			continue
+		}
+		if !ok || sym.fn != c.want {
+			t.Errorf("lookup(%#x) = %q,%v want %q", c.addr, sym.fn, ok, c.want)
+		}
+	}
+
+	if _, ok := (*perfMap)(nil).lookup(0x1000); ok {
+		t.Error("nil perfMap resolved an address")
+	}
+}
+
+// V8 reuses an address after a deopt, writing a new line for the same start.
+// The later line is the truth.
+func TestPerfMapLastEntryWinsAtSameAddress(t *testing.T) {
+	in := "1000 100 JS:~old /x.js:1:1\n1000 100 JS:^new /x.js:1:1\n"
+	pm := parsePerfMap(strings.NewReader(in), int64(len(in)))
+	sym, ok := pm.lookup(0x1050)
+	if !ok || sym.fn != "JS:new" {
+		t.Errorf("lookup = %q,%v want JS:new (the later line)", sym.fn, ok)
+	}
+}
+
+// A JIT frame has no file behind it, and the frame must say that rather than
+// leave the module blank, which reads as a failure to identify it.
+func TestPerfSymFrame(t *testing.T) {
+	s := perfSym{start: 0x1000, size: 0x100, fn: "JS:hotSmall", file: "/app/x.js", line: 2}
+	fr := s.frame(0x1040)
+	if fr.Func != "JS:hotSmall" || fr.File != "/app/x.js" || fr.Line != 2 {
+		t.Errorf("frame = %+v", fr)
+	}
+	if fr.Module != "[jit]" {
+		t.Errorf("Module = %q, want [jit]", fr.Module)
+	}
+	if fr.Offset != 0x40 {
+		t.Errorf("Offset = %#x, want 0x40", fr.Offset)
+	}
+}

--- a/pkg/symbol/proc_linux.go
+++ b/pkg/symbol/proc_linux.go
@@ -10,6 +10,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"time"
 )
 
 // segment is one executable, file-backed mapping from /proc/<pid>/maps.
@@ -31,6 +32,12 @@ type Symbolizer struct {
 
 	buildOnce   sync.Once
 	execBuildID string
+
+	// JIT side file (perf map), for frames in anonymous executable memory.
+	// Reloaded on demand because a JIT map grows for the life of the process.
+	jitMu        sync.Mutex
+	jitMap       *perfMap
+	jitCheckedAt time.Time
 }
 
 // NewSymbolizer snapshots pid's executable mappings. The set of mapped modules
@@ -45,10 +52,18 @@ func NewSymbolizer(pid int) (*Symbolizer, error) {
 }
 
 // Symbolize resolves a runtime address. It never errors: an address in an
-// unmapped / anonymous / unreadable region degrades to a bare Frame{Offset}.
+// unmapped / unreadable region degrades to a bare Frame{Offset}.
+//
+// An address in no file-backed segment is not necessarily junk — it is where
+// JIT'd code lives, since V8 and the JVM compile into anonymous executable
+// memory. Those are resolved from the runtime's perf map (perfmap.go) before
+// giving up.
 func (s *Symbolizer) Symbolize(addr uint64) Frame {
 	seg, ok := s.segFor(addr)
 	if !ok {
+		if sym, hit := s.perfMapFor().lookup(addr); hit {
+			return sym.frame(addr)
+		}
 		return Frame{Offset: addr}
 	}
 	m := s.module(seg.path)

--- a/pkg/symbol/testdata/cfixture/main.c
+++ b/pkg/symbol/testdata/cfixture/main.c
@@ -1,0 +1,21 @@
+// Fixture for DWARF line resolution. The line numbers below are asserted by
+// dwarf_test.go — adding lines above a marked function will break the test,
+// which is the point: it proves the line came from the debug info and not from
+// a coincidence.
+#include <stdlib.h>
+
+void *alloc_small(void) {
+    return malloc(128); /* LINE:alloc_small_body */
+}
+
+void *alloc_big(void) {
+    return malloc(256 * 1024); /* LINE:alloc_big_body */
+}
+
+int main(void) {
+    void *a = alloc_small();
+    void *b = alloc_big();
+    free(a);
+    free(b);
+    return 0;
+}

--- a/pkg/symbol/testdata/perfmap/node22.map
+++ b/pkg/symbol/testdata/perfmap/node22.map
@@ -1,0 +1,52 @@
+18a1000 318 Builtin:DeoptimizationEntry_Eager
+18a1320 318 Builtin:DeoptimizationEntry_Lazy
+18a1640 7f4 Builtin:RecordWriteSaveFP
+18a1e40 554 Builtin:RecordWriteIgnoreFP
+18a23a0 10c Builtin:EphemeronKeyBarrierSaveFP
+18a24c0 ac Builtin:EphemeronKeyBarrierIgnoreFP
+18a2580 8 Builtin:DummyBuiltin
+18a25a0 2c Builtin:IndirectPointerBarrierSaveFP
+18a25e0 2c Builtin:IndirectPointerBarrierIgnoreFP
+18a2620 2c Builtin:AdaptorWithBuiltinExitFrame0
+18a2660 40 Builtin:AdaptorWithBuiltinExitFrame1
+18a26c0 40 Builtin:AdaptorWithBuiltinExitFrame2
+18a2720 40 Builtin:AdaptorWithBuiltinExitFrame3
+18a2780 40 Builtin:AdaptorWithBuiltinExitFrame4
+18a27e0 40 Builtin:AdaptorWithBuiltinExitFrame5
+18a2840 168 Builtin:CallFunction_ReceiverIsNullOrUndefined
+18a29c0 1b4 Builtin:CallFunction_ReceiverIsNotNullOrUndefined
+18a2b80 1dc Builtin:CallFunction_ReceiverIsAny
+18a2d60 e8 Builtin:CallBoundFunction
+18a2e60 3d0 Builtin:CallWrappedFunction
+18a3240 c0 Builtin:Call_ReceiverIsNullOrUndefined
+18a3320 c0 Builtin:Call_ReceiverIsNotNullOrUndefined
+18a3400 c0 Builtin:Call_ReceiverIsAny
+18a34e0 320 Builtin:Call_ReceiverIsNullOrUndefined_Baseline_Compact
+18a3820 320 Builtin:Call_ReceiverIsNullOrUndefined_Baseline
+18a3b60 3b0 Builtin:Call_ReceiverIsNotNullOrUndefined_Baseline_Compact
+18a3f20 3b0 Builtin:Call_ReceiverIsNotNullOrUndefined_Baseline
+18a42e0 3b0 Builtin:Call_ReceiverIsAny_Baseline_Compact
+18a46a0 3b0 Builtin:Call_ReceiverIsAny_Baseline
+18a4a60 310 Builtin:Call_ReceiverIsNullOrUndefined_WithFeedback
+18a4d80 310 Builtin:Call_ReceiverIsNotNullOrUndefined_WithFeedback
+18a50a0 310 Builtin:Call_ReceiverIsAny_WithFeedback
+18a53c0 2fc Builtin:CallProxy
+18a56c0 ac Builtin:CallVarargs
+18a5780 488 Builtin:CallWithSpread
+18a5c20 758 Builtin:CallWithSpread_Baseline
+18a6380 7a0 Builtin:CallWithSpread_WithFeedback
+18a6b40 4dc Builtin:CallWithArrayLike
+18a7020 7d4 Builtin:CallWithArrayLike_WithFeedback
+18a7800 c4 Builtin:CallForwardVarargs
+2ed7f41848 5 Eval:~ /app/jittarget.js:1:1
+2ed7f41978 61 JS:~ /app/jittarget.js:1:1
+2ed7f4c5c8 2e JS:~ /app/jittarget.js:6:23
+2ed7f4c660 23 JS:~hotSmall /app/jittarget.js:2:18
+edfc50005260 488 JS:+hotSmall /app/jittarget.js:2:18
+edfc50005ea0 198 JS:^hotSmall /app/jittarget.js:2:18
+2ed7f4c738 43 JS:~hotBig /app/jittarget.js:3:16
+edfc50006060 650 JS:+hotBig /app/jittarget.js:3:16
+edfc50006760 288 JS:^hotBig /app/jittarget.js:3:16
+edfc50006a20 574 JS:*hotBig /app/jittarget.js:3:16
+edfc50007000 2f8 JS:*hotSmall /app/jittarget.js:2:18
+edfc500080e0 4b0 JS:+hotSmall /app/jittarget.js:2:18

--- a/proto/event.proto
+++ b/proto/event.proto
@@ -204,6 +204,11 @@ message HeapCallSite {
   // (the full leaf-first stack). A sentinel (resolves to not-found) when the
   // stack walk failed.
   uint64 stack_id = 12;
+  // Total bytes ever allocated from this site. Unlike live_bytes this only
+  // grows, so it is comparable across a capture window regardless of what the
+  // GC or free() did in between — and it is the ranking signal on the Go lane,
+  // where live_bytes is not measured at all.
+  uint64 alloc_bytes = 13;
 }
 
 // HeapSnapshot is the periodic heap aggregate. live_heap_bytes and
@@ -215,6 +220,25 @@ message HeapSnapshot {
   double alloc_rate = 2;
   uint64 suspected_leak_bytes = 3;
   repeated HeapCallSite top_call_sites = 4;
+  // Bytes allocated per second over the last window. Measured on every lane.
+  double alloc_bytes_rate = 5;
+  // Which mechanism produced this snapshot: "libc" (uprobes on
+  // malloc/calloc/realloc/free) or "go" (a uprobe on runtime.mallocgc). A Go
+  // process allocates through neither malloc nor free, so on the libc lane its
+  // call-site axis comes back empty; the go lane is what makes func/file/line
+  // — and therefore attribution to a commit — reachable for a Go target.
+  // Diagnostic: branch on live_measured, not on this.
+  string lane = 6;
+  // Whether live_heap_bytes, suspected_leak_bytes, HeapCallSite.live_bytes and
+  // HeapCallSite.avg_lifetime_ms mean anything in this snapshot.
+  //
+  // False on the "go" lane: nothing frees a Go allocation at a point a probe
+  // can observe (the GC sweeper reclaims spans in bulk, asynchronously, naming
+  // no object), so those fields carry 0 as "NOT MEASURED", not as "measured,
+  // and zero". A consumer diffing two deploys must check this before comparing
+  // them — an unmeasured 0 read against a libc-lane baseline reports the live
+  // heap collapsing to nothing when in fact nothing changed.
+  bool live_measured = 7;
 }
 
 // ─── Threads ────────────────────────────────────────────────────────────────

--- a/proto/event.proto
+++ b/proto/event.proto
@@ -35,7 +35,7 @@ message StackRef {
 // StackFrame is one symbolized frame of a captured stack (#54), leaf-first.
 // func is "" when the address couldn't be resolved to a function (stripped
 // non-Go module — module+offset still locate it); file/line are populated only
-// for Go modules in this cut (C/C++ file:line needs DWARF). offset is
+// from the Go line table, or from DWARF for C/C++ built with debug info. offset is
 // module-relative, so it is comparable across runs/ASLR.
 message StackFrame {
   string func = 1;
@@ -186,7 +186,8 @@ message HeapEvent {
 // call_site is the raw instruction pointer; func/file/line/module/offset are its
 // symbolization (#54). func is "" when the address can't be resolved to a
 // function (stripped non-Go module — module+offset still locate it); file/line
-// are set only for Go modules in this cut (C/C++ file:line needs DWARF). addr_hex
+// come from the Go line table, or from DWARF for C/C++ built with debug info; they
+// stay empty for a module with neither. addr_hex
 // is the raw-address fallback ("0x…", or "unknown" when the stack walk failed).
 message HeapCallSite {
   uint64 call_site = 1;
@@ -196,7 +197,7 @@ message HeapCallSite {
   double avg_lifetime_ms = 5;
   bool suspected = 6; // has live allocations older than the leak threshold
   string func = 7; // resolved function name ("" if unresolved)
-  string file = 8; // source file (Go only in this cut; "" otherwise)
+  string file = 8; // source file ("" when the module carries no line info)
   int32 line = 9; // source line (0 if unknown)
   string module = 10; // backing module basename ("" if unresolved)
   uint64 offset = 11; // module-relative offset of the call site


### PR DESCRIPTION
Upstream work for **sunnysystems/witness#53** (the symbol axis) and the collector half of **sunnysystems/witness#36** (the overhead benchmark). Four commits, each independently reviewable.

## The problem, in one table

The symbol axis is the only part of the event surface carrying `func`/`file:line` — it is what lets a consumer cross a behavioural delta against a code diff. It did not work in three of the four runtime families that matter:

| Runtime | Before | After |
|---|---|---|
| **Go** | axis **empty** — the runtime never calls libc `malloc` | `func` + `file:line` via a `runtime.mallocgc` uprobe |
| **Node** | resolves to `libv8` | `func` + `file:line` via the perf map |
| **JVM** | resolves to `libjvm` | symbol via the perf map |
| **C/C++** | function name only | `func` + `file:line` via DWARF |

## 1. `e5715b6` — the Go allocation axis

`heap.bpf.c` hangs its uprobes on the libc allocator, and the Go runtime never calls it: `runtime.mallocgc` carves out of per-P caches backed by mmap'd spans. A Go process produced not a *sparse* call-site axis but an **empty** one.

`goalloc.bpf.c` attaches one uprobe to `runtime.mallocgc`, the single funnel every Go heap allocation passes through — `newobject`, `makeslice`, `growslice` and `reflect.unsafe_New` all call it, and the size-specialised fast paths are dispatched from inside its body.

Three choices worth stating, because each could have gone the other way:

- **Entry probe only, no uretprobe.** A uretprobe patches the return address on the stack; the Go runtime copies and moves goroutine stacks as they grow, and the patched address is not one it can relocate.
- **Live bytes and lifetime are NOT reported, and the snapshot says so.** Nothing frees a Go allocation where a probe can see it — the GC sweeper reclaims spans in bulk, naming no object. So `live_measured=false`, and those fields carry 0 meaning *not measured*. Publishing a zero would make a deploy diff read as the live heap collapsing to nothing when nothing had changed.
- **The Go lane wins for a cgo build too**, even though libc *is* mapped there. Trying libc first would attach happily and report an empty axis forever — a silent wrong answer, worse than a loud missing one.

Go uses ABIInternal, not the C ABI: `mallocgc`'s first argument arrives in `RAX` on x86-64 and `X0` on arm64. `PT_REGS_PARM1` would read `rdi`, a register `mallocgc` does not use. `PT_REGS_RC` names exactly those two registers on those two arches, so the probe is portable without an arch switch.

**Verified against a real collector** (privileged container, kernel 7.0, arm64). Byte counts exact against the target's own arithmetic:

```
ALLOC_BYTES COUNT     FUNC                  FILE:LINE
1027473408  15678     main.allocBig         gotarget.go:22
198487936   1550687   main.allocSmall       gotarget.go:13     128 x 1,550,687 exactly
37248000    776       main.allocSmall       gotarget.go:12      48,000 x 776 exactly
```

Repeated with `-ldflags="-s -w"`, which leaves **no `.symtab` at all**: still fully resolved, because `.gopclntab` survives stripping. That is the production build, so the fallback is not optional. The libc lane was re-verified unchanged against a C target on the same runs.

## 2. `1d822c6` — DWARF line numbers for C/C++

`.symtab` gives a function name; the source position lives only in DWARF, which nothing here read. Observable on a real capture — two call sites that were both an indistinguishable `main`:

```
ctarget.c:14   211028 allocations
ctarget.c:15     3297 allocations     211028/3297 = 64.0, the fixture's exact ratio
```

The awkward part is lifetime, and the resolution is a budget. A `Module` deliberately holds no open file handle, so the debug bytes are copied in while the file is open and parsed later. Copying is unbounded in principle, so it is capped; past the cap the module resolves without `file:line` — a real degradation but a safe one. The alternative, one file handle per mapped module for the life of the process, trades a bounded memory cost for an unbounded fd cost.

## 3. `52a4cc2` — JIT frames for Node and the JVM

Both ecosystems already write `/tmp/perf-<pid>.map` for `perf(1)`, so this reads that rather than inventing a mechanism.

**The tier marker is the part that took the thought.** V8 emits the same function once per optimization tier:

```
JS:~hotSmall /app/server.js:2:18     interpreted
JS:+hotSmall /app/server.js:2:18     baseline
JS:^hotSmall /app/server.js:2:18     optimized
```

One function at three addresses. Left alone, a consumer diffing deploys by call-site name would watch functions appear and vanish purely because V8 re-tiered them under slightly different load — churn produced by every warm-up, indistinguishable from a real change. The marker is stripped; the name collapses, the address ranges do not.

Two parsing rules that are not the obvious ones, because the obvious one is wrong on real input:

- The name/location split is **not** "the last space". V8 spells accessors with a space in the *name* (`get length`), and paths can contain spaces. It prefers the leftmost split whose remainder looks rooted (`/…`, `./…`, `node:…`), falling back to the rightmost parsable split for V8's own `evalmachine.<anonymous>:1:1`.
- The kind prefix is recognised structurally, not from a list, so a new V8 kind still parses — and the rule (letters only, not a doubled colon) is what leaves `Ljava/lang/String;::indexOf` intact.

Finding the file is its own problem, and getting it wrong fails **silently**: the runtime names the map with the pid *it* can see and puts it in *its* `/tmp`. Verified across a container boundary, which is the shape that matters — the container wrote `/tmp/perf-1.map` as pid 1, the host observed it as pid 943406, and four tiers at four addresses all resolved to `JS:hotSmall` at `jittarget.js:2`.

## 4. `ecf551f` — measure the overhead, and let the expensive probe be turned off

ptop shipped `overhead <0.5%` with nothing behind it: no harness, no workload, no raw data. It was also the wrong *shape* of claim — the dominant cost is a uprobe that fires once per allocation, so no single percentage can be true for both an idle service and one allocating 14 million times a second.

Target CPU time per unit of work, 2-core aarch64, kernel 7.0:

| allocation rate | all probes | without heap | heap alone |
|---|---|---|---|
| 0 (control) | −4.9% | −4.9% | −4.6% |
| 11k/s | +14.8% | +0.1% | +15.9% |
| 114k/s | +109.9% | +0.2% | +98.1% |
| 1.2M/s | +404.4% | −0.9% | +358.1% |
| 14.4M/s | +3213.9% | +2.3% | +3159.1% |

**Everything except the heap probe is free** at every rate tested — the old `<0.5%` was, by accident, about right for them. **The heap probe is the entire cost.** Hence `--disable`: knowing the cost is only useful if it can be declined.

The noise floor is measured, not assumed: the control row allocates nothing, so every cell in it *should* read zero. It reads ±4.9%. That is this host's resolution, published beside the table so a reader can tell an overhead from a rounding artefact.

**The harness took three attempts, and the failures are in its comments** because each produced a confident table that was wrong: guessing the work size left the baseline finishing in 200 microseconds; sizing by a calibrated baseline put the instrumented arm into the minutes; sizing by the expensive arm left the baseline at 0.1s, where the decomposition cell came out at **−28.8%** — "attaching ptop made the target faster". What fixed it: per-configuration sizing, a per-iteration metric, and **CPU time rather than wall time** (by wall time on this host, identical runs varied 65x).

The sweep was run twice end to end; independent runs agreed within a few percent at every point. Raw output for both is in `bench/results/`.

## What is not verified

- **JVM**: the symbol format is parsed and unit-tested, but never run against a live JVM. Node was, twice.
- **amd64**: the Go probe is written for both arches, but only **arm64** was exercised — that is what the test host is.
- Frame **symbolization** is verified; whether the eBPF stack walk *reaches* JIT frames depends on V8 frame pointers and is a separate question.
- The benchmark host has 2 cores. Hence the published noise floor and the duplicate sweep.

## Unrelated, but seen while verifying

`TestServeBackpressureMetaOverGRPC` is load-sensitive on a small host: commit `95a1540` — before any of this work — fails it 2 runs in 5 under CPU load here, and passes 8 of 8 idle. Not introduced here, but the test has been hardened once already (`b8028e6`) and the stall it forces is still not forced enough.

`make all` green (both lanes: default and `-tags=ebpf`), `go test -race ./...` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PxdUB3Jq8LJSXTQUzqG37v