### PR TITLE
Measure the CPU axis in nanoseconds instead of sampling for it

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,7 +71,7 @@ ptop/
 │   │   ├── programs/              .bpf.c sources, compiled by `make gen`
 │   │   │   ├── target.bpf.h       shared pid-namespace target filter
 │   │   │   ├── syscalls.bpf.c     raw_syscalls/sys_{enter,exit}
-│   │   │   ├── cpu.bpf.c          perf_event @ 100Hz/CPU
+│   │   │   ├── cpu.bpf.c          sched_switch → target on-CPU nanoseconds
 │   │   │   ├── io.bpf.c           VFS read/write/fsync
 │   │   │   ├── network.bpf.c      sock tracepoints + tcp kprobes
 │   │   │   ├── threads.bpf.c      sched_switch
@@ -92,7 +92,7 @@ ptop/
 │   │   ├── caps.go                CAP_BPF / CAP_PERFMON detection
 │   │   ├── caps_stub.go           non-Linux stub
 │   │   ├── caps_test.go
-│   │   ├── cpu.go                 perf_event tracer
+│   │   ├── cpu.go                 on-CPU time tracer (sched_switch)
 │   │   ├── syscalls.go            raw_syscalls tracepoint loader
 │   │   ├── network.go             sock tracepoints + connection seeding
 │   │   ├── io.go                  VFS syscall tracker loader
@@ -149,7 +149,8 @@ ptop/
 │       ├── shed.go                snapshot vs per-occurrence rate class (#108)
 │       ├── source_{linux,darwin}.go  platform source labels (Source*)
 │       ├── cpu_proc.go            /proc/<pid>/stat utime+stime
-│       ├── cpu_ebpf.go            eBPF perf_event sampling
+│       ├── cpu_ebpf.go            eBPF on-CPU time → CPU%
+│       ├── cpu_rate.go            on-CPU ns → single-core % (build-tag-free)
 │       ├── threads_proc.go        /proc/<pid>/task/*/stat + wchan
 │       ├── threads_ebpf.go        sched_switch → CPU% real-time
 │       ├── mem_proc.go            /proc/<pid>/statm + faults
@@ -320,6 +321,47 @@ hidden. **A new collector value type defaults to the snapshot class**, so
 adding one cannot silently starve it; add it to `isPerOccurrenceValue` /
 `isPerOccurrence` only if it really is emitted per occurrence.
 
+### A percentage of CPU is a time, so measure the time
+
+The CPU axis used to be a perf_event at 100Hz per CPU whose BPF program
+incremented a counter whenever the target happened to be on-CPU; the collector
+divided that count by the nominal rate to get a percentage. It disagreed with
+`/proc` in both directions, and #108 reported three runs of one binary
+measuring 0%, 1% and 19% where `/proc` said 2.5% every time. Two independent
+reasons, both structural:
+
+- **The signal was a handful of samples.** A process using 2.5% of a core draws
+  2.5 samples a second. A one-second bucket of that is shot noise, and a
+  perfectly busy second can legitimately draw ZERO — which reads as an idle
+  process, not as a gap. Taking a p95 over a short window then reports the
+  maximum of the noise, so the cheap arm of an A/B pair can measure hotter than
+  the expensive one and invert the comparison the axis exists for.
+- **The nominal rate was not the achieved rate.** In `freq` mode the kernel
+  re-derives the sampling period from the count it observes at scheduler ticks,
+  and ticks do not run on an idle CPU; after an idle stretch the period inflates
+  and the event fires well below the requested rate while the collector keeps
+  dividing by the requested rate. Measured on a lightly loaded 10-CPU host:
+  80–90Hz per CPU, drifting window to window — a standing undercount, worst on
+  exactly the quiet machines where a 2.5% process lives.
+
+`cpu.bpf.c` now brackets the target's slices at `sched_switch` and accumulates
+nanoseconds, which is the same quantity `/proc` reports as `utime+stime`, at
+nanosecond resolution and with no rate to assume. Measured against
+`sum_exec_runtime` over a duty-cycle sweep, it agrees to within about one
+percent of the reading at every point from 2.5% to 400% of a core, and where
+the truth moves the axis moves with it.
+
+`cmd/ebpfselftest` is the gate: it runs the same pair the report was about —
+one workload at a few percent of a core, one at ten times that — and fails if
+the axis and `/proc` disagree by more than 15%. The quiet point is the one that
+matters, because a full CPU burn is the single case the old sampler got right.
+
+The general rule: sampling estimates *where* time went (which stack, which call
+site) and is the only affordable way to get that. It is the wrong instrument
+for *how much*, whenever the kernel already accounts the quantity exactly.
+Before adding a counter that has to be divided by an assumed rate, check
+whether something already counts the thing itself.
+
 ### The observer's cost is charged to the target
 
 A uprobe runs on the thread that tripped it, so its cost lands in the TARGET's
@@ -435,6 +477,8 @@ Two caveats worth knowing before extending this:
 
 Verify both modes with `make ebpf-selftest` → `sudo ./bin/ebpf-selftest`: it
 runs one workload and checks the pid filter and the cgroup filter against it
+(and then two quieter ones, to check the CPU axis against `/proc` — see the
+section on measuring time above)
 (the cgroup phase reports SKIP where there is no subtree to target — a cgroup
 v1 host, or a cgroup namespace that shows `/` as its own root).
 

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ what the live binary renders against a real PID.
 │· gc          ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░    -- ⏳ nanosleep  ││18:06:31.367 I/O  write /var/log/app/api.log 512B     │
 │■ http-pool   ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░    -- ⏳ epoll_wait ││18:06:31.367  FD  openat → fd=15 /tmp/tmpXXXX         │
 └──────────────────────────────────────────────────────────────────────────────────┘└──────────────────────────────────────────────────────┘
- F1-F7 tabs  ·  q quit  ·  p pause  ·  / filter  ·  s snapshot  ·  e export                                       eBPF kernel 6.8 · sampling 100Hz
+ F1-F7 tabs  ·  q quit  ·  p pause  ·  / filter  ·  s snapshot  ·  e export                                       eBPF kernel 6.8 · cpu from sched_switch
 ```
 
 A live recording (vhs script in [`assets/demo.tape`](assets/demo.tape)) will
@@ -219,7 +219,7 @@ overlay shows which one is active per tab.
 eBPF programs in `internal/bpf/programs/`:
 
 - `syscalls.bpf.c` — raw_syscalls/sys_{enter,exit}
-- `cpu.bpf.c` — perf_event @ 100Hz/CPU
+- `cpu.bpf.c` — sched_switch → the target's on-CPU nanoseconds
 - `io.bpf.c` — VFS read/write/fsync + filesystem semantics (denials/deletes/renames)
 - `network.bpf.c` — sock tracepoints + tcp kprobes + connection errors (RST/retransmit)
 - `threads.bpf.c` — sched_switch

--- a/cmd/ebpfselftest/main.go
+++ b/cmd/ebpfselftest/main.go
@@ -7,14 +7,18 @@
 //	sudo ./bin/ebpf-selftest
 //
 // It targets its own process, generates a known workload (CPU burn + write
-// syscalls), and reports whether the eBPF counters moved. Exit code is 0 on
-// PASS, 1 on FAIL — usable directly in CI / scripts.
+// syscalls), and reports whether the eBPF counters moved. It then runs a
+// second, deliberately quiet workload and checks that the CPU axis agrees
+// with the kernel's own accounting of it — a counter that moves is not the
+// same as a counter that is right (#108). Exit code is 0 on PASS, 1 on FAIL —
+// usable directly in CI / scripts.
 package main
 
 import (
 	"errors"
 	"fmt"
 	"os"
+	"strconv"
 	"strings"
 	"time"
 
@@ -83,11 +87,11 @@ func run() error {
 
 	failed := false
 
-	samples, _ := cpuT.SampleCount()
-	if samples > 0 {
-		fmt.Printf("PASS  cpu:      %d on-CPU samples observed\n", samples)
+	onCPU, _ := cpuT.OnCPUNanos()
+	if onCPU > 0 {
+		fmt.Printf("PASS  cpu:      %v of on-CPU time observed\n", time.Duration(onCPU))
 	} else {
-		fmt.Fprintln(os.Stderr, "FAIL  cpu:      0 samples — the eBPF filter did not match this process")
+		fmt.Fprintln(os.Stderr, "FAIL  cpu:      0ns on-CPU — the eBPF filter did not match this process")
 		failed = true
 	}
 
@@ -107,12 +111,16 @@ func run() error {
 	case cgT == nil:
 		fmt.Printf("SKIP  cgroup:   %s\n", cgroupWhy)
 	default:
-		if samples, _ := cgT.SampleCount(); samples > 0 {
-			fmt.Printf("PASS  cgroup:   %d on-CPU samples observed via cgroup subtree filter\n", samples)
+		if ns, _ := cgT.OnCPUNanos(); ns > 0 {
+			fmt.Printf("PASS  cgroup:   %v of on-CPU time observed via cgroup subtree filter\n", time.Duration(ns))
 		} else {
-			fmt.Fprintln(os.Stderr, "FAIL  cgroup:   0 samples — the cgroup subtree filter did not match this process")
+			fmt.Fprintln(os.Stderr, "FAIL  cgroup:   0ns on-CPU — the cgroup subtree filter did not match this process")
 			failed = true
 		}
+	}
+
+	if !checkCPUAccuracy(cpuT) {
+		failed = true
 	}
 
 	if failed {
@@ -146,4 +154,133 @@ func selfCgroup() (spec, why string) {
 		return "", "this process sees its own cgroup as the root (cgroup namespace) — no subtree to target"
 	}
 	return "", "no cgroup v2 (unified) entry in /proc/self/cgroup — cgroup v1 only host"
+}
+
+// checkCPUAccuracy is the regression test for #108: the axis has to report
+// what the target actually used, not merely something greater than zero.
+//
+// The two points below are the pair from that report — a process at a few
+// percent of a core and one at roughly ten times that. The quiet one matters
+// most: it is where the old 100Hz sampler fell apart, drawing two or three
+// samples a second, so that a one-second bucket was shot noise and three runs
+// of one binary measured 0%, 1% and 19%. A full CPU burn is the one case that
+// sampler got right, so a burn alone would not have caught any of this.
+//
+// Ground truth is the kernel's own sum_exec_runtime for the process, summed
+// over /proc/self/task/*/schedstat. That is the nanosecond-resolution form of
+// the utime+stime every `top` shows, and /proc is what a user compares ptop
+// against when they doubt it.
+func checkCPUAccuracy(t *bpf.CPUTracer) bool {
+	points := []struct {
+		name string
+		on   time.Duration // busy out of every 10ms
+	}{
+		{"quiet", 250 * time.Microsecond},   // ~2.5% of a core
+		{"busier", 2500 * time.Microsecond}, // ~25% of a core
+	}
+	ok := true
+	for _, p := range points {
+		got, want, err := measureCPU(t, 3*time.Second, p.on, 10*time.Millisecond)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "FAIL  cpu%% %-7s %v\n", p.name+":", err)
+			ok = false
+			continue
+		}
+		// 15% of the truth, or 2ms, whichever is larger — the floor keeps a
+		// workload this short from failing on scheduling noise alone. The
+		// scheduler-timed axis lands an order of magnitude inside this; the
+		// sampler it replaced did not.
+		tolerance := want / 100 * 15
+		if tolerance < 2*time.Millisecond {
+			tolerance = 2 * time.Millisecond
+		}
+		diff := got - want
+		if diff < 0 {
+			diff = -diff
+		}
+		if diff > tolerance {
+			fmt.Fprintf(os.Stderr, "FAIL  cpu%% %-7s axis says %v, /proc says %v — off by %v, more than the %v allowed\n",
+				p.name+":", round(got), round(want), round(diff), round(tolerance))
+			ok = false
+			continue
+		}
+		fmt.Printf("PASS  cpu%% %-7s %v on-CPU vs %v in /proc (±%v)\n",
+			p.name+":", round(got), round(want), round(tolerance))
+	}
+	return ok
+}
+
+func round(d time.Duration) time.Duration { return d.Round(time.Millisecond) }
+
+// measureCPU runs the duty-cycled workload and returns what the axis saw and
+// what /proc saw over the same interval.
+func measureCPU(t *bpf.CPUTracer, total, on, period time.Duration) (axis, proc time.Duration, err error) {
+	beforeBPF, err := t.OnCPUNanos()
+	if err != nil {
+		return 0, 0, fmt.Errorf("read on-CPU nanos: %w", err)
+	}
+	beforeProc, err := procOnCPUNanos()
+	if err != nil {
+		return 0, 0, err
+	}
+
+	burnDutyCycle(total, on, period)
+
+	afterBPF, err := t.OnCPUNanos()
+	if err != nil {
+		return 0, 0, fmt.Errorf("read on-CPU nanos: %w", err)
+	}
+	afterProc, err := procOnCPUNanos()
+	if err != nil {
+		return 0, 0, err
+	}
+	proc = time.Duration(afterProc - beforeProc)
+	if proc <= 0 {
+		return 0, 0, errors.New("/proc reported no CPU time for a workload that burned some; cannot judge the axis")
+	}
+	return time.Duration(afterBPF - beforeBPF), proc, nil
+}
+
+// burnDutyCycle spins for `on` out of every `period` until `total` elapses,
+// which puts the process at roughly on/period of one core.
+func burnDutyCycle(total, on, period time.Duration) {
+	deadline := time.Now().Add(total)
+	var spin uint64
+	for time.Now().Before(deadline) {
+		until := time.Now().Add(on)
+		for time.Now().Before(until) {
+			for i := 0; i < 5000; i++ {
+				spin++
+			}
+		}
+		time.Sleep(period - on)
+	}
+	_ = spin
+}
+
+// procOnCPUNanos sums sum_exec_runtime across the process's threads. Unlike
+// utime+stime in /proc/self/stat it is in nanoseconds rather than 10ms ticks,
+// so it can judge a workload that only runs for a few milliseconds at a time.
+func procOnCPUNanos() (uint64, error) {
+	entries, err := os.ReadDir("/proc/self/task")
+	if err != nil {
+		return 0, fmt.Errorf("read /proc/self/task: %w", err)
+	}
+	var total uint64
+	for _, e := range entries {
+		b, err := os.ReadFile("/proc/self/task/" + e.Name() + "/schedstat")
+		if err != nil {
+			continue // the thread exited between the readdir and the read
+		}
+		fields := strings.Fields(string(b))
+		if len(fields) == 0 {
+			continue
+		}
+		ns, err := strconv.ParseUint(fields[0], 10, 64)
+		if err != nil {
+			return 0, fmt.Errorf("parse %s schedstat: %w", e.Name(), err)
+		}
+		total += ns
+	}
+	return total, nil
 }

--- a/internal/bpf/cpu.go
+++ b/internal/bpf/cpu.go
@@ -9,9 +9,9 @@ import (
 	"fmt"
 	"os"
 	"runtime"
-	"unsafe"
 
 	"github.com/cilium/ebpf"
+	"github.com/cilium/ebpf/link"
 	"github.com/cilium/ebpf/rlimit"
 	"golang.org/x/sys/unix"
 )
@@ -19,19 +19,20 @@ import (
 //go:embed programs/cpu.bpf.o
 var cpuBPFObj []byte
 
-// CPUTracer samples the target PID via perf_event PERF_COUNT_SW_CPU_CLOCK
-// at SAMPLE_FREQ Hz per CPU. When the kernel fires a sample and the current
-// tgid is the target, the BPF program increments a counter. The collector
-// reads the counter every N seconds and computes CPU %.
+// CPUTracer accumulates how many nanoseconds the target spent on-CPU, by
+// bracketing its scheduler slices at sched:sched_switch (see programs/cpu.bpf.c
+// for the mechanism and for why this is not a sampler any more, #108).
+//
+// The collector reads OnCPUNanos every second and divides by the elapsed wall
+// time; the result is the same quantity /proc reports as utime+stime, so the
+// two agree by construction instead of by luck.
 type CPUTracer struct {
-	coll       *ebpf.Collection
-	samplesMap *ebpf.Map
-	perfFDs    []int // 1 fd per online CPU
+	coll  *ebpf.Collection
+	link  link.Link
+	acc   *ebpf.Map // cpu_oncpu_ns, per-CPU
+	since *ebpf.Map // cpu_on_since, per-CPU
+	ncpu  int
 }
-
-// SampleFreq is the sampling frequency in Hz per CPU. 100Hz is what
-// `perf record` uses by default — granular enough to detect CPU spikes >10ms.
-const SampleFreq = 100
 
 func OpenCPUTracer(target Target) (*CPUTracer, error) {
 	if err := target.validate(); err != nil {
@@ -50,7 +51,12 @@ func OpenCPUTracer(target Target) (*CPUTracer, error) {
 		return nil, fmt.Errorf("load cpu BPF collection: %w", err)
 	}
 
-	t := &CPUTracer{coll: coll}
+	cpus, err := onlineCPUs()
+	if err != nil {
+		coll.Close()
+		return nil, err
+	}
+	t := &CPUTracer{coll: coll, ncpu: len(cpus)}
 
 	targetMap := coll.Maps["cpu_target_pid"]
 	if targetMap == nil {
@@ -67,74 +73,35 @@ func OpenCPUTracer(target Target) (*CPUTracer, error) {
 		return nil, fmt.Errorf("set cpu_target_pid: %w", err)
 	}
 
-	t.samplesMap = coll.Maps["cpu_target_samples"]
-	if t.samplesMap == nil {
+	t.acc = coll.Maps["cpu_oncpu_ns"]
+	t.since = coll.Maps["cpu_on_since"]
+	if t.acc == nil || t.since == nil {
 		t.Close()
-		return nil, errors.New("cpu_target_samples map not found")
+		return nil, errors.New("cpu_oncpu_ns / cpu_on_since map not found")
 	}
 
-	prog := coll.Programs["handle_perf_event"]
+	prog := coll.Programs["handle_sched_switch"]
 	if prog == nil {
 		t.Close()
-		return nil, errors.New("handle_perf_event program not found")
+		return nil, errors.New("handle_sched_switch program not found")
 	}
-
-	// perf_event_open + ioctl(PERF_EVENT_IOC_SET_BPF) per CPU.
-	// PERF_TYPE_SOFTWARE/PERF_COUNT_SW_CPU_CLOCK fires samples at
-	// SAMPLE_FREQ Hz per CPU (kernel guarantees uniformity).
-	//
-	// Every ONLINE cpu, by id — not runtime.NumCPU() (#108). NumCPU reports
-	// the size of PTOP's own affinity mask, so a ptop confined to a cpuset
-	// (systemd CPUAffinity=, taskset, a container's cpuset) opened events on
-	// only part of the machine and never saw the target's time on the rest.
-	// The counter still read as a rate, so the shortfall came out as a plain
-	// undercount — a busy target reported as idle, with nothing saying why.
-	// Ids matter too, not just how many: hot-unplug leaves gaps.
-	cpus, err := onlineCPUs()
+	l, err := link.Tracepoint("sched", "sched_switch", prog, nil)
 	if err != nil {
 		t.Close()
-		return nil, err
+		return nil, fmt.Errorf("attach sched/sched_switch: %w", err)
 	}
-	for _, cpu := range cpus {
-		attr := unix.PerfEventAttr{
-			Type:        unix.PERF_TYPE_SOFTWARE,
-			Config:      unix.PERF_COUNT_SW_CPU_CLOCK,
-			Sample:      SampleFreq,
-			Sample_type: unix.PERF_SAMPLE_RAW,
-			Bits:        unix.PerfBitFreq, // Sample is a rate (Hz), not a period in ns
-		}
-		attr.Size = uint32(unsafe.Sizeof(attr))
-		// pid=-1 (any task), cpu=cpu, group_fd=-1
-		fd, err := unix.PerfEventOpen(&attr, -1, cpu, -1, 0)
-		if err != nil {
-			t.Close()
-			return nil, fmt.Errorf("perf_event_open cpu=%d: %w", cpu, err)
-		}
-		// Attach BPF program to this fd
-		if err := unix.IoctlSetInt(fd, unix.PERF_EVENT_IOC_SET_BPF, prog.FD()); err != nil {
-			unix.Close(fd)
-			t.Close()
-			return nil, fmt.Errorf("ioctl SET_BPF cpu=%d: %w", cpu, err)
-		}
-		// Enable sampling
-		if err := unix.IoctlSetInt(fd, unix.PERF_EVENT_IOC_ENABLE, 0); err != nil {
-			unix.Close(fd)
-			t.Close()
-			return nil, fmt.Errorf("ioctl ENABLE cpu=%d: %w", cpu, err)
-		}
-		t.perfFDs = append(t.perfFDs, fd)
-	}
+	t.link = l
 
 	return t, nil
 }
 
-// onlineCPUs lists the ids of the CPUs the kernel currently has online — the
-// set a task can be scheduled on, and therefore the set that has to be sampled
-// for the count to mean "the target's share of a core".
+// onlineCPUs lists the ids of the CPUs the kernel currently has online.
 //
-// Falls back to 0..runtime.NumCPU()-1 only when sysfs cannot be read at all
-// (an unusual /proc-less or restricted mount namespace); that is the old
-// behaviour, kept as a floor rather than as the answer.
+// It is only the ceiling for the saturation clamp now that nothing is opened
+// per CPU — but it stays a sysfs read rather than runtime.NumCPU(), which
+// reports the size of PTOP's own affinity mask and would shrink the ceiling
+// below what the target can actually use whenever ptop is confined to a cpuset
+// (systemd CPUAffinity=, taskset, a container's cpuset).
 func onlineCPUs() ([]int, error) {
 	b, err := os.ReadFile("/sys/devices/system/cpu/online")
 	if err == nil {
@@ -148,11 +115,8 @@ func onlineCPUs() ([]int, error) {
 	}
 	n := runtime.NumCPU()
 	if n < 1 {
-		return nil, errors.New("no online CPUs to sample")
+		return nil, errors.New("no online CPUs")
 	}
-	fmt.Fprintf(os.Stderr,
-		"cpu: /sys/devices/system/cpu/online unreadable (%v); sampling %d CPUs from this process's affinity mask, which undercounts if the target runs outside it\n",
-		err, n)
 	ids := make([]int, n)
 	for i := range ids {
 		ids[i] = i
@@ -160,40 +124,84 @@ func onlineCPUs() ([]int, error) {
 	return ids, nil
 }
 
-// SampleCount returns the current accumulated count of on-CPU samples.
-// The collector uses the delta between calls to compute %.
-func (t *CPUTracer) SampleCount() (uint64, error) {
-	if t == nil || t.samplesMap == nil {
+// OnCPUNanos returns the target's total on-CPU time since the tracer attached.
+//
+// It is the sum of the finished slices the BPF program has accumulated plus
+// the slice in flight on every CPU currently running a target thread —
+// without that second term, a thread that runs for a whole window without
+// being switched out would report zero for that window and a spike for the
+// next one, which is the failure this axis is trying to stop reporting.
+//
+// The two maps are read in this order — accumulator, then clock, then the
+// in-flight timestamps — so that a slice ending mid-read is either counted
+// once in the accumulator or dropped from this reading and picked up by the
+// next one. The reverse order can count the same nanoseconds twice and make
+// the total go backwards.
+func (t *CPUTracer) OnCPUNanos() (uint64, error) {
+	if t == nil || t.acc == nil || t.since == nil {
 		return 0, errors.New("tracer not initialized")
 	}
-	var key uint32 = 0
-	var val uint64
-	if err := t.samplesMap.Lookup(&key, &val); err != nil {
+	var key uint32
+
+	var accPerCPU []uint64
+	if err := t.acc.Lookup(&key, &accPerCPU); err != nil {
 		return 0, err
 	}
-	return val, nil
+	now, err := monotonicNanos()
+	if err != nil {
+		return 0, err
+	}
+	var sincePerCPU []uint64
+	if err := t.since.Lookup(&key, &sincePerCPU); err != nil {
+		return 0, err
+	}
+
+	var total uint64
+	for _, v := range accPerCPU {
+		total += v
+	}
+	for _, s := range sincePerCPU {
+		if s != 0 && now > s {
+			total += now - s
+		}
+	}
+	return total, nil
 }
 
-// NumCPU returns the number of CPUs the tracer is sampling on.
-// Used by the collector for the % computation.
+// monotonicNanos reads the clock bpf_ktime_get_ns() is based on
+// (CLOCK_MONOTONIC — not CLOCK_BOOTTIME, which counts time spent suspended),
+// so the in-flight slice above is measured in the same domain the BPF program
+// timestamped it in.
+func monotonicNanos() (uint64, error) {
+	var ts unix.Timespec
+	if err := unix.ClockGettime(unix.CLOCK_MONOTONIC, &ts); err != nil {
+		return 0, fmt.Errorf("clock_gettime(CLOCK_MONOTONIC): %w", err)
+	}
+	return uint64(ts.Sec)*1e9 + uint64(ts.Nsec), nil
+}
+
+// NumCPU returns how many CPUs are online — the ceiling the collector clamps
+// its percentage to.
 func (t *CPUTracer) NumCPU() int {
-	return len(t.perfFDs)
+	if t == nil {
+		return 0
+	}
+	return t.ncpu
 }
 
 func (t *CPUTracer) Close() error {
 	if t == nil {
 		return nil
 	}
-	for _, fd := range t.perfFDs {
-		// Disable then close
-		_ = unix.IoctlSetInt(fd, unix.PERF_EVENT_IOC_DISABLE, 0)
-		_ = unix.Close(fd)
+	if t.link != nil {
+		_ = t.link.Close()
+		t.link = nil
 	}
-	t.perfFDs = nil
 	if t.coll != nil {
 		t.coll.Close()
 		t.coll = nil
-		t.samplesMap = nil
+		t.acc = nil
+		t.since = nil
 	}
 	return nil
 }

--- a/internal/bpf/cpu_stub.go
+++ b/internal/bpf/cpu_stub.go
@@ -4,13 +4,11 @@ package bpf
 
 import "errors"
 
-var errCPUStub = errors.New("eBPF cpu sampler not available in this build (requires Linux + -tags=ebpf)")
+var errCPUStub = errors.New("eBPF cpu tracer not available in this build (requires Linux + -tags=ebpf)")
 
 type CPUTracer struct{}
 
-const SampleFreq = 100
-
 func OpenCPUTracer(Target) (*CPUTracer, error) { return nil, errCPUStub }
-func (*CPUTracer) SampleCount() (uint64, error) { return 0, errCPUStub }
-func (*CPUTracer) NumCPU() int                  { return 0 }
-func (*CPUTracer) Close() error                 { return nil }
+func (*CPUTracer) OnCPUNanos() (uint64, error) { return 0, errCPUStub }
+func (*CPUTracer) NumCPU() int                 { return 0 }
+func (*CPUTracer) Close() error                { return nil }

--- a/internal/bpf/programs/cpu.bpf.c
+++ b/internal/bpf/programs/cpu.bpf.c
@@ -1,26 +1,65 @@
 // SPDX-License-Identifier: GPL-2.0
 //
-// cpu.bpf.c — CPU sampling of the target PID via perf_event at 100Hz per CPU.
+// cpu.bpf.c — the target's on-CPU time, taken from the scheduler.
 //
 // Maps:
-//   cpu_target_pid       ARRAY[1]  struct target_filter (written by the Go loader)
-//   cpu_target_samples   ARRAY[1]  accumulated counter of samples where the
-//                                   target was on-CPU
+//   cpu_target_pid    ARRAY[1]        struct target_filter (written by Go)
+//   cpu_oncpu_ns      PERCPU_ARRAY[1] nanoseconds the target has been on this
+//                                     CPU, summed over slices that have ended
+//   cpu_on_since      PERCPU_ARRAY[1] when the slice running right now began,
+//                                     0 when this CPU is not running the target
+//   cpu_target_tids   LRU_HASH        root-ns TIDs known to belong to the target
 //
-// The Go loader opens a PERF_TYPE_SOFTWARE/PERF_COUNT_SW_CPU_CLOCK perf_event
-// with sample_freq=100 on each CPU. Each time the kernel fires a sample,
-// if the current task is the target — resolved within its PID namespace via
-// pid_is_target() (see target.bpf.h) — the counter is incremented.
+// Why time and not samples (#108).
+//   This used to be a perf_event at 100Hz per CPU that incremented a counter
+//   whenever the target happened to be on-CPU, and the collector turned that
+//   count into a percentage by dividing by the nominal rate. Two things were
+//   wrong with that, and both surfaced as a CPU axis contradicting /proc:
 //
-// % computation on the Go side:
-//   delta_samples / (sample_freq × elapsed_seconds × NCPU) × 100 = % of
-//   the system. Multiply by NCPU to get % on a "single-core" scale (top-style).
+//   - A process using 2.5% of a core produces 2.5 samples a second. The whole
+//     signal was a handful of Bernoulli trials per bucket, so a one-second
+//     bucket was mostly shot noise — three runs of one binary measured 0, 1
+//     and 19 percent — and a busy second could legitimately come out ZERO.
+//   - The nominal 100Hz is not the achieved rate. In freq mode the kernel
+//     re-derives the sampling period from the count it observes at scheduler
+//     ticks, which do not run on an idle CPU; after an idle stretch the period
+//     inflates and the event fires well below 100Hz while the collector keeps
+//     dividing by 100. Measured on a lightly loaded 10-CPU host: 80-90Hz per
+//     CPU, drifting from one window to the next.
+//
+//   The scheduler already knows the answer exactly. sched_switch brackets
+//   every slice the target gets, so summing (switch_out - switch_in) is the
+//   quantity /proc reports as utime+stime, at nanosecond resolution instead
+//   of 10ms ticks, and with no sampling rate to assume.
+//
+// PID-namespace handling, and why `next` needs a map.
+//   At sched_switch `current` is `prev`, so pid_is_target() answers directly
+//   for the outgoing task — that is the only side where the target can be
+//   identified, in either PID or CGROUP mode. The incoming task arrives as a
+//   bare root-namespace TID in next_pid, which no helper can resolve for a
+//   task that is not current, so target TIDs are learned from the `prev` side
+//   and remembered in cpu_target_tids. A thread's very first slice is
+//   therefore missed, once, until it has been switched out at least once.
 
 #include <linux/bpf.h>
 #include <bpf/bpf_helpers.h>
 #include "target.bpf.h"
 
 char LICENSE[] SEC("license") = "GPL";
+
+// Stable layout of the sched:sched_switch tracepoint — the same one
+// threads.bpf.c reads. See
+// /sys/kernel/tracing/events/sched/sched_switch/format.
+struct sched_switch_args {
+    unsigned long long _pad;     // common_type/flags/preempt_count/pid (8B)
+    char prev_comm[16];          // offset 8
+    int prev_pid;                // offset 24
+    int prev_prio;               // offset 28
+    long prev_state;             // offset 32
+    char next_comm[16];          // offset 40
+    int next_pid;                // offset 56
+    int next_prio;               // offset 60
+};
 
 struct {
     __uint(type, BPF_MAP_TYPE_ARRAY);
@@ -29,22 +68,73 @@ struct {
     __uint(max_entries, 1);
 } cpu_target_pid SEC(".maps");
 
+// Per-CPU, so the hot path is a plain add rather than an atomic on one
+// cacheline shared by every CPU in the machine. The Go side sums them.
 struct {
-    __uint(type, BPF_MAP_TYPE_ARRAY);
+    __uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
     __type(key, __u32);
     __type(value, __u64);
     __uint(max_entries, 1);
-} cpu_target_samples SEC(".maps");
+} cpu_oncpu_ns SEC(".maps");
 
-SEC("perf_event")
-int handle_perf_event(void *ctx)
+// The slice in flight. Only one task runs on a CPU at a time, so one
+// timestamp per CPU is enough, and a switch-in is always followed by a
+// switch-out on the same CPU (a task cannot migrate while running).
+struct {
+    __uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
+    __type(key, __u32);
+    __type(value, __u64);
+    __uint(max_entries, 1);
+} cpu_on_since SEC(".maps");
+
+// Only the target's threads are ever inserted; LRU evicts the dead ones. A
+// cgroup subtree can hold many more threads than one process, hence the
+// headroom over threads.bpf.c's 8192.
+struct {
+    __uint(type, BPF_MAP_TYPE_LRU_HASH);
+    __type(key, __u32);
+    __type(value, __u8);
+    __uint(max_entries, 16384);
+} cpu_target_tids SEC(".maps");
+
+SEC("tracepoint/sched/sched_switch")
+int handle_sched_switch(struct sched_switch_args *ctx)
 {
-    if (!pid_is_target(&cpu_target_pid))
+    __u32 key = 0;
+    __u64 *since = bpf_map_lookup_elem(&cpu_on_since, &key);
+    if (!since)
         return 0;
 
-    __u32 key = 0;
-    __u64 *count = bpf_map_lookup_elem(&cpu_target_samples, &key);
-    if (count)
-        __sync_fetch_and_add(count, 1);
+    __u64 now = bpf_ktime_get_ns();
+
+    // Outgoing task. `current` is still prev here, so the target filter
+    // applies to it directly.
+    if (pid_is_target(&cpu_target_pid)) {
+        // Learn this thread for the `next` side. Lookup first: after the
+        // first switch-out this is the target's own hot path, and a lookup
+        // takes no bucket lock where an update does. It also refreshes the
+        // LRU entry, which is what keeps a busy thread from being evicted.
+        __u32 tid = (__u32)ctx->prev_pid;
+        if (!bpf_map_lookup_elem(&cpu_target_tids, &tid)) {
+            __u8 one = 1;
+            bpf_map_update_elem(&cpu_target_tids, &tid, &one, BPF_ANY);
+        }
+
+        // *since == 0 means this slice began before the thread was known —
+        // the one-slice warm-up. Charging it would mean charging from zero.
+        if (*since) {
+            __u64 *acc = bpf_map_lookup_elem(&cpu_oncpu_ns, &key);
+            if (acc)
+                *acc += now - *since;
+        }
+    }
+
+    // Incoming task. Clear first: whoever ran before is accounted for by now,
+    // and most switches hand the CPU to someone who is not the target.
+    *since = 0;
+    __u32 next = (__u32)ctx->next_pid;
+    if (bpf_map_lookup_elem(&cpu_target_tids, &next))
+        *since = now;
+
     return 0;
 }

--- a/internal/tui/platform_linux.go
+++ b/internal/tui/platform_linux.go
@@ -30,10 +30,14 @@ const (
 // statusBarSourceLabel is the footer's data-source descriptor. It must
 // describe how this build actually collects, never claim a path it can't
 // take. The kernel release is read live (it used to be hardcoded "6.8"), and
-// the old unmeasured "overhead <0.5%" claim is gone. The 100Hz figure is real
-// — the eBPF cpu.bpf.c perf_event runs at sample_freq=100.
+// the old unmeasured "overhead <0.5%" claim is gone.
+//
+// It used to end "sampling 100Hz", which described the CPU axis when that axis
+// counted perf_event samples. It does not sample any more — it reads the
+// scheduler's own accounting of the target's slices (#108) — so the claim
+// went with the mechanism rather than being left to age into a lie.
 func statusBarSourceLabel() string {
-	return "eBPF kernel " + kernelRelease() + " · sampling 100Hz"
+	return "eBPF kernel " + kernelRelease() + " · cpu from sched_switch"
 }
 
 // kernelRelease returns the running kernel version (uname -r), or "?" if the

--- a/pkg/collector/cpu_ebpf.go
+++ b/pkg/collector/cpu_ebpf.go
@@ -10,13 +10,17 @@ import (
 	"github.com/trentas/ptop/internal/bpf"
 )
 
-// CPUEBPFCollector consumes the on-CPU sample counter from the perf_event
-// tracer (internal/bpf/cpu.go) and publishes CpuSample{UsagePct} every 1s.
+// CPUEBPFCollector turns the on-CPU nanosecond counter kept by the scheduler
+// tracer (internal/bpf/cpu.go) into a CpuSample{UsagePct} every second:
 //
-// Calculation:
-//   delta_samples / (SampleFreq × NCPU × elapsed_seconds) × 100 × NCPU
-//   = delta_samples / (SampleFreq × elapsed_seconds) × 100
-//   = single-core % (top-style; can exceed 100% when multi-threaded)
+//	pct = Δ on-CPU ns / Δ wall ns × 100
+//
+// That is single-core % (top-style; a multi-threaded target can exceed 100%)
+// and it is the same quantity /proc reports as utime+stime, measured in
+// nanoseconds rather than 10ms ticks. Before #108 this divided a count of
+// 100Hz perf samples by an assumed sampling rate, which agreed with /proc only
+// on average and, over the one-second buckets this publishes, mostly did not:
+// see programs/cpu.bpf.c.
 //
 // In builds without -tags=ebpf or non-Linux OS, the parallel stub always
 // fails in Start, leading the model to use the /proc collector or simulation.
@@ -25,9 +29,9 @@ type CPUEBPFCollector struct {
 	ch     chan interface{}
 	stop   chan struct{}
 
-	mu       sync.Mutex
-	lastSamp uint64
-	lastAt   time.Time
+	mu     sync.Mutex
+	lastNs uint64
+	lastAt time.Time
 }
 
 func NewCPUEBPFCollector() *CPUEBPFCollector {
@@ -49,6 +53,12 @@ func (c *CPUEBPFCollector) start(t bpf.Target) error {
 		return fmt.Errorf("cpu eBPF: %w", err)
 	}
 	c.tracer = tracer
+	// Take the baseline now rather than on the first tick: with no baseline
+	// the first published sample is a structural zero, and a zero on this
+	// axis reads as an idle process rather than as "not measured yet".
+	if ns, err := tracer.OnCPUNanos(); err == nil {
+		c.lastNs, c.lastAt = ns, time.Now()
+	}
 	go c.loop()
 	return nil
 }
@@ -90,7 +100,7 @@ func (c *CPUEBPFCollector) sample() (CpuSample, error) {
 	if c.tracer == nil {
 		return CpuSample{}, fmt.Errorf("tracer not open")
 	}
-	count, err := c.tracer.SampleCount()
+	ns, err := c.tracer.OnCPUNanos()
 	if err != nil {
 		return CpuSample{}, err
 	}
@@ -98,21 +108,9 @@ func (c *CPUEBPFCollector) sample() (CpuSample, error) {
 	now := time.Now()
 	var pct float64
 	if !c.lastAt.IsZero() {
-		elapsed := now.Sub(c.lastAt).Seconds()
-		if elapsed > 0 && count >= c.lastSamp {
-			delta := float64(count - c.lastSamp)
-			// pct = single-core %. SampleFreq samples per second per CPU
-			// give NCPU × SampleFreq samples/s in total. delta in that
-			// interval represents fractions of CPU used by the target.
-			//
-			// pct = (delta / (SampleFreq × elapsed)) × 100
-			pct = (delta / (float64(bpf.SampleFreq) * elapsed)) * 100
-			if pct > float64(c.tracer.NumCPU()*100) {
-				pct = float64(c.tracer.NumCPU() * 100) // saturation
-			}
-		}
+		pct = cpuPercent(c.lastNs, ns, now.Sub(c.lastAt), c.tracer.NumCPU())
 	}
-	c.lastSamp = count
+	c.lastNs = ns
 	c.lastAt = now
 
 	return CpuSample{

--- a/pkg/collector/cpu_rate.go
+++ b/pkg/collector/cpu_rate.go
@@ -1,0 +1,29 @@
+package collector
+
+import "time"
+
+// cpuPercent turns two readings of a monotonic on-CPU nanosecond counter into
+// single-core percent — the top-style scale, where a target using two cores
+// fully reads 200%, not 100%.
+//
+// Build-tag-free so the arithmetic is testable on any host; the counter it
+// reads comes from the eBPF scheduler tracer (cpu_ebpf.go).
+func cpuPercent(prevNs, curNs uint64, elapsed time.Duration, ncpu int) float64 {
+	// A counter that went backwards means a slice ended between the two map
+	// reads inside a single OnCPUNanos call (see its doc comment). Those
+	// nanoseconds are not lost — they land in the next window — so report no
+	// progress rather than a negative rate.
+	if elapsed <= 0 || curNs < prevNs {
+		return 0
+	}
+	pct := float64(curNs-prevNs) / float64(elapsed.Nanoseconds()) * 100
+	// Saturate at every core running the target flat out. Nothing above that
+	// is physical; it would mean the clock the counter is timestamped with
+	// and the clock the interval is measured with disagree.
+	if ncpu > 0 {
+		if ceiling := float64(ncpu) * 100; pct > ceiling {
+			return ceiling
+		}
+	}
+	return pct
+}

--- a/pkg/collector/cpu_rate_test.go
+++ b/pkg/collector/cpu_rate_test.go
@@ -1,0 +1,38 @@
+package collector
+
+import (
+	"math"
+	"testing"
+	"time"
+)
+
+func TestCPUPercent(t *testing.T) {
+	const sec = uint64(time.Second)
+
+	tests := []struct {
+		name      string
+		prev, cur uint64
+		elapsed   time.Duration
+		ncpu      int
+		want      float64
+	}{
+		{"idle", 100, 100, time.Second, 8, 0},
+		{"one core flat out", 0, sec, time.Second, 8, 100},
+		{"a quiet 2.5% — the case the sampler could not resolve", 0, sec / 40, time.Second, 8, 2.5},
+		{"four threads on four cores", 0, 4 * sec, time.Second, 8, 400},
+		{"half a second of wall clock", 0, sec / 4, 500 * time.Millisecond, 8, 50},
+		{"saturates at the core count", 0, 100 * sec, time.Second, 8, 800},
+		{"counter went backwards", 500, 400, time.Second, 8, 0},
+		{"no interval", 0, sec, 0, 8, 0},
+		{"unknown core count does not clamp", 0, 100 * sec, time.Second, 0, 10000},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := cpuPercent(tc.prev, tc.cur, tc.elapsed, tc.ncpu)
+			if math.Abs(got-tc.want) > 1e-9 {
+				t.Errorf("cpuPercent(%d, %d, %v, %d) = %v, want %v",
+					tc.prev, tc.cur, tc.elapsed, tc.ncpu, got, tc.want)
+			}
+		})
+	}
+}

--- a/pkg/collector/set.go
+++ b/pkg/collector/set.go
@@ -127,7 +127,8 @@ func NewSet(cfg SetConfig) *Set {
 		fmt.Fprintf(os.Stderr, "warning: FD collector unavailable\n")
 	}
 
-	// CPU: eBPF perf_event @ 100Hz/CPU first, /proc polling as fallback.
+	// CPU: eBPF (the target's on-CPU time, from sched_switch) first, /proc
+	// polling of utime+stime as fallback.
 	if !cfg.NoEBPF && !cfg.off(SubsystemCPU) {
 		c := NewCPUEBPFCollector()
 		if err := c.Start(cfg.PID); err == nil {


### PR DESCRIPTION
Closes #108.

v1.4.0 fixed the three defects behind the first report — the shared queue, the cpuset, ptop's own probe — and the axis still could not carry a deploy comparison. Three runs of **one** pair of binaries, same paced load, same host, ~17s windows: `0 → 8.99`, `0.99 → 2.00`, `19.00 → 16.99`, where `/proc` says `2.5% → 22.6%` every time, and the third **inverts**. What was left is not a defect in the plumbing; it is the instrument.

## Why the sampler could not do this

**A count of samples is not a measurement of time.** A process at 2.5% of a core draws 2.5 samples a second at 100Hz, so a one-second bucket is a handful of Bernoulli trials, and a perfectly busy second can legitimately draw zero — which reads as an idle process, not as a gap. A p95 over seventeen such buckets reports the maximum of the noise, which is how the cheap arm of an A/B pair comes out hotter than the expensive one.

**And the nominal rate is not the achieved rate.** In `freq` mode the kernel re-derives the sampling period from the count it observes at scheduler ticks, and ticks do not run on an idle CPU; after an idle stretch the period inflates and the event fires below the requested rate while the collector keeps dividing by the requested rate. Instrumented with a second counter over every sample fired, on a lightly loaded 10-CPU host: **80–90Hz per CPU**, drifting window to window. A standing undercount, worst on the quiet machines where a 2.5% process lives.

## What it does now

`cpu.bpf.c` brackets the target's slices at `sched_switch` and accumulates nanoseconds; the collector divides by elapsed wall time. Same quantity `/proc` reports as `utime+stime`, at nanosecond resolution instead of 10ms ticks, with no rate to assume — the two agree by construction. The per-CPU perf events are gone, and with them 100 interrupts per second per CPU.

Two details the mechanism needs: `current` is `prev` at `sched_switch`, so the target filter answers directly for the outgoing task in both PID and cgroup mode, while `next` arrives as a bare root-namespace TID — target TIDs are learned from the `prev` side, costing each thread its first slice once. And `OnCPUNanos` adds the slice in flight, because without it a thread that runs a whole window without being switched out reports zero for that window and a spike for the next.

## Verified on a live arm64 kernel 7.0

Against `sum_exec_runtime` summed over `/proc/<pid>/task/*/schedstat`, sweeping one workload's duty cycle:

| duty | axis p50 | /proc p50 |
| --- | --- | --- |
| 2.5% | 2.42 | 2.45 |
| 22.6% | 21.01 | 21.07 |
| 50% | 47.09 | 47.15 |
| 100% | 100.02 | 100.03 |
| 8 × 50% | 369.84 | 370.80 |

And the report's own shape — the same pair, three times, 17s windows: `2.74 → 22.20`, `2.40 → 20.76`, `2.36 → 20.81`, against a truth of `2.81 → 22.51`, `2.44 → 20.89`, `2.41 → 20.88`. Direction right every time, and where the truth moves the axis moves with it.

`ebpf-selftest` gates it from here: it runs the report's pair — one workload at a few percent of a core, one at ten times that — and fails if the axis and `/proc` disagree by more than 15%. The quiet point is the one that matters; a full CPU burn is the single case the old sampler got right.

```
PASS  cpu:      2.992972649s of on-CPU time observed
PASS  syscalls: 209772 events across 18 syscall ids
PASS  cpu% quiet:  73ms on-CPU vs 75ms in /proc (±11ms)
PASS  cpu% busier: 678ms on-CPU vs 680ms in /proc (±102ms)
```

## Consequences worth knowing

- The footer said `sampling 100Hz` and no longer does, because nothing samples.
- The CPU axis now needs debugfs/tracefs mounted, like every other tracepoint collector. Where it is not, `Start` fails cleanly and the axis falls back to `/proc`; the `?` overlay reports the source honestly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)