### PR TITLE
Say which collectors are running, so silence stops meaning "idle"

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -108,7 +108,7 @@ ptop/
 │   ├── serve/                     headless gRPC server (ptop --serve)
 │   │   ├── serve.go               addr parse + privilege boundary + Run
 │   │   ├── tls.go                 transport security: TLS/mTLS policy + hot reload (#95)
-│   │   ├── hub.go                 fan-in collectors → fan-out to sinks
+│   │   ├── hub.go                 fan-in collectors → fan-out to sinks; probe set in the handshake (#112)
 │   │   ├── sink.go                Sink iface: gRPC subscriber + JSONL writer
 │   │   ├── shed.go                which event a full sink queue gives up (#108)
 │   │   ├── registry.go            fixed target vs targets on demand, refcounted (#72)
@@ -145,6 +145,7 @@ ptop/
 │   ├── collector/                 /proc + eBPF collectors + shared types
 │       ├── types.go               public type contracts (see below)
 │       ├── set.go                 source-priority selection + lifecycle (Set)
+│       ├── probes.go              per-subsystem outcome: active/disabled/failed (#112)
 │       ├── bus.go                 single fan-out: Set → N consumers (Feed, #71)
 │       ├── shed.go                snapshot vs per-occurrence rate class (#108)
 │       ├── source_{linux,darwin}.go  platform source labels (Source*)

--- a/README.md
+++ b/README.md
@@ -439,6 +439,24 @@ the modes aggregate differently: in cgroup mode `Event.pid` is 0 on aggregate
 payloads (there is no single process to name) and any pid inside a payload is a
 **root-namespace** pid, since a subtree can span pid namespaces.
 
+The same handshake carries the **probe set**: every collector this server tried
+to run and what became of it — `active` (with its source, `eBPF` or `/proc`),
+`disabled`, `failed`, or `unsupported`, plus why. A probe that is not running
+emits nothing, which in the events alone is indistinguishable from a target that
+never did the thing, so a consumer comparing two captures has to compare their
+probe sets before it compares their numbers. `active` versus `failed` is the
+distinction that is not cosmetic: a probe someone switched off is a knob they can
+turn back on, one that failed to attach is a broken deployment. The server says
+the same thing on stderr when it starts:
+
+```
+[ptop] probes: 9 active, 1 failed, 3 disabled, 0 unsupported
+[ptop] ⚠ 1 collector(s) asked for but NOT attached — … : syscalls (open tracefs: no such file or directory)
+```
+
+An empty probe set means the server does not report one — never that every probe
+ran.
+
 Cgroup mode is `--serve` only (the TUI's header, thread table and fd list are
 all one process's) and needs eBPF, since the filter runs in the kernel. It
 starts a deliberately smaller set of collectors — syscalls, I/O, network,

--- a/cmd/ptop/main.go
+++ b/cmd/ptop/main.go
@@ -388,7 +388,7 @@ func runServe(addr string, target serve.Target, noEBPF, tlsEnabled bool, tlsByte
 	resolver := stackResolverFor(set)
 
 	if tuiCfg == nil {
-		if err := serve.Run(ctx, addr, target, feed.Bus, resolver, opts); err != nil {
+		if err := serve.Run(ctx, addr, target, feed, resolver, opts); err != nil {
 			feed.Stop() // os.Exit skips the defer
 			fmt.Fprintf(os.Stderr, "fatal error: %v\n", err)
 			os.Exit(1)
@@ -403,7 +403,7 @@ func runServe(addr string, target serve.Target, noEBPF, tlsEnabled bool, tlsByte
 	ready := make(chan struct{})
 	opts.Ready = ready
 	srvErr := make(chan error, 1)
-	go func() { srvErr <- serve.Run(ctx, addr, target, feed.Bus, resolver, opts) }()
+	go func() { srvErr <- serve.Run(ctx, addr, target, feed, resolver, opts) }()
 
 	select {
 	case <-ready:

--- a/internal/serve/hub.go
+++ b/internal/serve/hub.go
@@ -2,6 +2,9 @@ package serve
 
 import (
 	"context"
+	"fmt"
+	"os"
+	"strings"
 	"sync"
 
 	"github.com/trentas/ptop/pkg/collector"
@@ -14,7 +17,8 @@ import (
 // Sinks (see sink.go).
 type Hub struct {
 	target  Target
-	buildID string // target exec build-id, stamped onto every StackRef (#54)
+	buildID string          // target exec build-id, stamped onto every StackRef (#54)
+	probes  []*pb.ProbeInfo // what became of each collector, for the handshake (#112)
 	mu      sync.Mutex
 	sinks   map[Sink]struct{}
 
@@ -26,24 +30,64 @@ type Hub struct {
 	cgroupID uint64
 }
 
-func NewHub(target Target, buildID string) *Hub {
-	return &Hub{target: target, buildID: buildID, sinks: make(map[Sink]struct{})}
+// NewHub builds the hub for one target. set is the running collectors behind it,
+// whose per-probe outcome goes into the handshake (#112); nil is accepted and
+// yields an empty probe set, which a consumer reads as "unknown", not as "none".
+func NewHub(target Target, buildID string, set *collector.Set) *Hub {
+	return &Hub{
+		target:  target,
+		buildID: buildID,
+		probes:  probeInfos(set),
+		sinks:   make(map[Sink]struct{}),
+	}
 }
 
 // targetInfo renders the handshake every subscriber receives before its first
-// event, so a consumer knows the scope of what follows (#94).
+// event, so a consumer knows the scope of what follows (#94) and which probes
+// produced it (#112).
 func (h *Hub) targetInfo() *pb.TargetInfo {
 	if h.target.IsCgroup() {
 		return &pb.TargetInfo{
 			Mode:       pb.TargetMode_TARGET_MODE_CGROUP,
 			CgroupPath: h.target.CgroupPath,
 			CgroupId:   h.target.CgroupID,
+			Probes:     h.probes,
 		}
 	}
 	return &pb.TargetInfo{
-		Mode: pb.TargetMode_TARGET_MODE_PID,
-		Pid:  int32(h.target.PID),
+		Mode:   pb.TargetMode_TARGET_MODE_PID,
+		Pid:    int32(h.target.PID),
+		Probes: h.probes,
 	}
+}
+
+// probeStates maps the collector package's outcome onto the wire enum. An
+// unknown state becomes UNSPECIFIED rather than a guess: a consumer that treats
+// "I don't know" as "active" is the failure this whole field exists to prevent.
+var probeStates = map[collector.ProbeState]pb.ProbeState{
+	collector.ProbeActive:      pb.ProbeState_PROBE_STATE_ACTIVE,
+	collector.ProbeDisabled:    pb.ProbeState_PROBE_STATE_DISABLED,
+	collector.ProbeFailed:      pb.ProbeState_PROBE_STATE_FAILED,
+	collector.ProbeUnsupported: pb.ProbeState_PROBE_STATE_UNSUPPORTED,
+}
+
+// probeInfos renders a Set's probe outcomes for the handshake, in the sorted
+// order Set.Probes guarantees.
+func probeInfos(set *collector.Set) []*pb.ProbeInfo {
+	sts := set.Probes()
+	if len(sts) == 0 {
+		return nil
+	}
+	out := make([]*pb.ProbeInfo, 0, len(sts))
+	for _, st := range sts {
+		out = append(out, &pb.ProbeInfo{
+			Name:   st.Name,
+			State:  probeStates[st.State],
+			Source: st.Source,
+			Detail: st.Detail,
+		})
+	}
+	return out
 }
 
 // Start attaches the hub to the shared collector bus (#71) — the same bus the
@@ -129,4 +173,45 @@ func (h *Hub) sinkCount() int {
 	h.mu.Lock()
 	defer h.mu.Unlock()
 	return len(h.sinks)
+}
+
+// probeSummary is the one-line census of what is actually watching, plus a
+// loud line naming every probe that was asked for and did not attach.
+//
+// A failure already warns at attach time, buried in whatever the collectors
+// printed. The failure that matters is the one nobody read: 9 of 10 collectors
+// silently dead for every capture of a service, with the resulting signatures
+// indistinguishable from complete ones. Saying it once, at the moment the
+// server announces itself, is the least this can do; the handshake is what
+// makes it survive into the artifact.
+func (h *Hub) probeSummary() []string {
+	if len(h.probes) == 0 {
+		return nil
+	}
+	byState := map[pb.ProbeState]int{}
+	var failed []string
+	for _, p := range h.probes {
+		byState[p.GetState()]++
+		if p.GetState() == pb.ProbeState_PROBE_STATE_FAILED {
+			failed = append(failed, fmt.Sprintf("%s (%s)", p.GetName(), p.GetDetail()))
+		}
+	}
+	lines := []string{fmt.Sprintf("[ptop] probes: %d active, %d failed, %d disabled, %d unsupported",
+		byState[pb.ProbeState_PROBE_STATE_ACTIVE],
+		byState[pb.ProbeState_PROBE_STATE_FAILED],
+		byState[pb.ProbeState_PROBE_STATE_DISABLED],
+		byState[pb.ProbeState_PROBE_STATE_UNSUPPORTED])}
+	if len(failed) > 0 {
+		lines = append(lines, fmt.Sprintf("[ptop] \u26a0 %d collector(s) asked for but NOT attached — this stream is instrumented"+
+			" less than requested, and a consumer comparing it against a fully instrumented capture will"+
+			" read the missing axes as behaviour that stopped: %s", len(failed), strings.Join(failed, "; ")))
+	}
+	return lines
+}
+
+// reportProbes prints the summary to stderr.
+func (h *Hub) reportProbes() {
+	for _, line := range h.probeSummary() {
+		fmt.Fprintln(os.Stderr, line)
+	}
 }

--- a/internal/serve/hub_test.go
+++ b/internal/serve/hub_test.go
@@ -24,7 +24,7 @@ func TestHubFanOut(t *testing.T) {
 	defer cancel()
 
 	f := newFake(8)
-	h := NewHub(TargetPID(7), "")
+	h := NewHub(TargetPID(7), "", nil)
 	sub := h.subscribe(nil)
 	h.Start(ctx, collector.StartBus(ctx, []collector.Collector{f}))
 
@@ -52,7 +52,7 @@ func TestHubCategoryFilter(t *testing.T) {
 	defer cancel()
 
 	f := newFake(8)
-	h := NewHub(TargetPID(1), "")
+	h := NewHub(TargetPID(1), "", nil)
 	sub := h.subscribe([]pb.Category{pb.Category_CATEGORY_NETWORK})
 	h.Start(ctx, collector.StartBus(ctx, []collector.Collector{f}))
 
@@ -84,7 +84,7 @@ func TestHubBackpressureDrops(t *testing.T) {
 
 	// Source channel large enough to hold every emit without blocking the test.
 	f := newFake(subBuffer + 200)
-	h := NewHub(TargetPID(1), "")
+	h := NewHub(TargetPID(1), "", nil)
 	sub := h.subscribe(nil) // never read → its buffer fills, then drops
 	h.Start(ctx, collector.StartBus(ctx, []collector.Collector{f}))
 
@@ -107,7 +107,7 @@ func TestHubBackpressureDrops(t *testing.T) {
 }
 
 func TestHubUnsubscribe(t *testing.T) {
-	h := NewHub(TargetPID(1), "")
+	h := NewHub(TargetPID(1), "", nil)
 	sub := h.subscribe(nil)
 	if h.sinkCount() != 1 {
 		t.Fatalf("count = %d, want 1", h.sinkCount())
@@ -128,7 +128,7 @@ func TestHubSharesTheBusWithAnotherConsumer(t *testing.T) {
 	f := newFake(64)
 	bus := collector.StartBus(ctx, []collector.Collector{f})
 
-	h := NewHub(TargetPID(7), "")
+	h := NewHub(TargetPID(7), "", nil)
 	sub := h.subscribe(nil)
 	h.Start(ctx, bus)
 

--- a/internal/serve/probes_test.go
+++ b/internal/serve/probes_test.go
@@ -1,0 +1,108 @@
+package serve
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/trentas/ptop/pkg/collector"
+	pb "github.com/trentas/ptop/pkg/streampb"
+)
+
+// The handshake carries the probe set alongside the scope (#112). A subscriber
+// that only sees events cannot tell a probe that never attached from a target
+// that never did the thing; TargetInfo is where that gets said.
+func TestHandshakeReportsTheProbeSet(t *testing.T) {
+	set := collector.NewSet(collector.SetConfig{PID: os.Getpid(), NoEBPF: true})
+	defer set.Stop()
+
+	ti := NewHub(TargetPID(os.Getpid()), "", set).targetInfo()
+	if len(ti.GetProbes()) == 0 {
+		t.Fatal("handshake carried no probe set")
+	}
+
+	seen := map[string]*pb.ProbeInfo{}
+	for _, p := range ti.GetProbes() {
+		if p.GetState() == pb.ProbeState_PROBE_STATE_UNSPECIFIED {
+			t.Errorf("%s reported UNSPECIFIED — a state the wire reserves for a server that does not know", p.GetName())
+		}
+		seen[p.GetName()] = p
+	}
+
+	// --no-ebpf removes the heap probe rather than degrading it, and the
+	// handshake must say disabled — the case that turns a no-op deploy into a
+	// −100% regression on every heap call site when it goes unrecorded.
+	heap, ok := seen[collector.SubsystemHeap]
+	if !ok {
+		t.Fatalf("heap absent from the handshake: %v", seen)
+	}
+	if heap.GetState() != pb.ProbeState_PROBE_STATE_DISABLED {
+		t.Errorf("heap state = %v, want DISABLED", heap.GetState())
+	}
+	if heap.GetDetail() == "" {
+		t.Error("a disabled probe must carry why")
+	}
+}
+
+// A hub built without a Set reports no probes at all. Empty means "this server
+// does not say", which is what an older ptop looks like on the wire — never
+// "every probe ran".
+func TestHandshakeWithoutASetCarriesNoProbes(t *testing.T) {
+	if got := NewHub(TargetPID(7), "", nil).targetInfo().GetProbes(); got != nil {
+		t.Errorf("probes = %v, want nil for a hub with no collectors", got)
+	}
+}
+
+// Cgroup mode gets the probe set too: its structural omissions are exactly the
+// ones a consumer would otherwise read as the subtree having gone quiet.
+func TestCgroupHandshakeReportsTheProbeSet(t *testing.T) {
+	set := collector.NewSet(collector.SetConfig{Cgroup: "/sys/fs/cgroup/nonexistent.scope"})
+	defer set.Stop()
+
+	ti := NewHub(TargetCgroup("/sys/fs/cgroup/nonexistent.scope", 7), "", set).targetInfo()
+	if ti.GetMode() != pb.TargetMode_TARGET_MODE_CGROUP {
+		t.Fatalf("mode = %v, want CGROUP", ti.GetMode())
+	}
+	for _, p := range ti.GetProbes() {
+		if p.GetName() == collector.SubsystemHeap {
+			if p.GetState() != pb.ProbeState_PROBE_STATE_UNSUPPORTED {
+				t.Errorf("heap state = %v, want UNSUPPORTED in cgroup scope", p.GetState())
+			}
+			return
+		}
+	}
+	t.Fatalf("heap absent from the cgroup handshake: %v", ti.GetProbes())
+}
+
+// A probe that was asked for and did not attach must be loud at the moment the
+// server announces itself, not only in whatever the collector printed while
+// attaching. The measured cost of it being quiet: 9 of 10 collectors dead on
+// every capture of a service, with nothing downstream able to tell.
+func TestProbeSummaryNamesEveryFailedCollector(t *testing.T) {
+	h := &Hub{probes: []*pb.ProbeInfo{
+		{Name: "cpu", State: pb.ProbeState_PROBE_STATE_ACTIVE, Source: "eBPF"},
+		{Name: "heap", State: pb.ProbeState_PROBE_STATE_DISABLED, Detail: "--disable heap"},
+		{Name: "syscalls", State: pb.ProbeState_PROBE_STATE_FAILED, Detail: "open tracefs: no such file or directory"},
+	}}
+	lines := h.probeSummary()
+	if len(lines) != 2 {
+		t.Fatalf("expected a census and a warning, got %q", lines)
+	}
+	if !strings.Contains(lines[0], "1 active") || !strings.Contains(lines[0], "1 failed") || !strings.Contains(lines[0], "1 disabled") {
+		t.Errorf("census does not count the states: %q", lines[0])
+	}
+	if !strings.Contains(lines[1], "syscalls") || !strings.Contains(lines[1], "no such file or directory") {
+		t.Errorf("warning does not name the failure: %q", lines[1])
+	}
+	if strings.Contains(lines[1], "heap") {
+		t.Errorf("a disabled probe is not a failure and must not be warned about: %q", lines[1])
+	}
+}
+
+// Nothing is printed when the server has no probe set to report — silence is
+// what an older server says, and inventing a census for it would be a claim.
+func TestProbeSummarySilentWithoutAProbeSet(t *testing.T) {
+	if lines := (&Hub{}).probeSummary(); lines != nil {
+		t.Errorf("expected no output, got %q", lines)
+	}
+}

--- a/internal/serve/registry.go
+++ b/internal/serve/registry.go
@@ -161,12 +161,13 @@ func (r *onDemandRegistry) acquire(pid int) (*Hub, StackResolver, func(), error)
 	if resolver != nil {
 		buildID = resolver.ProcessBuildID()
 	}
-	hub := NewHub(TargetPID(pid), buildID)
+	hub := NewHub(TargetPID(pid), buildID, feed.Set)
 	hub.Start(ctx, feed.Bus)
 
 	t := &liveTarget{hub: hub, resolver: resolver, feed: feed, cancel: cancel, refs: 1}
 	r.targets[pid] = t
 	fmt.Fprintf(os.Stderr, "[ptop] observing pid %d (%d target(s) live)\n", pid, len(r.targets))
+	hub.reportProbes()
 	return hub, resolver, r.releaseFunc(pid), nil
 }
 

--- a/internal/serve/registry_test.go
+++ b/internal/serve/registry_test.go
@@ -215,7 +215,7 @@ func TestOnDemandLookupNeverStarts(t *testing.T) {
 // The fixed-target server answers for its own pid (or 0, the pre-#72 request
 // shape) and refuses to pretend it can serve another process.
 func TestFixedRegistryChecksPID(t *testing.T) {
-	reg := &fixedRegistry{target: TargetPID(42), hub: NewHub(TargetPID(42), "")}
+	reg := &fixedRegistry{target: TargetPID(42), hub: NewHub(TargetPID(42), "", nil)}
 
 	for _, pid := range []int{0, 42} {
 		if _, _, _, err := reg.acquire(pid); err != nil {
@@ -231,7 +231,7 @@ func TestFixedRegistryChecksPID(t *testing.T) {
 	}
 
 	// Cgroup mode has no pid to name, so only 0 is meaningful.
-	cg := &fixedRegistry{target: TargetCgroup("/x.scope", 99), hub: NewHub(TargetCgroup("/x.scope", 99), "")}
+	cg := &fixedRegistry{target: TargetCgroup("/x.scope", 99), hub: NewHub(TargetCgroup("/x.scope", 99), "", nil)}
 	if _, _, _, err := cg.acquire(0); err != nil {
 		t.Errorf("cgroup acquire(0) = %v, want accepted", err)
 	}

--- a/internal/serve/serve.go
+++ b/internal/serve/serve.go
@@ -79,19 +79,23 @@ type Options struct {
 }
 
 // Run starts the gRPC server bound to addr, streaming events for the given
-// target — a pid or a cgroup subtree — off bus, the shared fan-out over the
-// running collectors (#71). It blocks until ctx is cancelled, then stops the
-// server and returns. The caller owns the feed's lifecycle (typically
+// target — a pid or a cgroup subtree — off feed, the running collectors and the
+// shared fan-out over them (#71). It blocks until ctx is cancelled, then stops
+// the server and returns. The caller owns the feed's lifecycle (typically
 // collector.StartFeed here and feed.Stop() after Run returns), and may attach
 // other consumers to the same bus — the TUI does, under --serve --tui. addr is
 // "unix:///path" or "tcp://host:port"; a tcp:// endpoint must carry TLS
 // material or an explicit opt-in to cleartext (see serverCredentials).
 //
+// It takes the whole feed rather than feed.Bus alone because the handshake now
+// reports the probe set as well as the scope (#112), and that lives on
+// feed.Set — the pairing collector.Feed exists to keep together.
+//
 // resolver (optional, nil-safe) symbolizes captured stacks: it stamps the
 // per-process build-id onto every StackRef and backs the ResolveStack RPC.
 // Build it with CombineStackResolvers over the collectors that captured stacks
 // (heap, futex); nil leaves events without stack references.
-func Run(ctx context.Context, addr string, target Target, bus *collector.Bus, resolver StackResolver, opts Options) error {
+func Run(ctx context.Context, addr string, target Target, feed *collector.Feed, resolver StackResolver, opts Options) error {
 	// Resolve transport security first: a missing certificate or a refused
 	// cleartext endpoint should fail before anything is bound.
 	creds, mode, err := serverCredentials(addr, opts.TLS)
@@ -105,7 +109,7 @@ func Run(ctx context.Context, addr string, target Target, bus *collector.Bus, re
 	}
 	defer cleanup()
 
-	reg := fixedTargetRegistry(ctx, target, bus, resolver)
+	reg := fixedTargetRegistry(ctx, target, feed, resolver)
 	return runServer(ctx, lis, creds, mode, reg, reg.hub, opts)
 }
 
@@ -145,12 +149,19 @@ func RunOnDemand(ctx context.Context, addr string, factory FeedFactory, opts Opt
 
 // fixedTargetRegistry starts the hub for a server whose target was named on the
 // command line, and wraps it in the registry the service talks to.
-func fixedTargetRegistry(ctx context.Context, target Target, bus *collector.Bus, resolver StackResolver) *fixedRegistry {
+func fixedTargetRegistry(ctx context.Context, target Target, feed *collector.Feed, resolver StackResolver) *fixedRegistry {
 	buildID := ""
 	if resolver != nil {
 		buildID = resolver.ProcessBuildID()
 	}
-	hub := NewHub(target, buildID)
+	var (
+		set *collector.Set
+		bus *collector.Bus
+	)
+	if feed != nil {
+		set, bus = feed.Set, feed.Bus
+	}
+	hub := NewHub(target, buildID, set)
 	hub.Start(ctx, bus)
 	return &fixedRegistry{target: target, hub: hub, resolver: resolver}
 }
@@ -191,6 +202,9 @@ func runServer(ctx context.Context, lis net.Listener, creds credentials.Transpor
 	}
 	fmt.Fprintf(os.Stderr, "[ptop] serving events for %s on %s://%s (%s)\n",
 		reg.describe(), lis.Addr().Network(), lis.Addr().String(), mode)
+	if sinkHub != nil {
+		sinkHub.reportProbes()
+	}
 	if opts.Ready != nil {
 		close(opts.Ready)
 	}

--- a/internal/serve/serve_test.go
+++ b/internal/serve/serve_test.go
@@ -43,7 +43,7 @@ func TestServeUnixEndToEnd(t *testing.T) {
 
 	runErr := make(chan error, 1)
 	go func() {
-		runErr <- Run(ctx, addr, TargetPID(99), collector.StartBus(ctx, []collector.Collector{f}), nil, Options{})
+		runErr <- Run(ctx, addr, TargetPID(99), &collector.Feed{Bus: collector.StartBus(ctx, []collector.Collector{f})}, nil, Options{})
 	}()
 
 	// Wait for the listener socket to appear before dialing.
@@ -136,7 +136,7 @@ func TestServeBackpressureMetaOverGRPC(t *testing.T) {
 	f := newFake(8192) // holds the burst without blocking the producer
 	runErr := make(chan error, 1)
 	go func() {
-		runErr <- Run(ctx, addr, TargetPID(1), collector.StartBus(ctx, []collector.Collector{f}), nil, Options{})
+		runErr <- Run(ctx, addr, TargetPID(1), &collector.Feed{Bus: collector.StartBus(ctx, []collector.Collector{f})}, nil, Options{})
 	}()
 	waitFor(t, func() bool { _, err := os.Stat(sock); return err == nil })
 
@@ -209,7 +209,7 @@ func TestServeJSONLExport(t *testing.T) {
 
 	runErr := make(chan error, 1)
 	go func() {
-		runErr <- Run(ctx, "unix://"+sock, TargetPID(5), collector.StartBus(ctx, []collector.Collector{f}), nil, Options{JSONLPath: jsonl})
+		runErr <- Run(ctx, "unix://"+sock, TargetPID(5), &collector.Feed{Bus: collector.StartBus(ctx, []collector.Collector{f})}, nil, Options{JSONLPath: jsonl})
 	}()
 	waitFor(t, func() bool { _, err := os.Stat(sock); return err == nil })
 

--- a/internal/serve/target_test.go
+++ b/internal/serve/target_test.go
@@ -26,7 +26,7 @@ func handshakeFor(t *testing.T, target Target) *pb.TargetInfo {
 	f := newFake(4)
 	runErr := make(chan error, 1)
 	go func() {
-		runErr <- Run(ctx, addr, target, collector.StartBus(ctx, []collector.Collector{f}), nil, Options{})
+		runErr <- Run(ctx, addr, target, &collector.Feed{Bus: collector.StartBus(ctx, []collector.Collector{f})}, nil, Options{})
 	}()
 	waitFor(t, func() bool { _, err := os.Stat(sock); return err == nil })
 
@@ -96,7 +96,7 @@ func TestSubscribeHandshakeDeclaresTarget(t *testing.T) {
 // In cgroup mode the envelope pid stays 0: events come from anywhere in the
 // subtree, so stamping one process's pid on them would be a lie.
 func TestCgroupModeLeavesEnvelopePidUnset(t *testing.T) {
-	h := NewHub(TargetCgroup("/sys/fs/cgroup/x.scope", 7), "")
+	h := NewHub(TargetCgroup("/sys/fs/cgroup/x.scope", 7), "", nil)
 	ev := h.targetInfo()
 	if ev.GetPid() != 0 {
 		t.Fatalf("handshake pid = %d, want 0", ev.GetPid())

--- a/internal/serve/tls_test.go
+++ b/internal/serve/tls_test.go
@@ -213,7 +213,7 @@ func startTCPServer(ctx context.Context, t *testing.T, opts TLSOptions) string {
 	target := lis.Addr().String()
 	done := make(chan error, 1)
 	go func() {
-		reg := fixedTargetRegistry(ctx, TargetPID(4242), collector.StartBus(ctx, []collector.Collector{f}), nil)
+		reg := fixedTargetRegistry(ctx, TargetPID(4242), &collector.Feed{Bus: collector.StartBus(ctx, []collector.Collector{f})}, nil)
 		done <- runServer(ctx, lis, creds, "test", reg, reg.hub, Options{})
 	}()
 	t.Cleanup(func() {

--- a/pkg/collector/probes.go
+++ b/pkg/collector/probes.go
@@ -110,11 +110,16 @@ func (l *probeLog) statuses() []ProbeStatus {
 	return out
 }
 
-// ebpfOnlySubsystems have no /proc fallback: --no-ebpf does not degrade them,
+// ebpfOnlySubsystems have no /proc lane at all: --no-ebpf does not degrade them,
 // it removes them. They are listed here rather than inferred so degraded mode
 // can report them as disabled without walking collectors it never constructs.
+//
+// io is deliberately absent. Its per-file view is eBPF-only, but iowait% and
+// throughput come from /proc and publish under the same category, so degraded
+// mode still produces io events — reporting it disabled would be the same lie
+// this file exists to stop telling.
 var ebpfOnlySubsystems = []string{
-	SubsystemSyscalls, SubsystemIO, SubsystemNetwork, SubsystemFutex,
+	SubsystemSyscalls, SubsystemNetwork, SubsystemFutex,
 	SubsystemHeap, SubsystemSignals, SubsystemLifecycle, SubsystemSecurity,
 	SubsystemTLS,
 }

--- a/pkg/collector/probes.go
+++ b/pkg/collector/probes.go
@@ -1,0 +1,142 @@
+package collector
+
+import "sort"
+
+// What became of each collector, and why that has to leave the process.
+//
+// Sources (set.go) already records where a subsystem's data came from, but it
+// says "" for every subsystem that produced none — and there are three unrelated
+// reasons for that: the operator switched the probe off, the probe was asked for
+// and failed to attach, or the platform has no such source at all. They call for
+// opposite reactions. A disabled probe is a knob someone can turn back on; a
+// failed one is a broken deployment; only the target genuinely not doing the
+// thing is a finding.
+//
+// A consumer reading the event stream cannot tell them apart, because all three
+// look the same on the wire: a category that never appears. That is what
+// ProbeStatus exists to say out loud, and why it is reported in the subscription
+// handshake next to the scope (#112) — a probe set is as much a part of what was
+// observed as the pid or the cgroup is.
+
+// ProbeState is the outcome of one collector for one target.
+type ProbeState string
+
+const (
+	// ProbeActive: attached, and producing events.
+	ProbeActive ProbeState = "active"
+	// ProbeDisabled: not asked for — --disable named it, --no-ebpf turned off
+	// the lane it needs, or it is opt-in and was not opted into.
+	ProbeDisabled ProbeState = "disabled"
+	// ProbeFailed: asked for and could not attach. The target is instrumented
+	// less than requested, and after the fact only this says so.
+	ProbeFailed ProbeState = "failed"
+	// ProbeUnsupported: cannot exist here — this build embeds no eBPF, the
+	// platform has no such source, or the scope structurally excludes it.
+	ProbeUnsupported ProbeState = "unsupported"
+)
+
+// ProbeStatus is one subsystem's outcome, as reported to consumers.
+type ProbeStatus struct {
+	// Name is the subsystem, spelled as --disable accepts it (see disable.go),
+	// so a status names the flag that would change it.
+	Name  string
+	State ProbeState
+	// Source is where an ACTIVE probe's numbers come from ("eBPF", SourceProc);
+	// empty otherwise. The same subsystem read through a different source is not
+	// the same measurement.
+	Source string
+	// Detail is why a probe that is not ACTIVE is not running: the attach error,
+	// or the flag that switched it off. Prose, not a key.
+	Detail string
+}
+
+// probeLog accumulates one ProbeStatus per subsystem as NewSet walks them.
+//
+// Recording is inline rather than derived at the end because the interesting
+// part — the attach error — exists only at the moment of the failure. Deriving
+// the set afterwards from which collectors are nil would recover the states and
+// throw away every reason.
+type probeLog struct{ m map[string]ProbeStatus }
+
+// set records st unless the probe is already active. A subsystem with a /proc
+// fallback is walked twice — eBPF first, then /proc — so the eBPF failure must
+// not overwrite the fallback that succeeded, nor the reverse. Active is the
+// answer whenever any lane produced data.
+func (l *probeLog) set(st ProbeStatus) {
+	if l.m == nil {
+		l.m = make(map[string]ProbeStatus)
+	}
+	if prev, ok := l.m[st.Name]; ok && prev.State == ProbeActive {
+		return
+	}
+	l.m[st.Name] = st
+}
+
+func (l *probeLog) active(name, source string) {
+	l.set(ProbeStatus{Name: name, State: ProbeActive, Source: source})
+}
+
+func (l *probeLog) disabled(name, why string) {
+	l.set(ProbeStatus{Name: name, State: ProbeDisabled, Detail: why})
+}
+
+func (l *probeLog) unsupported(name, why string) {
+	l.set(ProbeStatus{Name: name, State: ProbeUnsupported, Detail: why})
+}
+
+// failed records an attach failure — or, on a build with no eBPF programs
+// embedded, the honest answer that this binary never had the probe to begin
+// with. Calling that a failure would report a broken deployment on every bare
+// build; it is the same distinction warnEBPFFailure makes before warning.
+func (l *probeLog) failed(name string, err error, ebpfAvailable bool) {
+	if !ebpfAvailable {
+		l.unsupported(name, "this ptop build embeds no eBPF programs (build with -tags=ebpf)")
+		return
+	}
+	l.set(ProbeStatus{Name: name, State: ProbeFailed, Detail: err.Error()})
+}
+
+// statuses returns every recorded subsystem, sorted by name so two captures of
+// the same configuration report byte-identical probe sets.
+func (l *probeLog) statuses() []ProbeStatus {
+	if len(l.m) == 0 {
+		return nil
+	}
+	out := make([]ProbeStatus, 0, len(l.m))
+	for _, st := range l.m {
+		out = append(out, st)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Name < out[j].Name })
+	return out
+}
+
+// ebpfOnlySubsystems have no /proc fallback: --no-ebpf does not degrade them,
+// it removes them. They are listed here rather than inferred so degraded mode
+// can report them as disabled without walking collectors it never constructs.
+var ebpfOnlySubsystems = []string{
+	SubsystemSyscalls, SubsystemIO, SubsystemNetwork, SubsystemFutex,
+	SubsystemHeap, SubsystemSignals, SubsystemLifecycle, SubsystemSecurity,
+	SubsystemTLS,
+}
+
+// cgroupUnsupported names the subsystems a cgroup subtree structurally cannot
+// have, with the reason (see Set.startCgroup, which documents each one). They
+// are reported rather than omitted: a consumer must be able to tell "this scope
+// cannot observe heap" from "heap was switched off", because only the second is
+// something an operator can change.
+var cgroupUnsupported = map[string]string{
+	SubsystemMemory:    "cgroup scope: RSS comes from /proc/<pid>/statm and a subtree has no single pid",
+	SubsystemThreads:   "cgroup scope: thread enumeration comes from /proc/<pid>/task and a subtree has no single pid",
+	SubsystemHeap:      "cgroup scope: the allocator uprobe attaches into one process's mapped libc",
+	SubsystemTLS:       "cgroup scope: the libssl uprobe attaches into one process's mapped libssl",
+	SubsystemSignals:   "cgroup scope: the signal probe filters on a global pid of its own",
+	SubsystemLifecycle: "cgroup scope: the exec-lineage probe filters on a global pid of its own",
+	SubsystemFD:        "cgroup scope: fd enumeration comes from /proc/<pid>/fd and a subtree has no single pid",
+}
+
+// cgroupSubsystems are the ones startCgroup can run — the subtree-capable set,
+// everything not in cgroupUnsupported.
+var cgroupSubsystems = []string{
+	SubsystemCPU, SubsystemSyscalls, SubsystemIO,
+	SubsystemNetwork, SubsystemFutex, SubsystemSecurity,
+}

--- a/pkg/collector/probes_test.go
+++ b/pkg/collector/probes_test.go
@@ -152,3 +152,19 @@ func TestNoEBPFBuildIsUnsupportedNotFailed(t *testing.T) {
 		t.Errorf("detail = %q, want the attach error verbatim", st.Detail)
 	}
 }
+
+// io keeps a /proc lane — iowait% and throughput — that publishes under the same
+// category as the eBPF per-file view. Degraded mode therefore still produces io
+// events, and reporting io "disabled" there would be the same lie the probe set
+// exists to stop telling.
+func TestNoEBPFLeavesIOActiveOnItsProcLane(t *testing.T) {
+	s := NewSet(SetConfig{PID: os.Getpid(), NoEBPF: true})
+	defer s.Stop()
+	st, ok := statusMap(t, s.Probes())[SubsystemIO]
+	if !ok {
+		t.Fatalf("io absent from the probe set: %+v", s.Probes())
+	}
+	if st.State != ProbeActive || st.Source != SourceProc {
+		t.Errorf("io = %+v, want active on %s", st, SourceProc)
+	}
+}

--- a/pkg/collector/probes_test.go
+++ b/pkg/collector/probes_test.go
@@ -1,0 +1,148 @@
+package collector
+
+import (
+	"errors"
+	"os"
+	"testing"
+)
+
+func statusMap(t *testing.T, sts []ProbeStatus) map[string]ProbeStatus {
+	t.Helper()
+	m := make(map[string]ProbeStatus, len(sts))
+	for _, st := range sts {
+		if _, dup := m[st.Name]; dup {
+			t.Fatalf("subsystem %q reported twice: %+v", st.Name, sts)
+		}
+		m[st.Name] = st
+	}
+	return m
+}
+
+// A Set that started nothing reports NO probes — not a set of inactive ones.
+// The distinction is the whole contract: an empty list means "this server does
+// not say", and a consumer must not read it as "nothing ran".
+func TestProbesEmptyForNonPositivePID(t *testing.T) {
+	for _, pid := range []int{0, -1} {
+		if got := NewSet(SetConfig{PID: pid}).Probes(); len(got) != 0 {
+			t.Errorf("pid=%d: expected no probe statuses, got %+v", pid, got)
+		}
+	}
+	var nilSet *Set
+	if got := nilSet.Probes(); got != nil {
+		t.Errorf("nil Set: expected nil, got %+v", got)
+	}
+}
+
+// --disable names a subsystem, and the status says so with the flag that would
+// undo it. This is the case #112 opens with: capture v1 with heap on and v2
+// with it off, and every heap call site reads as removed unless the signature
+// records that the probe was switched off.
+func TestDisabledSubsystemIsReportedAsDisabled(t *testing.T) {
+	s := NewSet(SetConfig{PID: os.Getpid(), Disable: map[string]bool{SubsystemHeap: true}})
+	st, ok := statusMap(t, s.Probes())[SubsystemHeap]
+	if !ok {
+		t.Fatalf("heap absent from the probe set: %+v", s.Probes())
+	}
+	if st.State != ProbeDisabled {
+		t.Errorf("heap state = %q, want %q", st.State, ProbeDisabled)
+	}
+	if st.Detail == "" {
+		t.Error("a disabled probe must say what switched it off")
+	}
+}
+
+// Degraded mode removes the eBPF-only subsystems rather than degrading them, so
+// each is reported disabled — not simply absent, which is what an idle target
+// looks like.
+func TestNoEBPFReportsTheEBPFOnlySubsystemsDisabled(t *testing.T) {
+	s := NewSet(SetConfig{PID: os.Getpid(), NoEBPF: true})
+	m := statusMap(t, s.Probes())
+	for _, name := range ebpfOnlySubsystems {
+		st, ok := m[name]
+		if !ok {
+			t.Errorf("%s absent from the probe set", name)
+			continue
+		}
+		if st.State != ProbeDisabled {
+			t.Errorf("%s state = %q, want %q", name, st.State, ProbeDisabled)
+		}
+	}
+}
+
+// A cgroup subtree structurally cannot carry the per-process probes, and says
+// so rather than staying silent: "this scope cannot observe heap" and "heap was
+// switched off" are different facts, and only the second is actionable.
+func TestCgroupScopeReportsItsStructuralOmissions(t *testing.T) {
+	s := NewSet(SetConfig{Cgroup: "/sys/fs/cgroup/nonexistent.scope"})
+	m := statusMap(t, s.Probes())
+	for name, why := range cgroupUnsupported {
+		st, ok := m[name]
+		if !ok {
+			t.Errorf("%s absent from the probe set in cgroup mode", name)
+			continue
+		}
+		if st.State != ProbeUnsupported {
+			t.Errorf("%s state = %q, want %q", name, st.State, ProbeUnsupported)
+		}
+		if st.Detail != why {
+			t.Errorf("%s detail = %q, want %q", name, st.Detail, why)
+		}
+	}
+}
+
+// Statuses come back sorted, so two captures of one configuration report a
+// byte-identical probe set — a consumer compares these as a key.
+func TestProbeStatusesAreSorted(t *testing.T) {
+	s := NewSet(SetConfig{PID: os.Getpid(), NoEBPF: true})
+	sts := s.Probes()
+	if len(sts) < 2 {
+		t.Fatalf("expected several statuses, got %+v", sts)
+	}
+	for i := 1; i < len(sts); i++ {
+		if sts[i-1].Name >= sts[i].Name {
+			t.Fatalf("statuses not sorted by name: %+v", sts)
+		}
+	}
+}
+
+// A subsystem with a /proc fallback is walked twice — eBPF first, then /proc.
+// Whichever lane produced data wins: the failure of the one must not overwrite
+// the success of the other, in either order.
+func TestActiveWinsOverAFailureInEitherOrder(t *testing.T) {
+	boom := errors.New("attach: no tracefs")
+
+	var failFirst probeLog
+	failFirst.failed(SubsystemCPU, boom, true)
+	failFirst.active(SubsystemCPU, SourceProc)
+	if st := failFirst.statuses()[0]; st.State != ProbeActive || st.Source != SourceProc {
+		t.Errorf("fail→active: got %+v, want active on %s", st, SourceProc)
+	}
+
+	var activeFirst probeLog
+	activeFirst.active(SubsystemCPU, "eBPF")
+	activeFirst.failed(SubsystemCPU, boom, true)
+	if st := activeFirst.statuses()[0]; st.State != ProbeActive || st.Source != "eBPF" {
+		t.Errorf("active→fail: got %+v, want active on eBPF", st)
+	}
+}
+
+// A build with no eBPF programs embedded never had the probe: reporting that as
+// FAILED would call every bare build a broken deployment, and a consumer acting
+// on "failed to attach" would chase an infrastructure problem that isn't there.
+func TestNoEBPFBuildIsUnsupportedNotFailed(t *testing.T) {
+	var l probeLog
+	l.failed(SubsystemSyscalls, errors.New("no program embedded"), false)
+	if st := l.statuses()[0]; st.State != ProbeUnsupported {
+		t.Errorf("state = %q, want %q (detail %q)", st.State, ProbeUnsupported, st.Detail)
+	}
+
+	var withEBPF probeLog
+	withEBPF.failed(SubsystemSyscalls, errors.New("permission denied"), true)
+	st := withEBPF.statuses()[0]
+	if st.State != ProbeFailed {
+		t.Errorf("state = %q, want %q", st.State, ProbeFailed)
+	}
+	if st.Detail != "permission denied" {
+		t.Errorf("detail = %q, want the attach error verbatim", st.Detail)
+	}
+}

--- a/pkg/collector/probes_test.go
+++ b/pkg/collector/probes_test.go
@@ -23,7 +23,9 @@ func statusMap(t *testing.T, sts []ProbeStatus) map[string]ProbeStatus {
 // not say", and a consumer must not read it as "nothing ran".
 func TestProbesEmptyForNonPositivePID(t *testing.T) {
 	for _, pid := range []int{0, -1} {
-		if got := NewSet(SetConfig{PID: pid}).Probes(); len(got) != 0 {
+		s := NewSet(SetConfig{PID: pid})
+		defer s.Stop()
+		if got := s.Probes(); len(got) != 0 {
 			t.Errorf("pid=%d: expected no probe statuses, got %+v", pid, got)
 		}
 	}
@@ -39,6 +41,7 @@ func TestProbesEmptyForNonPositivePID(t *testing.T) {
 // records that the probe was switched off.
 func TestDisabledSubsystemIsReportedAsDisabled(t *testing.T) {
 	s := NewSet(SetConfig{PID: os.Getpid(), Disable: map[string]bool{SubsystemHeap: true}})
+	defer s.Stop()
 	st, ok := statusMap(t, s.Probes())[SubsystemHeap]
 	if !ok {
 		t.Fatalf("heap absent from the probe set: %+v", s.Probes())
@@ -56,6 +59,7 @@ func TestDisabledSubsystemIsReportedAsDisabled(t *testing.T) {
 // looks like.
 func TestNoEBPFReportsTheEBPFOnlySubsystemsDisabled(t *testing.T) {
 	s := NewSet(SetConfig{PID: os.Getpid(), NoEBPF: true})
+	defer s.Stop()
 	m := statusMap(t, s.Probes())
 	for _, name := range ebpfOnlySubsystems {
 		st, ok := m[name]
@@ -74,6 +78,7 @@ func TestNoEBPFReportsTheEBPFOnlySubsystemsDisabled(t *testing.T) {
 // switched off" are different facts, and only the second is actionable.
 func TestCgroupScopeReportsItsStructuralOmissions(t *testing.T) {
 	s := NewSet(SetConfig{Cgroup: "/sys/fs/cgroup/nonexistent.scope"})
+	defer s.Stop()
 	m := statusMap(t, s.Probes())
 	for name, why := range cgroupUnsupported {
 		st, ok := m[name]
@@ -94,6 +99,7 @@ func TestCgroupScopeReportsItsStructuralOmissions(t *testing.T) {
 // byte-identical probe set — a consumer compares these as a key.
 func TestProbeStatusesAreSorted(t *testing.T) {
 	s := NewSet(SetConfig{PID: os.Getpid(), NoEBPF: true})
+	defer s.Stop()
 	sts := s.Probes()
 	if len(sts) < 2 {
 		t.Fatalf("expected several statuses, got %+v", sts)

--- a/pkg/collector/set.go
+++ b/pkg/collector/set.go
@@ -102,6 +102,24 @@ type Set struct {
 	SecurityEBPF      *SecurityEBPFCollector
 
 	Sources Sources
+
+	// probes records what became of every subsystem — including the ones that
+	// produced nothing, and why. Read it through Probes().
+	probes probeLog
+}
+
+// Probes reports every collector this Set tried to run and what became of it,
+// sorted by name (#112).
+//
+// Sources answers "where did this number come from" for the TUI; this answers
+// "was anything watching at all", which is the question a consumer diffing two
+// captures has to settle before it compares them. An empty slice means nothing
+// was attempted (PID <= 0).
+func (s *Set) Probes() []ProbeStatus {
+	if s == nil {
+		return nil
+	}
+	return s.probes.statuses()
 }
 
 // NewSet starts the collectors for cfg.PID following the per-subsystem source
@@ -121,45 +139,63 @@ func NewSet(cfg SetConfig) *Set {
 		return s
 	}
 
-	if c := NewFDCollector(); !cfg.off(SubsystemFD) && c.Start(cfg.PID) == nil {
+	if cfg.off(SubsystemFD) {
+		s.probes.disabled(SubsystemFD, "--disable "+SubsystemFD)
+	} else if c := NewFDCollector(); c.Start(cfg.PID) == nil {
 		s.FD = c
-	} else if !cfg.NoEBPF {
-		fmt.Fprintf(os.Stderr, "warning: FD collector unavailable\n")
+		s.probes.active(SubsystemFD, SourceProc)
+	} else {
+		s.probes.unsupported(SubsystemFD, "FD collector unavailable for this target")
+		if !cfg.NoEBPF {
+			fmt.Fprintf(os.Stderr, "warning: FD collector unavailable\n")
+		}
 	}
 
 	// CPU: eBPF (the target's on-CPU time, from sched_switch) first, /proc
 	// polling of utime+stime as fallback.
+	if cfg.off(SubsystemCPU) {
+		s.probes.disabled(SubsystemCPU, "--disable "+SubsystemCPU)
+	}
 	if !cfg.NoEBPF && !cfg.off(SubsystemCPU) {
 		c := NewCPUEBPFCollector()
 		if err := c.Start(cfg.PID); err == nil {
 			s.CPUEBPF = c
 			s.Sources.CPU = "eBPF"
+			s.probes.active(SubsystemCPU, "eBPF")
 		} else {
 			warnEBPFFailure("cpu", err)
+			s.probes.failed(SubsystemCPU, err, bpf.Available)
 		}
 	}
 	if s.CPUEBPF == nil && !cfg.off(SubsystemCPU) {
 		if c := NewCPUCollector(); c.Start(cfg.PID) == nil {
 			s.CPUProc = c
 			s.Sources.CPU = SourceProc
+			s.probes.active(SubsystemCPU, SourceProc)
 		}
 	}
 
 	// Threads: eBPF (sched_switch → real-time CPU% + ctx switches) preferred,
 	// /proc as fallback.
+	if cfg.off(SubsystemThreads) {
+		s.probes.disabled(SubsystemThreads, "--disable "+SubsystemThreads)
+	}
 	if !cfg.NoEBPF && !cfg.off(SubsystemThreads) {
 		c := NewThreadsEBPFCollector()
 		if err := c.Start(cfg.PID); err == nil {
 			s.ThreadsEBPF = c
 			s.Sources.Threads = "eBPF"
+			s.probes.active(SubsystemThreads, "eBPF")
 		} else {
 			warnEBPFFailure("threads", err)
+			s.probes.failed(SubsystemThreads, err, bpf.Available)
 		}
 	}
 	if s.ThreadsEBPF == nil {
 		if c := NewThreadsCollector(); c.Start(cfg.PID) == nil {
 			s.ThreadsProc = c
 			s.Sources.Threads = SourceProc
+			s.probes.active(SubsystemThreads, SourceProc)
 		}
 	}
 
@@ -170,14 +206,17 @@ func NewSet(cfg SetConfig) *Set {
 		if err := c.Start(cfg.PID); err == nil {
 			s.MemEBPF = c
 			s.Sources.Mem = "eBPF"
+			s.probes.active(SubsystemMemory, "eBPF")
 		} else {
 			warnEBPFFailure("memory", err)
+			s.probes.failed(SubsystemMemory, err, bpf.Available)
 		}
 	}
 	if s.MemEBPF == nil {
 		if c := NewMemCollector(); c.Start(cfg.PID) == nil {
 			s.MemProc = c
 			s.Sources.Mem = SourceProc
+			s.probes.active(SubsystemMemory, SourceProc)
 		}
 	}
 
@@ -202,15 +241,26 @@ func NewSet(cfg SetConfig) *Set {
 	// Each goes through startEBPF so "disabled" and "failed to attach" are
 	// handled the same way everywhere: a disabled subsystem is silent (it was
 	// asked for), a failed one warns.
+	if cfg.NoEBPF {
+		// Degraded mode skips these entirely, so nothing below records them.
+		// Saying so is the whole point: an eBPF-only subsystem is silent here by
+		// the operator's choice, not because the target was quiet.
+		for _, name := range ebpfOnlySubsystems {
+			s.probes.disabled(name, "--no-ebpf")
+		}
+	}
 	if !cfg.NoEBPF {
 		startEBPF := func(name string, c ebpfStarter, onOK func()) {
 			if cfg.off(name) {
+				s.probes.disabled(name, "--disable "+name)
 				return
 			}
 			if err := c.Start(cfg.PID); err != nil {
 				warnEBPFFailure(name, err)
+				s.probes.failed(name, err, bpf.Available)
 				return
 			}
+			s.probes.active(name, "eBPF")
 			onOK()
 		}
 
@@ -281,6 +331,8 @@ func NewSet(cfg SetConfig) *Set {
 				s.TLSEBPF = c7
 				s.Sources.TLS = "eBPF"
 			})
+		} else {
+			s.probes.disabled(SubsystemTLS, "not opted in (--tls); payload capture observes plaintext")
 		}
 	}
 
@@ -310,44 +362,61 @@ type ebpfStarter interface {
 // There is no /proc fallback and nothing is simulated here: cgroup targeting is
 // an in-kernel filter, so without eBPF there is simply nothing to start.
 func (s *Set) startCgroup(cfg SetConfig) {
+	// The omissions are reported, not merely skipped: "this scope cannot observe
+	// heap" and "heap was switched off" reach a consumer as the same silence
+	// otherwise, and only the second is something an operator can undo.
+	for name, why := range cgroupUnsupported {
+		s.probes.unsupported(name, why)
+	}
+
 	if cfg.NoEBPF {
 		fmt.Fprintln(os.Stderr, "warning: --cgroup targeting needs eBPF; nothing started in --no-ebpf mode")
+		for _, name := range cgroupSubsystems {
+			s.probes.disabled(name, "--no-ebpf (cgroup targeting is an in-kernel filter: without eBPF there is nothing to start)")
+		}
 		return
 	}
 
-	if c := NewCPUEBPFCollector(); startCgroupCollector("cpu", c, cfg.Cgroup) {
+	if c := NewCPUEBPFCollector(); s.startCgroupCollector(SubsystemCPU, c, cfg) {
 		s.CPUEBPF = c
 		s.Sources.CPU = "eBPF"
 	}
-	if c := NewSyscallsEBPFCollector(); startCgroupCollector("syscalls", c, cfg.Cgroup) {
+	if c := NewSyscallsEBPFCollector(); s.startCgroupCollector(SubsystemSyscalls, c, cfg) {
 		s.SyscallsEBPF = c
 		s.Sources.Syscalls = "eBPF"
 	}
-	if c := NewIOEBPFCollector(); startCgroupCollector("io", c, cfg.Cgroup) {
+	if c := NewIOEBPFCollector(); s.startCgroupCollector(SubsystemIO, c, cfg) {
 		s.IOEBPF = c
 		s.Sources.IOFiles = "eBPF"
 	}
-	if c := NewNetworkEBPFCollector(); startCgroupCollector("network", c, cfg.Cgroup) {
+	if c := NewNetworkEBPFCollector(); s.startCgroupCollector(SubsystemNetwork, c, cfg) {
 		s.NetworkEBPF = c
 		s.Sources.Net = SourceNetworkRich
 	}
-	if c := NewFutexEBPFCollector(); startCgroupCollector("futex", c, cfg.Cgroup) {
+	if c := NewFutexEBPFCollector(); s.startCgroupCollector(SubsystemFutex, c, cfg) {
 		s.FutexEBPF = c
 		s.Sources.Locks = "eBPF"
 	}
-	if c := NewSecurityEBPFCollector(); startCgroupCollector("security", c, cfg.Cgroup) {
+	if c := NewSecurityEBPFCollector(); s.startCgroupCollector(SubsystemSecurity, c, cfg) {
 		s.SecurityEBPF = c
 		s.Sources.Security = "eBPF"
 	}
 }
 
 // startCgroupCollector starts c against a cgroup subtree, reporting a failure
-// the same way PID mode does.
-func startCgroupCollector(name string, c CgroupTargeter, spec string) bool {
-	if err := c.StartCgroup(spec); err != nil {
+// — and a probe status — the same way PID mode does.
+//
+// cfg.off is deliberately NOT consulted: cgroup mode has never honoured
+// --disable, and this change reports what ran, it does not change what runs.
+// The status then says "active" for a subsystem the operator asked to switch
+// off, which is the truth and is exactly how the gap became visible (#113).
+func (s *Set) startCgroupCollector(name string, c CgroupTargeter, cfg SetConfig) bool {
+	if err := c.StartCgroup(cfg.Cgroup); err != nil {
 		warnEBPFFailure(name, err)
+		s.probes.failed(name, err, bpf.Available)
 		return false
 	}
+	s.probes.active(name, "eBPF")
 	return true
 }
 

--- a/pkg/collector/set.go
+++ b/pkg/collector/set.go
@@ -220,6 +220,10 @@ func NewSet(cfg SetConfig) *Set {
 		}
 	}
 
+	// iowait% and throughput come from /proc and publish under CATEGORY_IO
+	// alongside the eBPF per-file view, so io is active on /proc whenever they
+	// start and the richer lane did not. Recorded after the eBPF block below,
+	// which gets first claim on the status.
 	if c := NewIOWaitCollector(); c.Start(cfg.PID) == nil {
 		s.IOWait = c
 	}
@@ -334,6 +338,10 @@ func NewSet(cfg SetConfig) *Set {
 		} else {
 			s.probes.disabled(SubsystemTLS, "not opted in (--tls); payload capture observes plaintext")
 		}
+	}
+
+	if s.IOWait != nil || s.IOThroughput != nil {
+		s.probes.active(SubsystemIO, SourceProc)
 	}
 
 	return s

--- a/pkg/streampb/service.pb.go
+++ b/pkg/streampb/service.pb.go
@@ -74,6 +74,77 @@ func (TargetMode) EnumDescriptor() ([]byte, []int) {
 	return file_service_proto_rawDescGZIP(), []int{0}
 }
 
+// ProbeState is what became of one collector for one target (#112).
+//
+// The three ways a subsystem goes quiet are unrelated and call for opposite
+// reactions — a probe the operator switched off is a knob they can turn back
+// on, one that failed to attach is a broken deployment, and a target that
+// simply did not do the thing is the only one that is a finding. Before this
+// existed all three reached a consumer as the same absence.
+type ProbeState int32
+
+const (
+	ProbeState_PROBE_STATE_UNSPECIFIED ProbeState = 0
+	// Attached, and producing events for this target.
+	ProbeState_PROBE_STATE_ACTIVE ProbeState = 1
+	// Not asked for: named in --disable, or needing an eBPF lane --no-ebpf turned
+	// off, or opt-in and not opted into (--tls).
+	ProbeState_PROBE_STATE_DISABLED ProbeState = 2
+	// Asked for and could not attach: missing capabilities, no tracefs, kernel
+	// too old, no symbol to hook. The target is instrumented less than requested,
+	// and nothing but this field says so after the fact.
+	ProbeState_PROBE_STATE_FAILED ProbeState = 3
+	// Cannot exist here: this build embeds no eBPF programs, the platform has no
+	// such source, or the scope structurally excludes it (a uprobe into one
+	// process's mapped libc has no meaning over a cgroup subtree).
+	ProbeState_PROBE_STATE_UNSUPPORTED ProbeState = 4
+)
+
+// Enum value maps for ProbeState.
+var (
+	ProbeState_name = map[int32]string{
+		0: "PROBE_STATE_UNSPECIFIED",
+		1: "PROBE_STATE_ACTIVE",
+		2: "PROBE_STATE_DISABLED",
+		3: "PROBE_STATE_FAILED",
+		4: "PROBE_STATE_UNSUPPORTED",
+	}
+	ProbeState_value = map[string]int32{
+		"PROBE_STATE_UNSPECIFIED": 0,
+		"PROBE_STATE_ACTIVE":      1,
+		"PROBE_STATE_DISABLED":    2,
+		"PROBE_STATE_FAILED":      3,
+		"PROBE_STATE_UNSUPPORTED": 4,
+	}
+)
+
+func (x ProbeState) Enum() *ProbeState {
+	p := new(ProbeState)
+	*p = x
+	return p
+}
+
+func (x ProbeState) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (ProbeState) Descriptor() protoreflect.EnumDescriptor {
+	return file_service_proto_enumTypes[1].Descriptor()
+}
+
+func (ProbeState) Type() protoreflect.EnumType {
+	return &file_service_proto_enumTypes[1]
+}
+
+func (x ProbeState) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use ProbeState.Descriptor instead.
+func (ProbeState) EnumDescriptor() ([]byte, []int) {
+	return file_service_proto_rawDescGZIP(), []int{1}
+}
+
 // SubscribeRequest opens a stream. categories filters which Event categories
 // the server sends; empty means all.
 //
@@ -151,8 +222,17 @@ type TargetInfo struct {
 	Pid int32 `protobuf:"varint,2,opt,name=pid,proto3" json:"pid,omitempty"`
 	// CGROUP mode: the resolved absolute cgroup path, and the cgroup id it
 	// resolved to (the directory inode). Empty/0 in pid mode.
-	CgroupPath    string `protobuf:"bytes,3,opt,name=cgroup_path,json=cgroupPath,proto3" json:"cgroup_path,omitempty"`
-	CgroupId      uint64 `protobuf:"varint,4,opt,name=cgroup_id,json=cgroupId,proto3" json:"cgroup_id,omitempty"`
+	CgroupPath string `protobuf:"bytes,3,opt,name=cgroup_path,json=cgroupPath,proto3" json:"cgroup_path,omitempty"`
+	CgroupId   uint64 `protobuf:"varint,4,opt,name=cgroup_id,json=cgroupId,proto3" json:"cgroup_id,omitempty"`
+	// Every collector this server tried to run for the target and what became of
+	// it, sorted by name (#112). Empty from a server older than that.
+	//
+	// This is the second half of the scope, for the same reason as the first: a
+	// probe that is not running emits nothing, which in the events alone is
+	// indistinguishable from a target that never did the thing. A consumer
+	// comparing two captures must compare their probe sets before their numbers,
+	// or it reports the change of instrumentation as a change in behaviour.
+	Probes        []*ProbeInfo `protobuf:"bytes,5,rep,name=probes,proto3" json:"probes,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -215,6 +295,89 @@ func (x *TargetInfo) GetCgroupId() uint64 {
 	return 0
 }
 
+func (x *TargetInfo) GetProbes() []*ProbeInfo {
+	if x != nil {
+		return x.Probes
+	}
+	return nil
+}
+
+// ProbeInfo is one collector's outcome for the target of this stream.
+type ProbeInfo struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Subsystem name, spelled as --disable accepts it: cpu, threads, memory,
+	// heap, syscalls, io, network, futex, signals, lifecycle, security, tls, fd.
+	Name  string     `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
+	State ProbeState `protobuf:"varint,2,opt,name=state,proto3,enum=ptop.v1.ProbeState" json:"state,omitempty"`
+	// Where an ACTIVE probe's numbers come from: "eBPF" or "/proc". Empty
+	// otherwise. The same subsystem read through different sources is not the
+	// same measurement, so this is part of the comparison key too.
+	Source string `protobuf:"bytes,3,opt,name=source,proto3" json:"source,omitempty"`
+	// Why a probe that is not ACTIVE is not running — the attach error, or the
+	// flag that switched it off. Operator-facing prose; do not parse it.
+	Detail        string `protobuf:"bytes,4,opt,name=detail,proto3" json:"detail,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ProbeInfo) Reset() {
+	*x = ProbeInfo{}
+	mi := &file_service_proto_msgTypes[2]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ProbeInfo) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ProbeInfo) ProtoMessage() {}
+
+func (x *ProbeInfo) ProtoReflect() protoreflect.Message {
+	mi := &file_service_proto_msgTypes[2]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ProbeInfo.ProtoReflect.Descriptor instead.
+func (*ProbeInfo) Descriptor() ([]byte, []int) {
+	return file_service_proto_rawDescGZIP(), []int{2}
+}
+
+func (x *ProbeInfo) GetName() string {
+	if x != nil {
+		return x.Name
+	}
+	return ""
+}
+
+func (x *ProbeInfo) GetState() ProbeState {
+	if x != nil {
+		return x.State
+	}
+	return ProbeState_PROBE_STATE_UNSPECIFIED
+}
+
+func (x *ProbeInfo) GetSource() string {
+	if x != nil {
+		return x.Source
+	}
+	return ""
+}
+
+func (x *ProbeInfo) GetDetail() string {
+	if x != nil {
+		return x.Detail
+	}
+	return ""
+}
+
 // StreamMeta is an out-of-band signal interleaved in the stream. It carries the
 // subscription handshake (target, sent once before any event) and reports
 // backpressure: how many events the server dropped for this subscriber because
@@ -231,7 +394,7 @@ type StreamMeta struct {
 
 func (x *StreamMeta) Reset() {
 	*x = StreamMeta{}
-	mi := &file_service_proto_msgTypes[2]
+	mi := &file_service_proto_msgTypes[3]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -243,7 +406,7 @@ func (x *StreamMeta) String() string {
 func (*StreamMeta) ProtoMessage() {}
 
 func (x *StreamMeta) ProtoReflect() protoreflect.Message {
-	mi := &file_service_proto_msgTypes[2]
+	mi := &file_service_proto_msgTypes[3]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -256,7 +419,7 @@ func (x *StreamMeta) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use StreamMeta.ProtoReflect.Descriptor instead.
 func (*StreamMeta) Descriptor() ([]byte, []int) {
-	return file_service_proto_rawDescGZIP(), []int{2}
+	return file_service_proto_rawDescGZIP(), []int{3}
 }
 
 func (x *StreamMeta) GetDropped() uint64 {
@@ -288,7 +451,7 @@ type SubscribeResponse struct {
 
 func (x *SubscribeResponse) Reset() {
 	*x = SubscribeResponse{}
-	mi := &file_service_proto_msgTypes[3]
+	mi := &file_service_proto_msgTypes[4]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -300,7 +463,7 @@ func (x *SubscribeResponse) String() string {
 func (*SubscribeResponse) ProtoMessage() {}
 
 func (x *SubscribeResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_service_proto_msgTypes[3]
+	mi := &file_service_proto_msgTypes[4]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -313,7 +476,7 @@ func (x *SubscribeResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SubscribeResponse.ProtoReflect.Descriptor instead.
 func (*SubscribeResponse) Descriptor() ([]byte, []int) {
-	return file_service_proto_rawDescGZIP(), []int{3}
+	return file_service_proto_rawDescGZIP(), []int{4}
 }
 
 func (x *SubscribeResponse) GetKind() isSubscribeResponse_Kind {
@@ -376,7 +539,7 @@ type ResolveStackRequest struct {
 
 func (x *ResolveStackRequest) Reset() {
 	*x = ResolveStackRequest{}
-	mi := &file_service_proto_msgTypes[4]
+	mi := &file_service_proto_msgTypes[5]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -388,7 +551,7 @@ func (x *ResolveStackRequest) String() string {
 func (*ResolveStackRequest) ProtoMessage() {}
 
 func (x *ResolveStackRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_service_proto_msgTypes[4]
+	mi := &file_service_proto_msgTypes[5]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -401,7 +564,7 @@ func (x *ResolveStackRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ResolveStackRequest.ProtoReflect.Descriptor instead.
 func (*ResolveStackRequest) Descriptor() ([]byte, []int) {
-	return file_service_proto_rawDescGZIP(), []int{4}
+	return file_service_proto_rawDescGZIP(), []int{5}
 }
 
 func (x *ResolveStackRequest) GetStackId() uint64 {
@@ -431,7 +594,7 @@ type ResolveStackResponse struct {
 
 func (x *ResolveStackResponse) Reset() {
 	*x = ResolveStackResponse{}
-	mi := &file_service_proto_msgTypes[5]
+	mi := &file_service_proto_msgTypes[6]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -443,7 +606,7 @@ func (x *ResolveStackResponse) String() string {
 func (*ResolveStackResponse) ProtoMessage() {}
 
 func (x *ResolveStackResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_service_proto_msgTypes[5]
+	mi := &file_service_proto_msgTypes[6]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -456,7 +619,7 @@ func (x *ResolveStackResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ResolveStackResponse.ProtoReflect.Descriptor instead.
 func (*ResolveStackResponse) Descriptor() ([]byte, []int) {
-	return file_service_proto_rawDescGZIP(), []int{5}
+	return file_service_proto_rawDescGZIP(), []int{6}
 }
 
 func (x *ResolveStackResponse) GetFrames() []*StackFrame {
@@ -482,14 +645,20 @@ const file_service_proto_rawDesc = "" +
 	"\n" +
 	"categories\x18\x01 \x03(\x0e2\x11.ptop.v1.CategoryR\n" +
 	"categories\x12\x10\n" +
-	"\x03pid\x18\x02 \x01(\x05R\x03pid\"\x85\x01\n" +
+	"\x03pid\x18\x02 \x01(\x05R\x03pid\"\xb1\x01\n" +
 	"\n" +
 	"TargetInfo\x12'\n" +
 	"\x04mode\x18\x01 \x01(\x0e2\x13.ptop.v1.TargetModeR\x04mode\x12\x10\n" +
 	"\x03pid\x18\x02 \x01(\x05R\x03pid\x12\x1f\n" +
 	"\vcgroup_path\x18\x03 \x01(\tR\n" +
 	"cgroupPath\x12\x1b\n" +
-	"\tcgroup_id\x18\x04 \x01(\x04R\bcgroupId\"S\n" +
+	"\tcgroup_id\x18\x04 \x01(\x04R\bcgroupId\x12*\n" +
+	"\x06probes\x18\x05 \x03(\v2\x12.ptop.v1.ProbeInfoR\x06probes\"z\n" +
+	"\tProbeInfo\x12\x12\n" +
+	"\x04name\x18\x01 \x01(\tR\x04name\x12)\n" +
+	"\x05state\x18\x02 \x01(\x0e2\x13.ptop.v1.ProbeStateR\x05state\x12\x16\n" +
+	"\x06source\x18\x03 \x01(\tR\x06source\x12\x16\n" +
+	"\x06detail\x18\x04 \x01(\tR\x06detail\"S\n" +
 	"\n" +
 	"StreamMeta\x12\x18\n" +
 	"\adropped\x18\x01 \x01(\x04R\adropped\x12+\n" +
@@ -508,7 +677,14 @@ const file_service_proto_rawDesc = "" +
 	"TargetMode\x12\x1b\n" +
 	"\x17TARGET_MODE_UNSPECIFIED\x10\x00\x12\x13\n" +
 	"\x0fTARGET_MODE_PID\x10\x01\x12\x16\n" +
-	"\x12TARGET_MODE_CGROUP\x10\x022\xa7\x01\n" +
+	"\x12TARGET_MODE_CGROUP\x10\x02*\x90\x01\n" +
+	"\n" +
+	"ProbeState\x12\x1b\n" +
+	"\x17PROBE_STATE_UNSPECIFIED\x10\x00\x12\x16\n" +
+	"\x12PROBE_STATE_ACTIVE\x10\x01\x12\x18\n" +
+	"\x14PROBE_STATE_DISABLED\x10\x02\x12\x16\n" +
+	"\x12PROBE_STATE_FAILED\x10\x03\x12\x1b\n" +
+	"\x17PROBE_STATE_UNSUPPORTED\x10\x042\xa7\x01\n" +
 	"\x12EventStreamService\x12D\n" +
 	"\tSubscribe\x12\x19.ptop.v1.SubscribeRequest\x1a\x1a.ptop.v1.SubscribeResponse0\x01\x12K\n" +
 	"\fResolveStack\x12\x1c.ptop.v1.ResolveStackRequest\x1a\x1d.ptop.v1.ResolveStackResponseB\x87\x01\n" +
@@ -526,36 +702,40 @@ func file_service_proto_rawDescGZIP() []byte {
 	return file_service_proto_rawDescData
 }
 
-var file_service_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
-var file_service_proto_msgTypes = make([]protoimpl.MessageInfo, 6)
+var file_service_proto_enumTypes = make([]protoimpl.EnumInfo, 2)
+var file_service_proto_msgTypes = make([]protoimpl.MessageInfo, 7)
 var file_service_proto_goTypes = []any{
 	(TargetMode)(0),              // 0: ptop.v1.TargetMode
-	(*SubscribeRequest)(nil),     // 1: ptop.v1.SubscribeRequest
-	(*TargetInfo)(nil),           // 2: ptop.v1.TargetInfo
-	(*StreamMeta)(nil),           // 3: ptop.v1.StreamMeta
-	(*SubscribeResponse)(nil),    // 4: ptop.v1.SubscribeResponse
-	(*ResolveStackRequest)(nil),  // 5: ptop.v1.ResolveStackRequest
-	(*ResolveStackResponse)(nil), // 6: ptop.v1.ResolveStackResponse
-	(Category)(0),                // 7: ptop.v1.Category
-	(*Event)(nil),                // 8: ptop.v1.Event
-	(*StackFrame)(nil),           // 9: ptop.v1.StackFrame
+	(ProbeState)(0),              // 1: ptop.v1.ProbeState
+	(*SubscribeRequest)(nil),     // 2: ptop.v1.SubscribeRequest
+	(*TargetInfo)(nil),           // 3: ptop.v1.TargetInfo
+	(*ProbeInfo)(nil),            // 4: ptop.v1.ProbeInfo
+	(*StreamMeta)(nil),           // 5: ptop.v1.StreamMeta
+	(*SubscribeResponse)(nil),    // 6: ptop.v1.SubscribeResponse
+	(*ResolveStackRequest)(nil),  // 7: ptop.v1.ResolveStackRequest
+	(*ResolveStackResponse)(nil), // 8: ptop.v1.ResolveStackResponse
+	(Category)(0),                // 9: ptop.v1.Category
+	(*Event)(nil),                // 10: ptop.v1.Event
+	(*StackFrame)(nil),           // 11: ptop.v1.StackFrame
 }
 var file_service_proto_depIdxs = []int32{
-	7, // 0: ptop.v1.SubscribeRequest.categories:type_name -> ptop.v1.Category
-	0, // 1: ptop.v1.TargetInfo.mode:type_name -> ptop.v1.TargetMode
-	2, // 2: ptop.v1.StreamMeta.target:type_name -> ptop.v1.TargetInfo
-	8, // 3: ptop.v1.SubscribeResponse.event:type_name -> ptop.v1.Event
-	3, // 4: ptop.v1.SubscribeResponse.meta:type_name -> ptop.v1.StreamMeta
-	9, // 5: ptop.v1.ResolveStackResponse.frames:type_name -> ptop.v1.StackFrame
-	1, // 6: ptop.v1.EventStreamService.Subscribe:input_type -> ptop.v1.SubscribeRequest
-	5, // 7: ptop.v1.EventStreamService.ResolveStack:input_type -> ptop.v1.ResolveStackRequest
-	4, // 8: ptop.v1.EventStreamService.Subscribe:output_type -> ptop.v1.SubscribeResponse
-	6, // 9: ptop.v1.EventStreamService.ResolveStack:output_type -> ptop.v1.ResolveStackResponse
-	8, // [8:10] is the sub-list for method output_type
-	6, // [6:8] is the sub-list for method input_type
-	6, // [6:6] is the sub-list for extension type_name
-	6, // [6:6] is the sub-list for extension extendee
-	0, // [0:6] is the sub-list for field type_name
+	9,  // 0: ptop.v1.SubscribeRequest.categories:type_name -> ptop.v1.Category
+	0,  // 1: ptop.v1.TargetInfo.mode:type_name -> ptop.v1.TargetMode
+	4,  // 2: ptop.v1.TargetInfo.probes:type_name -> ptop.v1.ProbeInfo
+	1,  // 3: ptop.v1.ProbeInfo.state:type_name -> ptop.v1.ProbeState
+	3,  // 4: ptop.v1.StreamMeta.target:type_name -> ptop.v1.TargetInfo
+	10, // 5: ptop.v1.SubscribeResponse.event:type_name -> ptop.v1.Event
+	5,  // 6: ptop.v1.SubscribeResponse.meta:type_name -> ptop.v1.StreamMeta
+	11, // 7: ptop.v1.ResolveStackResponse.frames:type_name -> ptop.v1.StackFrame
+	2,  // 8: ptop.v1.EventStreamService.Subscribe:input_type -> ptop.v1.SubscribeRequest
+	7,  // 9: ptop.v1.EventStreamService.ResolveStack:input_type -> ptop.v1.ResolveStackRequest
+	6,  // 10: ptop.v1.EventStreamService.Subscribe:output_type -> ptop.v1.SubscribeResponse
+	8,  // 11: ptop.v1.EventStreamService.ResolveStack:output_type -> ptop.v1.ResolveStackResponse
+	10, // [10:12] is the sub-list for method output_type
+	8,  // [8:10] is the sub-list for method input_type
+	8,  // [8:8] is the sub-list for extension type_name
+	8,  // [8:8] is the sub-list for extension extendee
+	0,  // [0:8] is the sub-list for field type_name
 }
 
 func init() { file_service_proto_init() }
@@ -564,7 +744,7 @@ func file_service_proto_init() {
 		return
 	}
 	file_event_proto_init()
-	file_service_proto_msgTypes[3].OneofWrappers = []any{
+	file_service_proto_msgTypes[4].OneofWrappers = []any{
 		(*SubscribeResponse_Event)(nil),
 		(*SubscribeResponse_Meta)(nil),
 	}
@@ -573,8 +753,8 @@ func file_service_proto_init() {
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_service_proto_rawDesc), len(file_service_proto_rawDesc)),
-			NumEnums:      1,
-			NumMessages:   6,
+			NumEnums:      2,
+			NumMessages:   7,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/proto/service.proto
+++ b/proto/service.proto
@@ -47,6 +47,54 @@ message TargetInfo {
   // resolved to (the directory inode). Empty/0 in pid mode.
   string cgroup_path = 3;
   uint64 cgroup_id = 4;
+  // Every collector this server tried to run for the target and what became of
+  // it, sorted by name (#112). Empty from a server older than that.
+  //
+  // This is the second half of the scope, for the same reason as the first: a
+  // probe that is not running emits nothing, which in the events alone is
+  // indistinguishable from a target that never did the thing. A consumer
+  // comparing two captures must compare their probe sets before their numbers,
+  // or it reports the change of instrumentation as a change in behaviour.
+  repeated ProbeInfo probes = 5;
+}
+
+// ProbeState is what became of one collector for one target (#112).
+//
+// The three ways a subsystem goes quiet are unrelated and call for opposite
+// reactions — a probe the operator switched off is a knob they can turn back
+// on, one that failed to attach is a broken deployment, and a target that
+// simply did not do the thing is the only one that is a finding. Before this
+// existed all three reached a consumer as the same absence.
+enum ProbeState {
+  PROBE_STATE_UNSPECIFIED = 0;
+  // Attached, and producing events for this target.
+  PROBE_STATE_ACTIVE = 1;
+  // Not asked for: named in --disable, or needing an eBPF lane --no-ebpf turned
+  // off, or opt-in and not opted into (--tls).
+  PROBE_STATE_DISABLED = 2;
+  // Asked for and could not attach: missing capabilities, no tracefs, kernel
+  // too old, no symbol to hook. The target is instrumented less than requested,
+  // and nothing but this field says so after the fact.
+  PROBE_STATE_FAILED = 3;
+  // Cannot exist here: this build embeds no eBPF programs, the platform has no
+  // such source, or the scope structurally excludes it (a uprobe into one
+  // process's mapped libc has no meaning over a cgroup subtree).
+  PROBE_STATE_UNSUPPORTED = 4;
+}
+
+// ProbeInfo is one collector's outcome for the target of this stream.
+message ProbeInfo {
+  // Subsystem name, spelled as --disable accepts it: cpu, threads, memory,
+  // heap, syscalls, io, network, futex, signals, lifecycle, security, tls, fd.
+  string name = 1;
+  ProbeState state = 2;
+  // Where an ACTIVE probe's numbers come from: "eBPF" or "/proc". Empty
+  // otherwise. The same subsystem read through different sources is not the
+  // same measurement, so this is part of the comparison key too.
+  string source = 3;
+  // Why a probe that is not ACTIVE is not running — the attach error, or the
+  // flag that switched it off. Operator-facing prose; do not parse it.
+  string detail = 4;
 }
 
 // StreamMeta is an out-of-band signal interleaved in the stream. It carries the


### PR DESCRIPTION
Closes #112.

## The gap

`TargetInfo` reports the scope — pid or cgroup subtree — and the proto states why: the two modes aggregate different populations, so a consumer comparing across the boundary reads the change of observation window as a change in behaviour. The set of probes is the second dimension of exactly that, and it was silent.

A subsystem goes quiet for three unrelated reasons: the operator switched it off (`--disable heap`, `--no-ebpf`, opt-in not opted into), it was asked for and **failed to attach**, or the target genuinely did not do the thing. Only the third is a finding. On the wire all three are the same absence.

Measured cost, on a real host: a `serve` container had no `tracefs`/`debugfs` mounted, 9 of 10 collectors never attached on **every** capture, and the signatures were built and persisted as if they had. A later, fully instrumented capture diffed against that baseline produced **14 headline regressions where the correctly-paired capture produces 5**. In the other direction, a consumer reading those diffs concluded *"the axis is allocation, not syscalls and not lock contention"* — absence of instrument read as absence of signal.

## What this adds

`TargetInfo.probes`: per subsystem, spelled as `--disable` accepts it —

| field | meaning |
|---|---|
| `name` | `cpu`, `heap`, `syscalls`, … — the name that would change it |
| `state` | `ACTIVE` / `DISABLED` / `FAILED` / `UNSUPPORTED` |
| `source` | `eBPF` or `/proc` for an active probe — not the same measurement |
| `detail` | the attach error, or the flag that switched it off |

`collector.Sources` already knew most of this and kept it inside the process. The missing half is the *reason*, which only exists at the moment of the failure — so it is recorded inline as `NewSet` walks the subsystems, rather than derived afterwards from which collectors ended up nil.

`ACTIVE`/`FAILED` is the distinction that is not cosmetic: a disabled probe is a knob someone can turn back on, a failed one is a broken deployment.

Server startup now also prints the census and names every collector that was asked for and did not attach:

```
[ptop] probes: 1 active, 1 failed, 1 disabled, 0 unsupported
[ptop] ⚠ 1 collector(s) asked for but NOT attached — this stream is instrumented less than
       requested, and a consumer comparing it against a fully instrumented capture will read
       the missing axes as behaviour that stopped: syscalls (open tracefs: no such file...)
```

## Scope

**Reporting only.** Nothing about which collectors start changes. That leaves `--disable memory` (PID mode) and every `--disable` in cgroup mode reporting `active` for a probe the operator asked to switch off — which is the truth, and is how those gaps became visible. Filed separately as #113, with the tradeoff that makes the memory one non-obvious.

`serve.Run` now takes `*collector.Feed` instead of `feed.Bus`: the probe set lives on `feed.Set`, and `Feed` is the pairing that exists to keep the two together.

## Compatibility

Additive on the wire. An older consumer ignores the field; a consumer reading an older server sees it empty, which it must read as **unknown**, never as "every probe ran" — the same reading `TargetMode_UNSPECIFIED` already gets.

## Tests

`pkg/collector/probes_test.go` — empty for a Set that started nothing, `--disable` → `DISABLED` with the flag in `detail`, `--no-ebpf` → the eBPF-only set disabled, cgroup mode → its structural omissions as `UNSUPPORTED`, sorted output, active-wins-over-failure in either lane order, and a no-eBPF build reported `UNSUPPORTED` rather than `FAILED` (calling every bare build a broken deployment would be the same class of lie).

`internal/serve/probes_test.go` — the handshake carries the set in both scopes, a hub with no collectors carries none, and the startup census names failures without naming disabled probes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hh1r1Vo8v6z65K7ryJpPQL