### PR TITLE
Honour --disable on every lane a subsystem has, not just its eBPF one

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,7 +230,12 @@ eBPF programs in `internal/bpf/programs/`:
   stack sampled by bytes allocated
 
 Any subsystem can be switched off with `--disable <name,...>` — see
-[what it costs](#what-it-costs-the-process-it-watches) for why you might.
+[what it costs](#what-it-costs-the-process-it-watches) for why you might. Naming
+one switches off **every** lane it has, its `/proc` reader included, because the
+flag is a statement about what is running and a subsystem still reporting
+through its cheaper lane would make that statement false. The view for it then
+simulates, as it does for any subsystem with no collector behind it, and the
+stream's probe set reports it `disabled`.
 - `signal.bpf.c` — `signal:signal_generate` → signals delivered, with sender
 - `proc.bpf.c` — `sched_process_{fork,exec,exit}` → exec-lineage subtree
 - `security.bpf.c` — PROT_EXEC `mmap`/`mprotect` + SELinux AVC denials

--- a/pkg/collector/disable.go
+++ b/pkg/collector/disable.go
@@ -23,6 +23,13 @@ import (
 // Subsystem names accepted by SetConfig.Disable. They match the names in
 // ptop's own warnings, so a message about a subsystem tells you what to pass
 // to switch it off.
+//
+// Naming one switches off EVERY lane it has, not just its eBPF one: the flag is
+// a statement about what is running, and a subsystem that keeps reporting
+// through its /proc reader after being disabled makes that statement false
+// (#113). NewSet routes every subsystem through Set.enabled for exactly this
+// reason. The corresponding view then simulates, as it does for any subsystem
+// with no collector behind it.
 const (
 	SubsystemCPU       = "cpu"
 	SubsystemThreads   = "threads"

--- a/pkg/collector/disable_lanes_test.go
+++ b/pkg/collector/disable_lanes_test.go
@@ -1,0 +1,123 @@
+package collector
+
+import (
+	"os"
+	"testing"
+)
+
+// --disable exists so an operator can be SURE which probes are running:
+// ParseDisable rejects a typo rather than let it silently disable nothing,
+// because the failure mode of a misspelled flag is a measurement that reports a
+// configuration other than the one it ran. Three places took the flag and then
+// started the collector anyway (#113) — memory on both lanes, threads and io on
+// their /proc lane, and every subsystem in cgroup mode.
+//
+// One test per lane, because each was a separate omission and a regression in
+// one would not show up in the others.
+
+// pidSet builds a Set against this process with the named subsystems disabled.
+func pidSet(t *testing.T, off ...string) *Set {
+	t.Helper()
+	disable := make(map[string]bool, len(off))
+	for _, n := range off {
+		disable[n] = true
+	}
+	s := NewSet(SetConfig{PID: os.Getpid(), Disable: disable})
+	t.Cleanup(s.Stop)
+	return s
+}
+
+// Memory consulted the flag nowhere: --disable memory parsed, validated, and
+// started both the eBPF collector and the /proc reader behind it.
+func TestDisableMemoryStopsBothLanes(t *testing.T) {
+	s := pidSet(t, SubsystemMemory)
+	if s.MemEBPF != nil || s.MemProc != nil {
+		t.Errorf("memory collectors still running: ebpf=%v proc=%v", s.MemEBPF != nil, s.MemProc != nil)
+	}
+	if !s.MockMem() {
+		t.Error("MockMem() = false — something is still feeding the memory view")
+	}
+	if s.Sources.Mem != "" {
+		t.Errorf("Sources.Mem = %q, want empty", s.Sources.Mem)
+	}
+	if st := statusMap(t, s.Probes())[SubsystemMemory]; st.State != ProbeDisabled {
+		t.Errorf("memory probe = %+v, want disabled", st)
+	}
+}
+
+// Threads guarded only its eBPF lane, so --disable threads still polled
+// /proc/<pid>/task.
+func TestDisableThreadsStopsTheProcLane(t *testing.T) {
+	s := pidSet(t, SubsystemThreads)
+	if s.ThreadsEBPF != nil || s.ThreadsProc != nil {
+		t.Errorf("thread collectors still running: ebpf=%v proc=%v", s.ThreadsEBPF != nil, s.ThreadsProc != nil)
+	}
+	if !s.MockThreads() {
+		t.Error("MockThreads() = false")
+	}
+	if st := statusMap(t, s.Probes())[SubsystemThreads]; st.State != ProbeDisabled {
+		t.Errorf("threads probe = %+v, want disabled", st)
+	}
+}
+
+// io's iowait% and throughput lanes are not a fallback for the eBPF per-file
+// view — they publish beside it, under the same category — and started
+// unconditionally, so --disable io left io events on the wire.
+func TestDisableIOStopsTheProcLanes(t *testing.T) {
+	s := pidSet(t, SubsystemIO)
+	if s.IOWait != nil || s.IOThroughput != nil || s.IOEBPF != nil {
+		t.Errorf("io collectors still running: wait=%v throughput=%v ebpf=%v",
+			s.IOWait != nil, s.IOThroughput != nil, s.IOEBPF != nil)
+	}
+	if !s.MockIOWait() || !s.MockIOThroughput() || !s.MockIOFiles() {
+		t.Error("an io lane is still feeding the view")
+	}
+	if st := statusMap(t, s.Probes())[SubsystemIO]; st.State != ProbeDisabled {
+		t.Errorf("io probe = %+v, want disabled", st)
+	}
+}
+
+// CPU already honoured the flag on both lanes; pinned so the restructuring that
+// fixed the others cannot quietly undo it.
+func TestDisableCPUStopsBothLanes(t *testing.T) {
+	s := pidSet(t, SubsystemCPU)
+	if s.CPUEBPF != nil || s.CPUProc != nil {
+		t.Errorf("cpu collectors still running: ebpf=%v proc=%v", s.CPUEBPF != nil, s.CPUProc != nil)
+	}
+	if st := statusMap(t, s.Probes())[SubsystemCPU]; st.State != ProbeDisabled {
+		t.Errorf("cpu probe = %+v, want disabled", st)
+	}
+}
+
+// Disabling one subsystem must not disturb its neighbours — the restructuring
+// moved every lane inside a gate, and a misplaced brace would show up here.
+func TestDisableIsScopedToWhatWasNamed(t *testing.T) {
+	s := pidSet(t, SubsystemMemory)
+	m := statusMap(t, s.Probes())
+	for _, name := range []string{SubsystemCPU, SubsystemThreads, SubsystemFD} {
+		if st := m[name]; st.State == ProbeDisabled {
+			t.Errorf("%s reported disabled, but only memory was named: %+v", name, st)
+		}
+	}
+}
+
+// cgroup mode consulted the flag nowhere: --disable syscalls --cgroup /x.scope
+// collected syscalls. The subtree is not reachable in a unit test, so the
+// assertion is on the recorded outcome — disabled, never "asked for and failed".
+func TestCgroupModeHonoursDisable(t *testing.T) {
+	s := NewSet(SetConfig{
+		Cgroup:  "/sys/fs/cgroup/nonexistent.scope",
+		Disable: map[string]bool{SubsystemSyscalls: true},
+	})
+	defer s.Stop()
+	if s.SyscallsEBPF != nil {
+		t.Error("syscalls collector started in cgroup mode despite --disable syscalls")
+	}
+	st := statusMap(t, s.Probes())[SubsystemSyscalls]
+	if st.State != ProbeDisabled {
+		t.Errorf("syscalls probe = %+v, want disabled", st)
+	}
+	if st.Detail == "" {
+		t.Error("a disabled probe must say what switched it off")
+	}
+}

--- a/pkg/collector/set.go
+++ b/pkg/collector/set.go
@@ -139,84 +139,90 @@ func NewSet(cfg SetConfig) *Set {
 		return s
 	}
 
-	if cfg.off(SubsystemFD) {
-		s.probes.disabled(SubsystemFD, "--disable "+SubsystemFD)
-	} else if c := NewFDCollector(); c.Start(cfg.PID) == nil {
-		s.FD = c
-		s.probes.active(SubsystemFD, SourceProc)
-	} else {
-		s.probes.unsupported(SubsystemFD, "FD collector unavailable for this target")
-		if !cfg.NoEBPF {
-			fmt.Fprintf(os.Stderr, "warning: FD collector unavailable\n")
+	if s.enabled(cfg, SubsystemFD) {
+		if c := NewFDCollector(); c.Start(cfg.PID) == nil {
+			s.FD = c
+			s.probes.active(SubsystemFD, SourceProc)
+		} else {
+			s.probes.unsupported(SubsystemFD, "FD collector unavailable for this target")
+			if !cfg.NoEBPF {
+				fmt.Fprintf(os.Stderr, "warning: FD collector unavailable\n")
+			}
 		}
 	}
 
 	// CPU: eBPF (the target's on-CPU time, from sched_switch) first, /proc
 	// polling of utime+stime as fallback.
-	if cfg.off(SubsystemCPU) {
-		s.probes.disabled(SubsystemCPU, "--disable "+SubsystemCPU)
-	}
-	if !cfg.NoEBPF && !cfg.off(SubsystemCPU) {
-		c := NewCPUEBPFCollector()
-		if err := c.Start(cfg.PID); err == nil {
-			s.CPUEBPF = c
-			s.Sources.CPU = "eBPF"
-			s.probes.active(SubsystemCPU, "eBPF")
-		} else {
-			warnEBPFFailure("cpu", err)
-			s.probes.failed(SubsystemCPU, err, bpf.Available)
+	if s.enabled(cfg, SubsystemCPU) {
+		if !cfg.NoEBPF {
+			c := NewCPUEBPFCollector()
+			if err := c.Start(cfg.PID); err == nil {
+				s.CPUEBPF = c
+				s.Sources.CPU = "eBPF"
+				s.probes.active(SubsystemCPU, "eBPF")
+			} else {
+				warnEBPFFailure("cpu", err)
+				s.probes.failed(SubsystemCPU, err, bpf.Available)
+			}
 		}
-	}
-	if s.CPUEBPF == nil && !cfg.off(SubsystemCPU) {
-		if c := NewCPUCollector(); c.Start(cfg.PID) == nil {
-			s.CPUProc = c
-			s.Sources.CPU = SourceProc
-			s.probes.active(SubsystemCPU, SourceProc)
+		if s.CPUEBPF == nil {
+			if c := NewCPUCollector(); c.Start(cfg.PID) == nil {
+				s.CPUProc = c
+				s.Sources.CPU = SourceProc
+				s.probes.active(SubsystemCPU, SourceProc)
+			}
 		}
 	}
 
 	// Threads: eBPF (sched_switch → real-time CPU% + ctx switches) preferred,
 	// /proc as fallback.
-	if cfg.off(SubsystemThreads) {
-		s.probes.disabled(SubsystemThreads, "--disable "+SubsystemThreads)
-	}
-	if !cfg.NoEBPF && !cfg.off(SubsystemThreads) {
-		c := NewThreadsEBPFCollector()
-		if err := c.Start(cfg.PID); err == nil {
-			s.ThreadsEBPF = c
-			s.Sources.Threads = "eBPF"
-			s.probes.active(SubsystemThreads, "eBPF")
-		} else {
-			warnEBPFFailure("threads", err)
-			s.probes.failed(SubsystemThreads, err, bpf.Available)
+	if s.enabled(cfg, SubsystemThreads) {
+		if !cfg.NoEBPF {
+			c := NewThreadsEBPFCollector()
+			if err := c.Start(cfg.PID); err == nil {
+				s.ThreadsEBPF = c
+				s.Sources.Threads = "eBPF"
+				s.probes.active(SubsystemThreads, "eBPF")
+			} else {
+				warnEBPFFailure("threads", err)
+				s.probes.failed(SubsystemThreads, err, bpf.Available)
+			}
 		}
-	}
-	if s.ThreadsEBPF == nil {
-		if c := NewThreadsCollector(); c.Start(cfg.PID) == nil {
-			s.ThreadsProc = c
-			s.Sources.Threads = SourceProc
-			s.probes.active(SubsystemThreads, SourceProc)
+		if s.ThreadsEBPF == nil {
+			if c := NewThreadsCollector(); c.Start(cfg.PID) == nil {
+				s.ThreadsProc = c
+				s.Sources.Threads = SourceProc
+				s.probes.active(SubsystemThreads, SourceProc)
+			}
 		}
 	}
 
 	// Memory: eBPF (real allocs/s + page faults via kprobe) preferred, /proc
 	// (accumulated minflt+majflt) as fallback.
-	if !cfg.NoEBPF {
-		c := NewMemEBPFCollector()
-		if err := c.Start(cfg.PID); err == nil {
-			s.MemEBPF = c
-			s.Sources.Mem = "eBPF"
-			s.probes.active(SubsystemMemory, "eBPF")
-		} else {
-			warnEBPFFailure("memory", err)
-			s.probes.failed(SubsystemMemory, err, bpf.Available)
+	//
+	// --disable memory takes BOTH lanes, RSS included. That is the flag's
+	// contract rather than an oversight: it exists so an operator can be certain
+	// which probes are running, and a subsystem that keeps reporting through its
+	// cheaper lane after being switched off makes that certainty worthless. The
+	// memory view then simulates, exactly as every other disabled subsystem's does.
+	if s.enabled(cfg, SubsystemMemory) {
+		if !cfg.NoEBPF {
+			c := NewMemEBPFCollector()
+			if err := c.Start(cfg.PID); err == nil {
+				s.MemEBPF = c
+				s.Sources.Mem = "eBPF"
+				s.probes.active(SubsystemMemory, "eBPF")
+			} else {
+				warnEBPFFailure("memory", err)
+				s.probes.failed(SubsystemMemory, err, bpf.Available)
+			}
 		}
-	}
-	if s.MemEBPF == nil {
-		if c := NewMemCollector(); c.Start(cfg.PID) == nil {
-			s.MemProc = c
-			s.Sources.Mem = SourceProc
-			s.probes.active(SubsystemMemory, SourceProc)
+		if s.MemEBPF == nil {
+			if c := NewMemCollector(); c.Start(cfg.PID) == nil {
+				s.MemProc = c
+				s.Sources.Mem = SourceProc
+				s.probes.active(SubsystemMemory, SourceProc)
+			}
 		}
 	}
 
@@ -224,11 +230,16 @@ func NewSet(cfg SetConfig) *Set {
 	// alongside the eBPF per-file view, so io is active on /proc whenever they
 	// start and the richer lane did not. Recorded after the eBPF block below,
 	// which gets first claim on the status.
-	if c := NewIOWaitCollector(); c.Start(cfg.PID) == nil {
-		s.IOWait = c
-	}
-	if c := NewIOThroughputCollector(); c.Start(cfg.PID) == nil {
-		s.IOThroughput = c
+	//
+	// They are not a fallback for that view — they run beside it — but they are
+	// still io, so they answer to --disable io just as it does.
+	if s.enabled(cfg, SubsystemIO) {
+		if c := NewIOWaitCollector(); c.Start(cfg.PID) == nil {
+			s.IOWait = c
+		}
+		if c := NewIOThroughputCollector(); c.Start(cfg.PID) == nil {
+			s.IOThroughput = c
+		}
 	}
 
 	// Execution/container context (#60): namespace + cgroup + uid/gid from
@@ -347,6 +358,24 @@ func NewSet(cfg SetConfig) *Set {
 	return s
 }
 
+// enabled reports whether a subsystem should be started, recording it as
+// disabled when it should not.
+//
+// Every subsystem goes through this one call instead of testing cfg.off at each
+// lane, because per-lane testing is precisely how --disable came to be honoured
+// by some lanes and ignored by others (#113): memory consulted it nowhere,
+// threads and io only on their eBPF lane, and cgroup mode not at all. A flag
+// that validates its input and then does nothing is worse than no flag —
+// ParseDisable rejects a typo so that nobody measures a configuration other
+// than the one they report.
+func (s *Set) enabled(cfg SetConfig, name string) bool {
+	if cfg.off(name) {
+		s.probes.disabled(name, "--disable "+name)
+		return false
+	}
+	return true
+}
+
 // ebpfStarter is the shape every eBPF collector shares: attach to a pid, or
 // explain why not.
 type ebpfStarter interface {
@@ -411,14 +440,12 @@ func (s *Set) startCgroup(cfg SetConfig) {
 	}
 }
 
-// startCgroupCollector starts c against a cgroup subtree, reporting a failure
-// — and a probe status — the same way PID mode does.
-//
-// cfg.off is deliberately NOT consulted: cgroup mode has never honoured
-// --disable, and this change reports what ran, it does not change what runs.
-// The status then says "active" for a subsystem the operator asked to switch
-// off, which is the truth and is exactly how the gap became visible (#113).
+// startCgroupCollector starts c against a cgroup subtree, honouring --disable and
+// reporting a failure — and a probe status — the same way PID mode does.
 func (s *Set) startCgroupCollector(name string, c CgroupTargeter, cfg SetConfig) bool {
+	if !s.enabled(cfg, name) {
+		return false
+	}
 	if err := c.StartCgroup(cfg.Cgroup); err != nil {
 		warnEBPFFailure(name, err)
 		s.probes.failed(name, err, bpf.Available)


### PR DESCRIPTION
Closes #113. Empilhado sobre #114 (`base: feat/probe-set-handshake`) — o campo que essa PR adiciona é o que tornou este bug visível.

## O bug

`ParseDisable` **rejeita um typo** em vez de deixá-lo desligar nada, e o comentário diz por quê: o modo de falha de um `--disable` mal escrito é uma medição que reporta uma configuração diferente da que rodou. Três lugares aceitavam o flag e subiam o coletor mesmo assim.

| lane | o que acontecia |
|---|---|
| `memory` | não consultava o flag em lugar nenhum — `--disable memory` subia o coletor eBPF **e** o leitor de `/proc` atrás dele |
| `threads` | guardava só a lane eBPF — o polling de `/proc/<pid>/task` continuava |
| `io` | guardava só a lane eBPF — `iowait%` e throughput continuavam, e eles publicam sob a **mesma** `CATEGORY_IO` da visão por arquivo, então eventos de io seguiam no fio |
| modo cgroup | não consultava o flag em lugar nenhum |

Cada lane testava `cfg.off` por conta própria, e foi exatamente assim que elas passaram a discordar. Agora todo subsistema passa por um único portão (`Set.enabled`), então uma lane adicionada depois não consegue pular a checagem em silêncio.

## A decisão que a issue pediu para tomar

**`--disable memory` leva o RSS junto.** É o contrato do flag, não um descuido: ele existe para que o operador tenha *certeza* de quais probes estão rodando, e um subsistema que segue reportando pela lane barata depois de ser desligado torna essa certeza inútil. A visão de memória então simula — exatamente como já faz a de qualquer subsistema sem coletor atrás, incluindo `--disable cpu`, que sempre se comportou assim.

## Como apareceu

O #112 fez o conjunto de probes reportar o que de fato rodou. Passar `--disable memory` hoje devolve `memory: active`, que é a verdade — e é o sintoma.

## Testes

Um teste por lane, porque cada uma foi uma omissão separada e uma regressão em qualquer delas não apareceria nas outras: memory nas duas lanes, threads no `/proc`, io nas duas lanes de `/proc`, cgroup mode, cpu (que já funcionava, pinado para que a reestruturação não o desfaça), e um teste de que desabilitar um subsistema não perturba os vizinhos — uma chave mal colocada na reestruturação apareceria ali.

Verde em `-race -count=2` e no lane `-tags=ebpf`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hh1r1Vo8v6z65K7ryJpPQL