### PR TITLE
Count the call-site cap in call sites, and say what the cut left out (#109)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -380,6 +380,18 @@ estimate, and `HeapSnapshot.sample_bytes` says so on the wire. What remains is
 the uprobe trap itself, which no amount of sampling removes; `--disable heap`
 is the only way to stop paying it.
 
+**`top_call_sites` says how complete it is.** The kernel keys its heap
+aggregates by stack id, so stacks reaching the same application call site are
+folded together (`foldCallSites`) BEFORE the top-N cut — otherwise the cap is
+counted in stacks, and a function reached six ways holds six of the eight slots
+while a busier single-stack site falls out (#109). The snapshot then reports
+`total_call_sites` and `omitted_alloc_count` / `omitted_alloc_bytes` /
+`omitted_live_bytes`. A consumer needs them to read ABSENCE: with a truncated
+list there is no way to tell a site that stopped allocating from one that
+stopped being reported, and those call for opposite responses
+(sunnysystems/witness#69). Equal counts mean the list is a census; otherwise the
+omitted totals bound what any one missing site can account for.
+
 **The sampling threshold is random, and that is load-bearing.** Allocation
 patterns are periodic — a handler allocates the same objects in the same order
 every request — and a fixed threshold crossed by a periodic byte stream always

--- a/README.md
+++ b/README.md
@@ -311,6 +311,7 @@ The lanes measure different things, and the snapshot says which:
 |---|---|---|
 | allocation rate + volume, total | exact | exact |
 | per-site split | exact | **sampled** — `sample_bytes > 0` |
+| completeness of the site list | `total_call_sites` + `omitted_*` | same |
 | `func` / `file:line` per site | via `.symtab` + DWARF | via `.gopclntab` |
 | live bytes, lifetime, leak suspects | yes | **no** — `live_measured=false` |
 
@@ -332,6 +333,34 @@ The interval is randomized around that average, because allocation patterns are
 periodic and a fixed one would cross at the same point of every cycle and hand
 one call site all the samples. `--heap-sample-bytes 0` records every allocation,
 which is exact and costs what the table below says.
+
+### The call-site list says how complete it is
+
+`top_call_sites` carries the largest few sites, not a census. Three fields say
+what it left out, on both lanes:
+
+| field | meaning |
+|---|---|
+| `total_call_sites` | distinct call sites the snapshot aggregated, before the cut |
+| `omitted_alloc_count` / `omitted_alloc_bytes` / `omitted_live_bytes` | volume carried by the sites that did not fit |
+
+When `total_call_sites` equals the length of the list, the list **is** a census
+and a site's absence from it means the site allocated nothing. Otherwise a site
+absent from the list did strictly less than the omitted totals — the bound that
+lets a consumer read absence instead of guessing at it.
+
+That distinction is not academic. A consumer diffing two deploys watches a site
+drop out of the list and cannot otherwise tell *"it stopped allocating"* from
+*"it stopped being reported"*; those are opposite situations, and reading the
+first where the second holds reports the largest regression such an engine can
+express over no evidence at all (#109, sunnysystems/witness#69).
+
+The count is in call sites, which is also the unit of the cut. The kernel keys
+its aggregate by stack id, and one call site is reached through as many stacks
+as there are paths into the allocator beneath it — a map that grows produces a
+fresh one per growth path. Stacks reaching the same site are folded together
+**before** the ranking, so a function reached many ways no longer holds several
+of the slots and pushes out a busier one reached a single way.
 
 Symbolization works on stripped release builds (`-ldflags="-s -w"`): `.symtab`
 is gone but `.gopclntab` survives, because the runtime needs it for tracebacks.

--- a/internal/serve/mapper.go
+++ b/internal/serve/mapper.go
@@ -82,6 +82,10 @@ func toEvent(pid int, buildID string, v interface{}) *pb.Event {
 			Lane:               x.Lane,
 			LiveMeasured:       x.LiveMeasured,
 			SampleBytes:        x.SampleBytes,
+			TotalCallSites:     x.TotalCallSites,
+			OmittedAllocCount:  x.OmittedAllocCount,
+			OmittedAllocBytes:  x.OmittedAllocBytes,
+			OmittedLiveBytes:   x.OmittedLiveBytes,
 		}}
 
 	case collector.HeapEvent:

--- a/internal/serve/mapper_test.go
+++ b/internal/serve/mapper_test.go
@@ -236,3 +236,41 @@ func TestMapHeapSnapshotCarriesLaneAndLiveMeasured(t *testing.T) {
 		})
 	}
 }
+
+// TestMapHeapSnapshotCarriesCompleteness pins the completeness signal onto the
+// wire (#109).
+//
+// Without it a consumer holding a truncated list cannot tell a site that
+// stopped allocating from one that stopped being reported, and reading the
+// first where the second holds reports the largest regression such an engine
+// can express over no evidence at all (sunnysystems/witness#69). total_call_sites
+// equal to the list length is the one state in which absence means zero.
+func TestMapHeapSnapshotCarriesCompleteness(t *testing.T) {
+	in := collector.HeapStats{
+		Lane: collector.HeapLaneGo, Timestamp: time.Unix(9, 0),
+		TopCallSites: []collector.HeapCallSite{
+			{CallSite: 0x1000, Func: "main.(*cache).storeThumb", AllocCount: 12024},
+			{CallSite: 0x2000, Func: "main.decode", AllocCount: 6008},
+		},
+		TotalCallSites:    9,
+		OmittedAllocCount: 11973,
+		OmittedAllocBytes: 96 << 10,
+		OmittedLiveBytes:  0,
+	}
+	h := toEvent(1, "", in).GetHeap()
+	if h == nil {
+		t.Fatal("payload is not a HeapSnapshot")
+	}
+	if h.GetTotalCallSites() != 9 {
+		t.Errorf("total_call_sites = %d, want 9", h.GetTotalCallSites())
+	}
+	if got := len(h.GetTopCallSites()); uint32(got) == h.GetTotalCallSites() {
+		t.Errorf("a truncated list reported itself as a census (%d of %d)", got, h.GetTotalCallSites())
+	}
+	if h.GetOmittedAllocCount() != 11973 {
+		t.Errorf("omitted_alloc_count = %d, want 11973", h.GetOmittedAllocCount())
+	}
+	if h.GetOmittedAllocBytes() != 96<<10 {
+		t.Errorf("omitted_alloc_bytes = %d, want %d", h.GetOmittedAllocBytes(), 96<<10)
+	}
+}

--- a/pkg/collector/heap_agg.go
+++ b/pkg/collector/heap_agg.go
@@ -19,34 +19,140 @@ func isSuspectedLeak(ageNs, thresholdNs uint64) bool {
 	return ageNs > thresholdNs
 }
 
-// chooseTopCallSites returns the n most significant call sites, descending.
-// n < 0 keeps all.
+// rawCallSite is ONE STACK's aggregate, before stacks that reach the same
+// application call site are folded into one entry. The kernel keys its heap
+// aggregates by stack id, and one call site is reached through as many stacks
+// as there are paths into the allocator beneath it — a map that grows produces
+// a fresh one per growth path. LifetimeSumNs/LifetimeCount are carried
+// alongside because a mean cannot be merged, only recomputed from its parts.
+type rawCallSite struct {
+	HeapCallSite
+	LifetimeSumNs uint64
+	LifetimeCount uint64
+}
+
+// foldCallSites merges per-stack aggregates into per-call-site ones, summing
+// the measurements and recomputing the lifetime mean from the pooled sum.
 //
-// Live bytes rank first, then bytes ever allocated, then allocation count,
-// then the address for a deterministic tie-break. The AllocBytes tier is what
-// makes this work unchanged on the Go lane: there LiveBytes is 0 for every
-// site (nothing observes a free), so the comparison falls straight through to
-// allocation volume — the ranking that means something there — instead of
-// collapsing into an address sort.
-func chooseTopCallSites(sites []HeapCallSite, n int) []HeapCallSite {
-	out := make([]HeapCallSite, len(sites))
-	copy(out, sites)
-	sort.Slice(out, func(i, j int) bool {
-		if out[i].LiveBytes != out[j].LiveBytes {
-			return out[i].LiveBytes > out[j].LiveBytes
+// Without this the top-N cut is counted in stacks, which is not the unit anyone
+// reading the list thinks in. A function reached through six stacks holds six of
+// the eight slots, so a busy site that reaches the allocator one way is pushed
+// out by a quieter one that reaches it many ways — and a consumer counting the
+// FUNCTIONS it received sees a short list and concludes nothing was dropped
+// (#109). Folding first makes the cap mean what it reads as.
+//
+// Sites whose stack walk failed (CallSite 0, "unknown") fold together too: they
+// are one bucket of unattributed allocation, not N distinct sites, and leaving
+// them apart lets them crowd out sites that DID resolve.
+//
+// The identity fields belong to the address, so the first resolution of a site
+// wins. StackID cannot be summed and is not dropped either — it keeps the
+// heaviest contributing stack, so resolving it still yields a stack that
+// genuinely reached this site. It is representative, not exhaustive.
+func foldCallSites(raw []rawCallSite) []HeapCallSite {
+	type acc struct {
+		site      HeapCallSite
+		dominant  HeapCallSite
+		lifeSumNs uint64
+		lifeCount uint64
+	}
+	order := make([]uint64, 0, len(raw))
+	by := make(map[uint64]*acc, len(raw))
+	for _, r := range raw {
+		a := by[r.CallSite]
+		if a == nil {
+			by[r.CallSite] = &acc{
+				site: r.HeapCallSite, dominant: r.HeapCallSite,
+				lifeSumNs: r.LifetimeSumNs, lifeCount: r.LifetimeCount,
+			}
+			order = append(order, r.CallSite)
+			continue
 		}
-		if out[i].AllocBytes != out[j].AllocBytes {
-			return out[i].AllocBytes > out[j].AllocBytes
+		a.site.LiveBytes += r.LiveBytes
+		a.site.AllocBytes += r.AllocBytes
+		a.site.AllocCount += r.AllocCount
+		a.site.Suspected = a.site.Suspected || r.Suspected
+		a.lifeSumNs += r.LifetimeSumNs
+		a.lifeCount += r.LifetimeCount
+		if outranks(r.HeapCallSite, a.dominant) {
+			a.dominant = r.HeapCallSite
 		}
-		if out[i].AllocCount != out[j].AllocCount {
-			return out[i].AllocCount > out[j].AllocCount
+	}
+	out := make([]HeapCallSite, 0, len(order))
+	for _, addr := range order {
+		a := by[addr]
+		a.site.StackID = a.dominant.StackID
+		a.site.AvgLifetimeMs = 0
+		if a.lifeCount > 0 {
+			a.site.AvgLifetimeMs = float64(a.lifeSumNs) / float64(a.lifeCount) / 1e6
 		}
-		return out[i].CallSite < out[j].CallSite
-	})
-	if n >= 0 && len(out) > n {
-		out = out[:n]
+		out = append(out, a.site)
 	}
 	return out
+}
+
+// heapOmitted is what the top-N cut left outside a snapshot: the sites that did
+// not fit and the volume they carried.
+//
+// It exists so absence can be read. A consumer holding a truncated list cannot
+// tell a site that stopped allocating from one that stopped being reported, and
+// the two call for opposite responses (sunnysystems/witness#69). Sites == 0
+// says the list is a census and absence means zero; otherwise these totals
+// bound what any single missing site can account for.
+type heapOmitted struct {
+	Sites      int
+	AllocCount uint64
+	AllocBytes uint64
+	LiveBytes  uint64
+}
+
+// outranks reports whether a is more significant than b.
+//
+// Live bytes rank first, then bytes ever allocated, then allocation count, then
+// address and stack for a deterministic tie-break. The AllocBytes tier is what
+// makes this work unchanged on the Go lane: there LiveBytes is 0 for every site
+// (nothing observes a free), so the comparison falls straight through to
+// allocation volume — the ranking that means something there — instead of
+// collapsing into an address sort.
+func outranks(a, b HeapCallSite) bool {
+	switch {
+	case a.LiveBytes != b.LiveBytes:
+		return a.LiveBytes > b.LiveBytes
+	case a.AllocBytes != b.AllocBytes:
+		return a.AllocBytes > b.AllocBytes
+	case a.AllocCount != b.AllocCount:
+		return a.AllocCount > b.AllocCount
+	case a.CallSite != b.CallSite:
+		return a.CallSite < b.CallSite
+	default:
+		return a.StackID < b.StackID
+	}
+}
+
+// topCallSites returns the n most significant call sites, descending, together
+// with an account of what it dropped. n < 0 keeps all.
+func topCallSites(sites []HeapCallSite, n int) ([]HeapCallSite, heapOmitted) {
+	out := make([]HeapCallSite, len(sites))
+	copy(out, sites)
+	sort.Slice(out, func(i, j int) bool { return outranks(out[i], out[j]) })
+	if n < 0 || len(out) <= n {
+		return out, heapOmitted{}
+	}
+	var om heapOmitted
+	for _, s := range out[n:] {
+		om.Sites++
+		om.AllocCount += s.AllocCount
+		om.AllocBytes += s.AllocBytes
+		om.LiveBytes += s.LiveBytes
+	}
+	return out[:n], om
+}
+
+// chooseTopCallSites is topCallSites for callers that do not report what was
+// dropped.
+func chooseTopCallSites(sites []HeapCallSite, n int) []HeapCallSite {
+	top, _ := topCallSites(sites, n)
+	return top
 }
 
 // pickAppFrame returns the first stack frame outside the libc address range —

--- a/pkg/collector/heap_agg_test.go
+++ b/pkg/collector/heap_agg_test.go
@@ -203,3 +203,154 @@ func TestIsGoRuntimeFunc(t *testing.T) {
 		}
 	}
 }
+
+// TestFoldCallSitesCountsTheCapInCallSitesNotStacks is the regression for #109.
+//
+// The measured case: a thumbnail cache that stops evicting grows its map, and
+// growth reaches the allocator through several distinct stacks. The kernel keys
+// its aggregate by stack id, so before folding each of those stacks held a slot
+// of its own and pushed a busy single-stack site (fmt.Sprintf, ~6000
+// allocations a window, called identically in both builds) out of a cap of 8 —
+// while a consumer counting the FUNCTIONS it received saw a short list and
+// concluded nothing had been dropped.
+func TestFoldCallSitesCountsTheCapInCallSitesNotStacks(t *testing.T) {
+	// storeThumb reaches mallocgc through six stacks; fmt.Sprintf through one.
+	var raw []rawCallSite
+	for i := 0; i < 6; i++ {
+		raw = append(raw, rawCallSite{HeapCallSite: HeapCallSite{
+			CallSite: 0x1000, Func: "main.(*cache).storeThumb", StackID: int32(i),
+			AllocBytes: 4 << 20, AllocCount: 2004,
+		}})
+	}
+	raw = append(raw, rawCallSite{HeapCallSite: HeapCallSite{
+		CallSite: 0x2000, Func: "fmt.Sprintf", StackID: 100,
+		AllocBytes: 96 << 10, AllocCount: 6017,
+	}})
+
+	folded := foldCallSites(raw)
+	if len(folded) != 2 {
+		t.Fatalf("len(folded) = %d, want 2 — the cap must be counted in call sites", len(folded))
+	}
+
+	top, omitted := topCallSites(folded, 2)
+	if len(top) != 2 {
+		t.Fatalf("len(top) = %d, want 2", len(top))
+	}
+	var sawSprintf bool
+	for _, s := range top {
+		if s.Func == "fmt.Sprintf" {
+			sawSprintf = true
+			if s.AllocCount != 6017 {
+				t.Errorf("fmt.Sprintf AllocCount = %d, want 6017", s.AllocCount)
+			}
+		}
+		if s.Func == "main.(*cache).storeThumb" {
+			if want := uint64(6 * 2004); s.AllocCount != want {
+				t.Errorf("storeThumb AllocCount = %d, want %d (six stacks summed)", s.AllocCount, want)
+			}
+			if s.AllocBytes != 6*(4<<20) {
+				t.Errorf("storeThumb AllocBytes = %d, want %d", s.AllocBytes, 6*(4<<20))
+			}
+		}
+	}
+	if !sawSprintf {
+		t.Errorf("fmt.Sprintf fell out of a list with room for it; the fold did not take")
+	}
+	if omitted.Sites != 0 {
+		t.Errorf("omitted.Sites = %d, want 0 — this list is a census", omitted.Sites)
+	}
+}
+
+// TestFoldCallSitesKeepsTheHeaviestStack pins what a folded StackID means: the
+// stack that contributed most, so resolving it still yields frames that
+// genuinely reached this site.
+func TestFoldCallSitesKeepsTheHeaviestStack(t *testing.T) {
+	raw := []rawCallSite{
+		{HeapCallSite: HeapCallSite{CallSite: 0x40, StackID: 7, AllocBytes: 10}},
+		{HeapCallSite: HeapCallSite{CallSite: 0x40, StackID: 9, AllocBytes: 900}},
+		{HeapCallSite: HeapCallSite{CallSite: 0x40, StackID: 3, AllocBytes: 50}},
+	}
+	got := foldCallSites(raw)
+	if len(got) != 1 {
+		t.Fatalf("len = %d, want 1", len(got))
+	}
+	if got[0].StackID != 9 {
+		t.Errorf("StackID = %d, want 9 (the heaviest contributor)", got[0].StackID)
+	}
+	if got[0].AllocBytes != 960 {
+		t.Errorf("AllocBytes = %d, want 960", got[0].AllocBytes)
+	}
+}
+
+// TestFoldCallSitesRecomputesTheLifetimeMean: a mean cannot be merged, only
+// recomputed from the pooled parts. Averaging the two averages here would give
+// 55ms; the real pooled mean is 19ms, because the 10ms bucket holds 90 of the
+// 100 freed allocations.
+func TestFoldCallSitesRecomputesTheLifetimeMean(t *testing.T) {
+	raw := []rawCallSite{
+		{HeapCallSite: HeapCallSite{CallSite: 0x50, StackID: 1}, LifetimeSumNs: 90 * 10 * 1e6, LifetimeCount: 90},
+		{HeapCallSite: HeapCallSite{CallSite: 0x50, StackID: 2}, LifetimeSumNs: 10 * 100 * 1e6, LifetimeCount: 10},
+	}
+	got := foldCallSites(raw)
+	if len(got) != 1 {
+		t.Fatalf("len = %d, want 1", len(got))
+	}
+	if got[0].AvgLifetimeMs != 19 {
+		t.Errorf("AvgLifetimeMs = %v, want 19 (pooled), not 55 (mean of means)", got[0].AvgLifetimeMs)
+	}
+}
+
+// TestFoldCallSitesPoolsUnresolvedStacks: a failed stack walk yields CallSite 0.
+// Those are one bucket of unattributed allocation, not N distinct sites — left
+// apart they crowd out sites that did resolve.
+func TestFoldCallSitesPoolsUnresolvedStacks(t *testing.T) {
+	raw := []rawCallSite{
+		{HeapCallSite: HeapCallSite{CallSite: 0, StackID: 1, AllocCount: 3}},
+		{HeapCallSite: HeapCallSite{CallSite: 0, StackID: 2, AllocCount: 4}},
+		{HeapCallSite: HeapCallSite{CallSite: 0, StackID: 3, AllocCount: 5}},
+		{HeapCallSite: HeapCallSite{CallSite: 0x60, StackID: 4, AllocCount: 1}},
+	}
+	got := foldCallSites(raw)
+	if len(got) != 2 {
+		t.Fatalf("len = %d, want 2 (one unknown bucket + one resolved site)", len(got))
+	}
+	for _, s := range got {
+		if s.CallSite == 0 && s.AllocCount != 12 {
+			t.Errorf("unknown bucket AllocCount = %d, want 12", s.AllocCount)
+		}
+	}
+}
+
+// TestTopCallSitesAccountsForWhatItDropped pins the completeness signal.
+//
+// A truncated list cannot tell a consumer whether a site is missing because it
+// stopped allocating or because it stopped being reported, and the two call for
+// opposite responses (sunnysystems/witness#69). The omitted totals bound what
+// any one missing site can account for.
+func TestTopCallSitesAccountsForWhatItDropped(t *testing.T) {
+	sites := []HeapCallSite{
+		{CallSite: 1, AllocBytes: 1000, AllocCount: 10, LiveBytes: 100},
+		{CallSite: 2, AllocBytes: 900, AllocCount: 9, LiveBytes: 90},
+		{CallSite: 3, AllocBytes: 30, AllocCount: 3, LiveBytes: 3},
+		{CallSite: 4, AllocBytes: 20, AllocCount: 2, LiveBytes: 2},
+	}
+	top, om := topCallSites(sites, 2)
+	if len(top) != 2 {
+		t.Fatalf("len(top) = %d, want 2", len(top))
+	}
+	if om.Sites != 2 {
+		t.Errorf("omitted.Sites = %d, want 2", om.Sites)
+	}
+	if om.AllocBytes != 50 || om.AllocCount != 5 || om.LiveBytes != 5 {
+		t.Errorf("omitted = %+v, want AllocBytes 50 / AllocCount 5 / LiveBytes 5", om)
+	}
+
+	// A census reports nothing omitted — the state in which a consumer may read
+	// absence as zero.
+	if _, om := topCallSites(sites, 4); om.Sites != 0 || om.AllocBytes != 0 {
+		t.Errorf("a complete list reported omissions: %+v", om)
+	}
+	if _, om := topCallSites(sites, -1); om.Sites != 0 {
+		t.Errorf("n < 0 keeps all but reported omissions: %+v", om)
+	}
+}

--- a/pkg/collector/heap_ebpf.go
+++ b/pkg/collector/heap_ebpf.go
@@ -370,10 +370,14 @@ func (c *HeapEBPFCollector) snapshotGo() (HeapStats, error) {
 		return HeapStats{}, err
 	}
 
-	sites := make([]HeapCallSite, 0, len(agg))
+	// The kernel aggregate is keyed by stack id, so fold the stacks that reach
+	// one call site together BEFORE ranking — otherwise the cut is counted in
+	// stacks and a function reached many ways crowds out one reached often
+	// (#109). See foldCallSites.
+	raws := make([]rawCallSite, 0, len(agg))
 	for sid, raw := range agg {
 		site := c.resolveSite(sid)
-		sites = append(sites, HeapCallSite{
+		raws = append(raws, rawCallSite{HeapCallSite: HeapCallSite{
 			CallSite:   site.addr,
 			AddrHex:    heapAddrHex(site.addr),
 			Func:       site.frame.Func,
@@ -384,19 +388,25 @@ func (c *HeapEBPFCollector) snapshotGo() (HeapStats, error) {
 			StackID:    sid,
 			AllocBytes: raw.AllocBytes,
 			AllocCount: raw.AllocCount,
-		})
+		}})
 	}
+	sites := foldCallSites(raws)
+	top, omitted := topCallSites(sites, heapTopCallSites)
 
 	now := time.Now()
 	allocRate, byteRate := c.ratesGo(now)
 	return HeapStats{
-		Timestamp:      now,
-		AllocRate:      allocRate,
-		AllocBytesRate: byteRate,
-		TopCallSites:   chooseTopCallSites(sites, heapTopCallSites),
-		Lane:           HeapLaneGo,
-		LiveMeasured:   false,
-		SampleBytes:    sampledRate(c.goTracer.SampleBytes()),
+		Timestamp:         now,
+		AllocRate:         allocRate,
+		AllocBytesRate:    byteRate,
+		TopCallSites:      top,
+		Lane:              HeapLaneGo,
+		LiveMeasured:      false,
+		SampleBytes:       sampledRate(c.goTracer.SampleBytes()),
+		TotalCallSites:    uint32(len(sites)),
+		OmittedAllocCount: omitted.AllocCount,
+		OmittedAllocBytes: omitted.AllocBytes,
+		OmittedLiveBytes:  omitted.LiveBytes,
 	}, nil
 }
 
@@ -419,7 +429,10 @@ func (c *HeapEBPFCollector) snapshotLibc() (HeapStats, error) {
 		suspectedTotal += lk.Size
 	}
 
-	sites := make([]HeapCallSite, 0, len(live))
+	// Keyed by stack id here too, so the same fold applies (#109). The lifetime
+	// sum and count travel with each stack rather than the mean they make: a
+	// mean cannot be merged, only recomputed from the pooled parts.
+	raws := make([]rawCallSite, 0, len(live))
 	var liveTotal uint64
 	for sid, raw := range live {
 		lb := raw.LiveBytes
@@ -427,27 +440,28 @@ func (c *HeapEBPFCollector) snapshotLibc() (HeapStats, error) {
 			lb = 0 // defensive: never present negative live bytes
 		}
 		liveTotal += uint64(lb)
-		avgLifeMs := 0.0
-		if raw.LifetimeCount > 0 {
-			avgLifeMs = float64(raw.LifetimeSumNs) / float64(raw.LifetimeCount) / 1e6
-		}
 		site := c.resolveSite(sid)
-		sites = append(sites, HeapCallSite{
-			CallSite:      site.addr,
-			AddrHex:       heapAddrHex(site.addr),
-			Func:          site.frame.Func,
-			File:          site.frame.File,
-			Line:          site.frame.Line,
-			Module:        site.frame.Module,
-			Offset:        site.frame.Offset,
-			StackID:       sid,
-			LiveBytes:     uint64(lb),
-			AllocCount:    raw.AllocCount,
-			AllocBytes:    0, // the libc aggregate counts live bytes, not cumulative ones
-			AvgLifetimeMs: avgLifeMs,
-			Suspected:     leakBytes[sid] > 0,
+		raws = append(raws, rawCallSite{
+			HeapCallSite: HeapCallSite{
+				CallSite:   site.addr,
+				AddrHex:    heapAddrHex(site.addr),
+				Func:       site.frame.Func,
+				File:       site.frame.File,
+				Line:       site.frame.Line,
+				Module:     site.frame.Module,
+				Offset:     site.frame.Offset,
+				StackID:    sid,
+				LiveBytes:  uint64(lb),
+				AllocCount: raw.AllocCount,
+				AllocBytes: 0, // the libc aggregate counts live bytes, not cumulative ones
+				Suspected:  leakBytes[sid] > 0,
+			},
+			LifetimeSumNs: raw.LifetimeSumNs,
+			LifetimeCount: raw.LifetimeCount,
 		})
 	}
+	sites := foldCallSites(raws)
+	top, omitted := topCallSites(sites, heapTopCallSites)
 
 	now := time.Now()
 	rate, byteRate := c.rates(now)
@@ -457,10 +471,14 @@ func (c *HeapEBPFCollector) snapshotLibc() (HeapStats, error) {
 		LiveHeapBytes:      liveTotal,
 		AllocRate:          rate,
 		AllocBytesRate:     byteRate,
-		TopCallSites:       chooseTopCallSites(sites, heapTopCallSites),
+		TopCallSites:       top,
 		SuspectedLeakBytes: suspectedTotal,
 		Lane:               HeapLaneLibc,
 		LiveMeasured:       true,
+		TotalCallSites:     uint32(len(sites)),
+		OmittedAllocCount:  omitted.AllocCount,
+		OmittedAllocBytes:  omitted.AllocBytes,
+		OmittedLiveBytes:   omitted.LiveBytes,
 	}, nil
 }
 

--- a/pkg/collector/types.go
+++ b/pkg/collector/types.go
@@ -161,6 +161,31 @@ type HeapStats struct {
 	// everything allocated since the previous sample, so nothing is discarded.
 	// See goalloc.bpf.c for why the probe cannot afford to run in full (#108).
 	SampleBytes uint64
+
+	// TotalCallSites is how many distinct application call sites this snapshot
+	// aggregated, before TopCallSites was cut to the largest few. Equal to
+	// len(TopCallSites) when nothing was dropped — which is the only state in
+	// which the list is a census and a site's absence from it means the site
+	// allocated nothing.
+	//
+	// Counted AFTER stacks reaching one call site are folded together, so it is
+	// in the same unit as the list a consumer receives (#109).
+	TotalCallSites uint32
+
+	// OmittedAllocCount, OmittedAllocBytes and OmittedLiveBytes are the volume
+	// carried by the call sites that did not fit in TopCallSites — zero when
+	// TotalCallSites == len(TopCallSites).
+	//
+	// They exist so absence can be read rather than guessed. A consumer diffing
+	// two deploys sees a site drop out of the list and cannot tell "it stopped
+	// allocating" from "it stopped being reported"; the two call for opposite
+	// responses, and reading the first where the second is true reports the
+	// largest regression such an engine can express, over nothing at all
+	// (sunnysystems/witness#69). These bound what any one missing site can
+	// account for: a site absent from the list did strictly less than this.
+	OmittedAllocCount uint64
+	OmittedAllocBytes uint64
+	OmittedLiveBytes  uint64
 }
 
 // Heap collection lanes — see HeapStats.Lane.

--- a/pkg/streampb/event.pb.go
+++ b/pkg/streampb/event.pb.go
@@ -1536,9 +1536,33 @@ type HeapSnapshot struct {
 	// previous one, so no byte goes unattributed. Sampling exists because a stack
 	// walk per allocation costs a large multiple of the TARGET's own CPU time,
 	// which ptop's CPU axis then reported as the target's (#108).
-	SampleBytes   uint64 `protobuf:"varint,8,opt,name=sample_bytes,json=sampleBytes,proto3" json:"sample_bytes,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	SampleBytes uint64 `protobuf:"varint,8,opt,name=sample_bytes,json=sampleBytes,proto3" json:"sample_bytes,omitempty"`
+	// How many distinct application call sites this snapshot aggregated, before
+	// top_call_sites was cut to the largest few. Equal to len(top_call_sites)
+	// when nothing was dropped — which is the only state in which the list is a
+	// census, and therefore the only one in which a site's ABSENCE from it means
+	// the site allocated nothing.
+	//
+	// Counted after stacks reaching one call site are folded together, so it is
+	// in the same unit as the list: the kernel keys its aggregate by stack id,
+	// and a function reached through several stacks used to hold several of the
+	// slots (#109).
+	TotalCallSites uint32 `protobuf:"varint,9,opt,name=total_call_sites,json=totalCallSites,proto3" json:"total_call_sites,omitempty"`
+	// The volume carried by the call sites that did not fit in top_call_sites.
+	// Zero when total_call_sites == len(top_call_sites).
+	//
+	// These exist so absence can be read instead of guessed. A consumer diffing
+	// two deploys watches a site drop out of the list and cannot tell "it stopped
+	// allocating" from "it stopped being reported" — opposite situations, and
+	// reading the first where the second holds reports the largest regression
+	// such an engine can express over no evidence at all
+	// (sunnysystems/witness#69). A site absent from the list did strictly less
+	// than these totals, which is the bound that makes the inference safe.
+	OmittedAllocCount uint64 `protobuf:"varint,10,opt,name=omitted_alloc_count,json=omittedAllocCount,proto3" json:"omitted_alloc_count,omitempty"`
+	OmittedAllocBytes uint64 `protobuf:"varint,11,opt,name=omitted_alloc_bytes,json=omittedAllocBytes,proto3" json:"omitted_alloc_bytes,omitempty"`
+	OmittedLiveBytes  uint64 `protobuf:"varint,12,opt,name=omitted_live_bytes,json=omittedLiveBytes,proto3" json:"omitted_live_bytes,omitempty"`
+	unknownFields     protoimpl.UnknownFields
+	sizeCache         protoimpl.SizeCache
 }
 
 func (x *HeapSnapshot) Reset() {
@@ -1623,6 +1647,34 @@ func (x *HeapSnapshot) GetLiveMeasured() bool {
 func (x *HeapSnapshot) GetSampleBytes() uint64 {
 	if x != nil {
 		return x.SampleBytes
+	}
+	return 0
+}
+
+func (x *HeapSnapshot) GetTotalCallSites() uint32 {
+	if x != nil {
+		return x.TotalCallSites
+	}
+	return 0
+}
+
+func (x *HeapSnapshot) GetOmittedAllocCount() uint64 {
+	if x != nil {
+		return x.OmittedAllocCount
+	}
+	return 0
+}
+
+func (x *HeapSnapshot) GetOmittedAllocBytes() uint64 {
+	if x != nil {
+		return x.OmittedAllocBytes
+	}
+	return 0
+}
+
+func (x *HeapSnapshot) GetOmittedLiveBytes() uint64 {
+	if x != nil {
+		return x.OmittedLiveBytes
 	}
 	return 0
 }
@@ -3196,7 +3248,7 @@ const file_event_proto_rawDesc = "" +
 	"\x06offset\x18\v \x01(\x04R\x06offset\x12\x19\n" +
 	"\bstack_id\x18\f \x01(\x04R\astackId\x12\x1f\n" +
 	"\valloc_bytes\x18\r \x01(\x04R\n" +
-	"allocBytes\"\xca\x02\n" +
+	"allocBytes\"\x82\x04\n" +
 	"\fHeapSnapshot\x12&\n" +
 	"\x0flive_heap_bytes\x18\x01 \x01(\x04R\rliveHeapBytes\x12\x1d\n" +
 	"\n" +
@@ -3206,7 +3258,12 @@ const file_event_proto_rawDesc = "" +
 	"\x10alloc_bytes_rate\x18\x05 \x01(\x01R\x0eallocBytesRate\x12\x12\n" +
 	"\x04lane\x18\x06 \x01(\tR\x04lane\x12#\n" +
 	"\rlive_measured\x18\a \x01(\bR\fliveMeasured\x12!\n" +
-	"\fsample_bytes\x18\b \x01(\x04R\vsampleBytes\"\xbe\x01\n" +
+	"\fsample_bytes\x18\b \x01(\x04R\vsampleBytes\x12(\n" +
+	"\x10total_call_sites\x18\t \x01(\rR\x0etotalCallSites\x12.\n" +
+	"\x13omitted_alloc_count\x18\n" +
+	" \x01(\x04R\x11omittedAllocCount\x12.\n" +
+	"\x13omitted_alloc_bytes\x18\v \x01(\x04R\x11omittedAllocBytes\x12,\n" +
+	"\x12omitted_live_bytes\x18\f \x01(\x04R\x10omittedLiveBytes\"\xbe\x01\n" +
 	"\n" +
 	"ThreadInfo\x12\x10\n" +
 	"\x03tid\x18\x01 \x01(\x05R\x03tid\x12\x12\n" +

--- a/proto/event.proto
+++ b/proto/event.proto
@@ -259,6 +259,30 @@ message HeapSnapshot {
   // walk per allocation costs a large multiple of the TARGET's own CPU time,
   // which ptop's CPU axis then reported as the target's (#108).
   uint64 sample_bytes = 8;
+  // How many distinct application call sites this snapshot aggregated, before
+  // top_call_sites was cut to the largest few. Equal to len(top_call_sites)
+  // when nothing was dropped — which is the only state in which the list is a
+  // census, and therefore the only one in which a site's ABSENCE from it means
+  // the site allocated nothing.
+  //
+  // Counted after stacks reaching one call site are folded together, so it is
+  // in the same unit as the list: the kernel keys its aggregate by stack id,
+  // and a function reached through several stacks used to hold several of the
+  // slots (#109).
+  uint32 total_call_sites = 9;
+  // The volume carried by the call sites that did not fit in top_call_sites.
+  // Zero when total_call_sites == len(top_call_sites).
+  //
+  // These exist so absence can be read instead of guessed. A consumer diffing
+  // two deploys watches a site drop out of the list and cannot tell "it stopped
+  // allocating" from "it stopped being reported" — opposite situations, and
+  // reading the first where the second holds reports the largest regression
+  // such an engine can express over no evidence at all
+  // (sunnysystems/witness#69). A site absent from the list did strictly less
+  // than these totals, which is the bound that makes the inference safe.
+  uint64 omitted_alloc_count = 10;
+  uint64 omitted_alloc_bytes = 11;
+  uint64 omitted_live_bytes = 12;
 }
 
 // ─── Threads ────────────────────────────────────────────────────────────────


### PR DESCRIPTION
Fecha o #109.

## O corte era por stack id, não por call site

A issue descartou o teto porque "a união deu 6 e 2, com folga nos dois lados".
Esse raciocínio conta **funções**; o coletor não cortava por função.

O agregado do BPF é `goalloc_callsite: HASH stack_id → stat`, e o `snapshotGo`
emitia **uma entrada por stack id** antes do `chooseTopCallSites` cortar em 8.
Um call site é alcançado por tantos stacks quantos forem os caminhos até o
alocador abaixo dele — um mapa que cresce produz um por caminho de crescimento.
No v1.1.0 do cenário (cache que parou de despejar), `storeThumb` ocupava vários
dos 8 slots sozinho e `fmt.Sprintf` — 6017 alocações por janela, um stack só —
caía fora.

A impressão digital está nos dados da própria issue: `sync.(*Pool).pinSlow` com
**8** alocações entrou na lista e `fmt.Sprintf` com **6017** não. Impossível num
ranking por contagem; natural num por bytes, que é o efetivo na lane Go
(`LiveBytes` é sempre 0 lá).

**`foldCallSites`** funde os stacks que chegam ao mesmo call site **antes** do
ranking, nas duas lanes:

- as medições somam;
- a média de tempo de vida é **recomputada da soma agrupada** — uma média não se
  funde, e média-de-médias daria 55ms onde a real é 19ms (teste pinando isso);
- `StackID` guarda o stack que mais contribuiu, então resolvê-lo ainda dá frames
  que de fato passaram por ali — representativo, não exaustivo;
- stacks sem símbolo (`CallSite 0`) fundem num balde só: são uma quantidade não
  atribuída, não N sítios distintos que roubam slots de sítios que resolveram.

## A lista agora diz o quanto está completa

`HeapSnapshot` ganha quatro campos:

| campo | significado |
|---|---|
| `total_call_sites` | call sites distintos agregados, antes do corte |
| `omitted_alloc_count` / `omitted_alloc_bytes` / `omitted_live_bytes` | o volume que não coube |

Isso existe para que a **ausência possa ser lida** em vez de adivinhada. Com uma
lista truncada, um consumidor que difa dois deploys vê um site sair e não tem
como distinguir *"parou de alocar"* de *"parou de ser reportado"* — são situações
opostas, e ler a primeira onde vale a segunda reporta a maior regressão que um
motor desses sabe expressar, sobre evidência nenhuma (sunnysystems/witness#69).

Com os campos: `total_call_sites == len(top_call_sites)` significa que a lista é
um **censo**, e ali ausência realmente é zero. Caso contrário, um site ausente
fez estritamente menos que os totais omitidos — o limite que torna a inferência
segura em vez de suposta.

Contado **depois** da fusão, na mesma unidade da lista que o consumidor recebe —
senão o número responderia a uma pergunta diferente da que foi feita.

## Compatibilidade

Aditivo no schema: uma captura antiga desserializa com os campos em zero.
`total_call_sites == 0` é "não informado", não "nenhum site" — um consumidor não
deve ler zero como censo.

## Verificação

`make proto` (buf format/lint/generate), `go build`, `go test ./...`, `go vet` —
verdes. Testes novos em `heap_agg_test.go` (fusão, stack dominante, média
agrupada, balde de não resolvidos, contabilidade do que foi cortado) e em
`mapper_test.go` (os campos chegam ao wire).

Não pude rodar contra um alvo real (precisa de CAP_BPF); a verificação de terra
é o harness e2e do Witness, que é onde o defeito apareceu.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PVPZc5VCX9dM4FWJuTcrxn