### PR TITLE
Say which collectors the capabilities actually run, and grant all five (#117)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -27,7 +27,10 @@ sudo ./bin/ptop --pid <PID>
 - Distro: <!-- e.g. Ubuntu 24.04, Debian 12, Fedora 40 -->
 - Architecture: <!-- amd64 / arm64 -->
 - Build mode: <!-- eBPF / --no-ebpf -->
-- Privileges: <!-- root / setcap CAP_BPF+CAP_PERFMON / unprivileged -->
+- Privileges: <!-- root / setcap / unprivileged -->
+- Capabilities: <!-- output of `ptop --caps` — it names which collectors your
+     privileges will actually run, which is usually the answer for "an axis is
+     all zeros" -->
 
 ## Output
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,9 +89,11 @@ ptop/
 │   │   ├── cpulist.go             /sys CPU-list parser (build-tag-free, #108)
 │   │   ├── goalloc.go             runtime.mallocgc uprobe loader + sampling rate
 │   │   ├── goalloc_spec.go        GoAllocDefaultSampleBytes (build-tag-free)
-│   │   ├── caps.go                CAP_BPF / CAP_PERFMON detection
+│   │   ├── caps.go                capability + measured-read detection (#117)
+│   │   ├── capgates.go            which cap gates which collector; --caps report
+│   │   ├── uprobe_caps.go         uprobe attach errors that name the capability
 │   │   ├── caps_stub.go           non-Linux stub
-│   │   ├── caps_test.go
+│   │   ├── caps_test.go, capgates_test.go
 │   │   ├── cpu.go                 on-CPU time tracer (sched_switch)
 │   │   ├── syscalls.go            raw_syscalls tracepoint loader
 │   │   ├── network.go             sock tracepoints + connection seeding
@@ -525,6 +527,7 @@ ptop --pid <PID> --tls-bytes 256   also capture ≤256 plaintext bytes/call (imp
 ptop --pid <PID> --heap-sample-bytes 0   record EVERY Go allocation (exact per site, very expensive)
 ptop --pid <PID> --disable heap   drop the one probe that costs the target real time
 ptop --pid <PID> --pprof localhost:6060   dev: serve net/http/pprof to profile ptop itself
+ptop --caps                 which capabilities this binary holds, and which collectors they run
 ptop --version              print version + commit + build date
 ```
 
@@ -668,9 +671,10 @@ Version metadata is injected via `-ldflags` at release time
 
 ## Security notes
 
-- eBPF requires `CAP_BPF + CAP_PERFMON` (or root). `bpf.GetCapStatus()` /
-  `Diagnose()` produce a structured error before the TUI starts — never
-  silently fall through to a non-functional state.
+- eBPF requires `CAP_BPF + CAP_PERFMON` (or root) to load *anything*, and three
+  more capabilities to load *everything* — see "Five capabilities, not two"
+  below. `bpf.GetCapStatus()` / `Diagnose()` produce a structured error before
+  the TUI starts — never silently fall through to a non-functional state.
 - In `--no-ebpf` mode, all collectors fall back to `/proc` — useful when
   granting caps isn't acceptable.
 - Never `panic` in production paths — collectors log to stderr and continue.
@@ -705,5 +709,100 @@ Version metadata is injected via `-ldflags` at release time
   rides the same `--serve`/`--export` surface, so the socket/file restrictions
   above are what keep it private. Resolve by symbol (version-drift safe); a Go or
   static target has no libssl, so capture is simply unavailable there.
+
+### Five capabilities, not two
+
+`setcap cap_bpf,cap_perfmon+ep` — what this repo taught for two years — loads
+the eBPF lane and then runs about three quarters of the probe set. The missing
+quarter is not a rounding error and it does not announce itself: the capture is
+well-formed, the dropped axes publish as zeros, and zero is a measurement — it
+says the process did not allocate (#117). `internal/bpf/capgates.go` is the
+whole story; the short version is that three different mechanisms decide it,
+and only the first looks like a capability question:
+
+- **A uprobe** is created through the dynamic `perf_uprobe` PMU in
+  `perf_event_open(2)`, whose gate is `CAP_SYS_ADMIN`. **`CAP_PERFMON` does not
+  satisfy it.** Both heap lanes and the TLS lane attach that way, so without it
+  they do not — and `heap` is the only axis carrying `func` and `file:line`.
+- **A kprobe-type program** is loaded with the running kernel's version stamped
+  into it, and cilium/ebpf reads that version out of the vDSO through
+  `/proc/self/mem` (`internal/vdso.go` upstream). The collectors affected fail
+  to **load**, before any attach is attempted — and that is `memory` and
+  `network` for their `SEC("kprobe/…")`, *plus* `heap` and `tls`, because
+  `SEC("uprobe/…")` also loads as `BPF_PROG_TYPE_KPROBE`. Hence granting
+  `CAP_SYS_ADMIN` alone recovers nothing: heap dies at load, never reaching the
+  PMU it was missing.
+- **A tracepoint** resolves its numeric event id from
+  `<tracefs>/events/<group>/<name>/id`, so an unreadable tracefs takes out every
+  tracepoint collector at once.
+- **Any pid-mode collector** stats `/proc/<pid>/ns/pid` to resolve the target's
+  namespace (`resolvePIDTarget`, `target.go`), which is a ptrace-mode read. For
+  a target owned by another user that needs `CAP_SYS_PTRACE`, and it takes out
+  *everything*, not just the two lanes that read the target's maps.
+
+And the part that catches people: **the `setcap` is itself what breaks the last
+two.** The kernel sets `secureexec` — and with `fs.suid_dumpable=2`, marks the
+process non-dumpable — whenever an `exec` gains credentials the parent did not
+have. `task_dump_owner()` then hands that process's own `/proc/self/*` to root,
+so ptop as uid 1000 can no longer read its own `/proc/self/mem` (mode 0600).
+Add tracefs being `0700 root:root` and the mechanism recommended for *not*
+needing root is the one that needs `CAP_DAC_READ_SEARCH` to undo itself.
+
+Note the "whenever an exec gains credentials" precisely, because it is what
+makes this reproduce or not: exec'd from an ordinary shell, ptop goes
+non-dumpable and loses the read; exec'd from a parent that already holds the
+same capabilities (`setpriv` without `--clear-caps`, a privileged launcher), it
+gains nothing, stays dumpable, and the identical binary with the identical file
+capabilities reads its own memory fine. `CapStatus.NonDumpable` reads
+`PR_GET_DUMPABLE` rather than inferring from `FileCaps` for exactly that
+reason, and `--caps` reports which of the two you are in.
+
+Three rules follow, for anything added here:
+
+- **Measure the read, don't infer it from cap bits.** `GetCapStatus` opens
+  `/proc/self/mem` and stats tracefs rather than reasoning from `CapEff`,
+  because AppArmor, mount options and file modes all get a vote and only the
+  open consults all three. (Both were ruled out by measurement in the report:
+  AppArmor logged no denial, and `perf_event_paranoid=2` gave the same error.)
+- **An attach error must name the probable capability**, not just the target
+  path. `uprobeAttachError` (`uprobe_caps.go`) is that for the uprobe lanes; a
+  bare "operation not permitted" against a libc path reads as a problem with the
+  *target*, which is the wrong place to look. The hint rides `ProbeStatus.Detail`
+  onto the wire, so a downstream consumer gets it too.
+- **A new attach mechanism needs a row in `ebpfCollectors`.** It is what decides
+  which capability gates a collector, and `TestEBPFCollectorsMatchPrograms` reads
+  the `.bpf.c` sources back to check the table — adding a `SEC("kprobe/…")` to an
+  existing program silently moves that collector under `CAP_DAC_READ_SEARCH`,
+  and nothing else would notice.
+
+`ptop --caps` prints the resulting inventory: capabilities held, the reads as
+measured now, and the per-collector verdict — with no pid and nothing attached,
+so it answers on a host being provisioned. A run that starts with a partial set
+also says so on stderr (`StartupAdvisory`), skipping whatever `--disable` or a
+missing `--tls` already switched off, because a warning about something nobody
+asked for is a warning nobody reads by the time it matters.
+
+All four mechanisms were verified against a live 7.0.0 kernel (privileged
+container, `setcap` at each of the three grants, running as uid 1000):
+`cap_bpf,cap_perfmon` alone gives `memory`, `network`, `heap` and `tls`
+`detecting kernel version: opening mem: open /proc/self/mem: permission denied`
+and every tracepoint collector
+`reading trace event ID …: permission denied`; adding `cap_sys_admin` on top of
+that changes **nothing**; `cap_bpf,cap_perfmon,cap_sys_admin,cap_dac_read_search`
+runs all twelve; and against a
+root-owned target with everything but `cap_sys_ptrace`, nine of twelve fail
+(`stat pid namespace of <pid>` for eight, `open /proc/<pid>/exe` for `heap`;
+only `signals` and `lifecycle` survive, filtering on a global pid of their own)
+while the same grant against a uid-matched target attaches all twelve. Two traps when reproducing this. A `setcap`
+binary on a `nosuid` mount (systemd mounts `/tmp` that way, and so a Docker
+bind of it) has its file capabilities **silently ignored** — `getcap` still
+shows them. And exec'ing it from a still-privileged parent leaves it dumpable,
+which hides the `/proc/self/mem` half entirely; put a plain binary in between
+(`setpriv … timeout 5 ./ptop`) to get the real thing.
+
+`CAP_SYS_ADMIN` is close to root, and in a container with `pid: host` it is
+root. That is a real trade and the docs state it as one — the point is that
+someone reading only this repo could not previously reach the working
+configuration, or know it was needed.
 
 See [`SECURITY.md`](SECURITY.md) for vulnerability reporting.

--- a/README.md
+++ b/README.md
@@ -66,7 +66,8 @@ replace this section soon.
 
 - Linux, kernel **5.8+** (BTF + ring buffer + `CAP_BPF`)
 - `amd64` or `arm64`
-- For full mode: root, or the binary with `cap_bpf,cap_perfmon+ep`
+- For full mode: root, or the binary with all five capabilities below —
+  `cap_bpf,cap_perfmon,cap_sys_admin,cap_dac_read_search,cap_sys_ptrace+ep`
 - For building from source: Go **1.25+**, `clang`, `libbpf-dev`, `bpftool`
 
 ## Platform support
@@ -145,6 +146,9 @@ sudo ./bin/ptop --pid <PID> --tls-bytes 256 --serve unix:///run/ptop.sock --expo
 # Heap probe: drop it entirely, or make it exact instead of sampled (see below)
 sudo ./bin/ptop --pid <PID> --disable heap
 sudo ./bin/ptop --pid <PID> --heap-sample-bytes 0
+
+# Which collectors will run with the privileges you actually have (no PID needed)
+./bin/ptop --caps
 ```
 
 > **TLS payload capture** (`--tls` / `--tls-bytes N`): uprobes the target's
@@ -172,8 +176,71 @@ sudo ./bin/ptop --pid <PID> --heap-sample-bytes 0
 The recommended setup is to grant capabilities once and run unprivileged:
 
 ```bash
-sudo setcap cap_bpf,cap_perfmon+ep ./bin/ptop
+sudo setcap cap_bpf,cap_perfmon,cap_sys_admin,cap_dac_read_search,cap_sys_ptrace+ep ./bin/ptop
 ./bin/ptop --pid <PID>
+```
+
+`cap_bpf,cap_perfmon` — what this README taught until v1.4 — is **not** the
+full set. It loads, and then silently runs about three quarters of the probe
+set (#117). The remainder does not announce itself: the capture comes out
+well-formed and the dropped axes publish as zeros, and zero is a measurement —
+it asserts the process did not allocate. `ptop --caps` prints exactly which
+collectors the privileges you have will run, before you take the capture:
+
+```
+$ ./bin/ptop --caps
+...
+collectors, with the privileges this process holds
+  ✓ cpu          will run
+  ✗ heap         WILL NOT COLLECT — CAP_SYS_ADMIN (uprobe PMU in perf_event_open)
+  ~ memory       eBPF lane blocked, /proc lane still reports — /proc/self/mem unreadable …
+```
+
+What each capability buys, and what its absence costs:
+
+| Capability | Without it | Why |
+|---|---|---|
+| `cap_bpf` | nothing loads | creates maps and loads programs (`bpf(2)`) |
+| `cap_perfmon` | nothing attaches | opens the perf events tracepoints and kprobes hang off |
+| `cap_sys_admin` | **no `heap`** (and no `--tls`) | the dynamic `perf_uprobe` PMU in `perf_event_open(2)` is gated on it, and **`CAP_PERFMON` does not satisfy that gate**. Both heap lanes attach by uprobe, and heap is the only axis carrying `func` and `file:line` |
+| `cap_dac_read_search` | **most of the set**: every tracepoint collector, plus `memory`, `network`, `heap` and `--tls` | see below — the `setcap` above is itself the cause. Two reads it restores: `<tracefs>/events/…/id`, which every tracepoint attach needs, and `/proc/self/mem`, which every `kprobe`- *and* `uprobe`-type program's load needs |
+| `cap_sys_ptrace` | **nothing at all**, for a target owned by another user | pid-mode targeting stats `/proc/<pid>/ns/pid` to resolve the target's pid namespace, so *every* eBPF collector fails its filter — not just the uprobe and symbolization paths that read `/proc/<pid>/{exe,maps,map_files,root}`. All ptrace-mode reads |
+
+**The trap in `cap_dac_read_search`.** The kernel marks a process
+non-dumpable at `exec` whenever the new credentials are not a subset of the old
+— which is exactly what happens when your shell execs a `setcap`'d binary — and
+a non-dumpable process's own `/proc/self/*` is reassigned to `root`. ptop, running as uid 1000, then cannot
+read its own `/proc/self/mem` — which is precisely where cilium/ebpf reads the
+running kernel's version out of the vDSO, and every `kprobe`-type program is
+loaded with that version stamped in. ptop's two collectors whose object files
+contain a `SEC("kprobe/…")` — `memory` and `network` — therefore fail to *load*,
+before any attach is attempted. So do `heap` and `--tls`: a `SEC("uprobe/…")`
+program loads as `BPF_PROG_TYPE_KPROBE` and takes the same version read, which
+is why **granting `cap_sys_admin` without `cap_dac_read_search` recovers
+nothing** — heap never reaches the PMU it was missing. `/sys/kernel/tracing`,
+where every tracepoint attach reads its numeric event id, is `0700 root:root`
+besides. **The mechanism recommended so you do not need root is the one that
+needs `CAP_DAC_READ_SEARCH` to undo itself.**
+
+Measured on Linux 7.0.0, everything else granted: against a **root-owned**
+target, nine of the twelve collectors fail —
+`stat pid namespace of <pid>: permission denied` for eight of them and
+`open /proc/<pid>/exe` for `heap`. Only `signals` and `lifecycle` survive, and
+only because they filter on a global pid of their own. Adding `cap_sys_ptrace`
+recovers all nine. Against a target that is **yours**, the same four caps
+without `cap_sys_ptrace` attach everything — so omitting it costs nothing if
+ptop only ever watches your own processes.
+
+**`cap_sys_admin` is close to root**, and in a container sharing the host pid
+namespace it *is* root. Grant it deliberately, and say so to whoever owns the
+host. Running without it is a legitimate choice — `--caps` is then the record
+of what you gave up, and `--disable heap` makes the omission explicit rather
+than incidental.
+
+Running as root grants all five and is the simplest thing that works:
+
+```bash
+sudo ./bin/ptop --pid <PID>
 ```
 
 If something is wrong (kernel too old, `unprivileged_bpf_disabled=1`, missing
@@ -185,6 +252,15 @@ error: eBPF not available
 
 Kernel 5.4 detected — ptop requires Linux 5.8+ (BTF + CAP_BPF).
 On older kernels, use --no-ebpf (/proc-only mode).
+```
+
+And if it starts with a *partial* set, it says so on stderr before collecting
+rather than leaving it to be inferred from the data:
+
+```
+[ptop] ⚠ capability gap: heap, memory, network will not collect.
+       Missing: CAP_SYS_ADMIN, CAP_DAC_READ_SEARCH
+       Their axes publish as zeros, which is not the same as the target not doing it.
 ```
 
 ## Collector sources

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,9 +2,11 @@
 
 ## Threat model
 
-ptop runs as root (or with `CAP_BPF + CAP_PERFMON`) and loads eBPF programs
-into the kernel. Bugs in this code path can affect the host kernel directly
-— we treat security reports accordingly.
+ptop runs as root (or with the capability set in [`README.md`](README.md#permissions)
+— `cap_bpf`, `cap_perfmon`, `cap_sys_admin`, `cap_dac_read_search`,
+`cap_sys_ptrace`) and loads eBPF programs into the kernel. Bugs in this code
+path can affect the host kernel directly — we treat security reports
+accordingly.
 
 ## Reporting a vulnerability
 
@@ -47,7 +49,14 @@ Out of scope:
 
 ## Hardening recommendations for operators
 
-- Prefer `setcap cap_bpf,cap_perfmon+ep ./bin/ptop` over running as root.
+- Prefer a file capability over running as root — but know what you are
+  granting. `CAP_SYS_ADMIN` is the gate on the uprobe PMU ptop's heap and TLS
+  lanes need, and it is close to root in practice; in a container sharing the
+  host pid namespace it *is* root. `cap_bpf,cap_perfmon+ep` alone is a real
+  hardening choice, and it costs the `heap`, `memory` and `network` collectors
+  (#117) — run `ptop --caps` to see exactly which collectors a given grant
+  will run, and pick the trade knowingly rather than discovering it in the
+  shape of a capture.
 - Don't run ptop binaries from untrusted sources. Verify release archives
   with the published `SHA256SUMS`.
 - The release binaries are built with `CGO_ENABLED=0` and no dynamic linking

--- a/bench/README.md
+++ b/bench/README.md
@@ -17,8 +17,10 @@ produces is a table across allocation rates rather than a number.
 
 ## Running it
 
-eBPF needs privileges. Either run as root on a host with `CAP_BPF`, or use a
-privileged container, which is what the `bench` target does:
+eBPF needs privileges. Either run as root, or use a privileged container, which
+is what the `bench` target does. Root, specifically — this benchmark is about
+the heap uprobe, and a `setcap`'d binary needs `cap_sys_admin` before that
+probe attaches at all (`ptop --caps` says so; see README → Permissions):
 
 ```
 make bench

--- a/cmd/ptop/main.go
+++ b/cmd/ptop/main.go
@@ -47,6 +47,7 @@ func main() {
 	disableSpec := flag.String("disable", "", "Comma-separated subsystems NOT to collect, e.g. --disable heap. Known: "+collector.KnownSubsystems())
 	heapSample := flag.Uint64("heap-sample-bytes", bpf.GoAllocDefaultSampleBytes, "Go allocation lane: bytes allocated between recorded call-site samples. 0 records every allocation — exact per site, and a large multiple of the target's own CPU time")
 	pprofAddr := flag.String("pprof", "", "Dev: serve net/http/pprof on this addr (e.g. localhost:6060) for profiling ptop itself")
+	showCaps := flag.Bool("caps", false, "Print which capabilities this ptop holds, which collectors will therefore run, and exit")
 	showVer := flag.Bool("version", false, "Print version and exit")
 	flag.Parse()
 
@@ -61,6 +62,15 @@ func main() {
 
 	if *showVer {
 		fmt.Printf("ptop %s (commit %s, built %s)\n", version, commit, buildDate)
+		os.Exit(0)
+	}
+
+	// --caps answers, before a target is even chosen, the question the probe
+	// set used to answer only by what was missing from the output (#117):
+	// which collectors these privileges can actually run. It needs no pid and
+	// attaches nothing, so it works on a host being provisioned.
+	if *showCaps {
+		fmt.Print(bpf.GetCapStatus().CapReport())
 		os.Exit(0)
 	}
 
@@ -81,6 +91,7 @@ func main() {
 		fmt.Fprintln(os.Stderr, "       ptop --pid <PID> --serve tcp://<ip>:50051 --serve-tls-cert <crt> --serve-tls-key <key>")
 		fmt.Fprintln(os.Stderr, "       ptop --cgroup <path|container-id> --serve tcp://127.0.0.1:50051")
 		fmt.Fprintln(os.Stderr, "       ptop --serve unix:///run/ptop.sock          (no --pid: subscribers pick the target)")
+		fmt.Fprintln(os.Stderr, "       ptop --caps                                 (which collectors these privileges run)")
 		fmt.Fprintln(os.Stderr, "       ptop --version")
 		os.Exit(1)
 	}
@@ -108,6 +119,9 @@ func main() {
 		}()
 	}
 
+	// caps stays zero unless the eBPF lane is actually in play; the advisory
+	// below reads it and prints nothing for a zero value.
+	var caps bpf.CapStatus
 	if !*noEBPF {
 		// Build vs runtime diagnostic:
 		//   - Available = false → binary was built WITHOUT `-tags=ebpf`.
@@ -127,7 +141,7 @@ func main() {
 			}
 			fmt.Fprintln(os.Stderr, "")
 		} else {
-			caps := bpf.GetCapStatus()
+			caps = bpf.GetCapStatus()
 			if diag := caps.Diagnose(); diag != "" {
 				fmt.Fprintln(os.Stderr, "error: eBPF not available")
 				fmt.Fprintln(os.Stderr, "")
@@ -159,6 +173,23 @@ func main() {
 	if tlsEnabled && tlsCap > 0 {
 		fmt.Fprintf(os.Stderr, "[ptop] ⚠ TLS plaintext capture ON (--tls-bytes %d): events carry decrypted\n", tlsCap)
 		fmt.Fprintln(os.Stderr, "       payload bytes (credentials/PII). Keep the stream/export private.")
+	}
+
+	// Loading is not the same as loading everything (#117). CAP_BPF +
+	// CAP_PERFMON get past Diagnose and still leave collectors out, and a
+	// collector that never attached is indistinguishable downstream from a
+	// target that never did the thing — so it is said here, before the run,
+	// rather than left to be inferred from an axis of zeros. Subsystems the
+	// operator already switched off are not a gap and are not mentioned.
+	notAsked := map[string]bool{}
+	for name := range disable {
+		notAsked[name] = true
+	}
+	if !tlsEnabled {
+		notAsked[collector.SubsystemTLS] = true
+	}
+	if adv := caps.StartupAdvisory(notAsked); adv != "" {
+		fmt.Fprint(os.Stderr, adv)
 	}
 
 	// Transport security of the event stream (#95) — distinct from --tls, which
@@ -354,6 +385,17 @@ func checkPIDExists(pid int) error {
 		// Collectors will degrade (macOS libproc needs same-euid), so warn
 		// rather than fail: partial data for a real process is still useful.
 		fmt.Fprintf(os.Stderr, "[ptop] warning: process %d is owned by another user — data may be limited or unavailable\n", pid)
+		// "Limited" understates it on Linux without CAP_SYS_PTRACE: pid-mode
+		// targeting stats /proc/<pid>/ns/pid, which is a ptrace-mode read, so
+		// EVERY eBPF collector fails to resolve its filter — not just the ones
+		// that read the target's maps (#117). Measured on 7.0.0 with every other
+		// capability granted: nine of twelve down against a root-owned target,
+		// all twelve up against a uid-matched one.
+		if caps := bpf.GetCapStatus(); bpf.Available && !caps.IsRoot && !caps.HasSysPtrace {
+			fmt.Fprintln(os.Stderr, "       Without CAP_SYS_PTRACE that means every eBPF collector, not some of them:")
+			fmt.Fprintln(os.Stderr, "       pid-mode targeting stats /proc/<pid>/ns/pid, which is a ptrace-mode read.")
+			fmt.Fprintln(os.Stderr, "       Run `ptop --caps`, or add cap_sys_ptrace to the grant.")
+		}
 		return nil
 	default:
 		return fmt.Errorf("cannot check process %d: %w", pid, err)

--- a/internal/bpf/capgates.go
+++ b/internal/bpf/capgates.go
@@ -1,0 +1,500 @@
+package bpf
+
+import (
+	"fmt"
+	"runtime"
+	"sort"
+	"strings"
+)
+
+// Which capabilities ptop actually needs, and what each one buys.
+//
+// `setcap cap_bpf,cap_perfmon+ep` — the line this README taught for two years —
+// loads most of the probe set and silently drops the rest (#117). It is not a
+// small remainder: it is the heap axis, the only one carrying func and
+// file:line, plus the two collectors whose programs contain a kprobe. Worse,
+// the failure is invisible downstream. A capture taken that way is
+// well-formed; the dead axes publish as zeros, and zero is a measurement — it
+// asserts the process did not allocate.
+//
+// Three mechanisms decide it, and only the first is about a capability in the
+// obvious way:
+//
+//   - A UPROBE is created through the dynamic perf_uprobe PMU in
+//     perf_event_open(2), whose gate is CAP_SYS_ADMIN. CAP_PERFMON does not
+//     satisfy it. Both heap lanes (libc malloc, Go runtime.mallocgc) and the
+//     TLS lane attach that way, so without it they do not.
+//
+//   - A KPROBE program is loaded with the running kernel's version stamped
+//     into it, and cilium/ebpf reads that version out of the vDSO image
+//     through /proc/self/mem (internal/vdso.go). ptop's two collectors whose
+//     object files contain a SEC("kprobe/...") — memory and network — fail to
+//     LOAD when that read fails, before any attach is attempted.
+//
+//   - A TRACEPOINT attach resolves its numeric event id by reading
+//     <tracefs>/events/<group>/<name>/id, so an unreadable tracefs takes out
+//     every tracepoint collector at once.
+//
+// And here is the part that catches people: the setcap the README recommended
+// is itself what breaks the last two. A binary that gains privilege from a
+// file capability becomes non-dumpable, and a non-dumpable process's own
+// /proc/self/* is reassigned to root — so ptop, running as uid 1000, can no
+// longer read its own /proc/self/mem. Add tracefs being 0700 root:root on most
+// distributions and the mechanism recommended for NOT needing root is the one
+// that needs CAP_DAC_READ_SEARCH to undo itself.
+//
+// So the gates are measured, not assumed: ProbeTracefs and the /proc/self/mem
+// open in GetCapStatus ask the kernel rather than reasoning from cap bits,
+// because AppArmor, mount options and file modes all get a vote and only the
+// open consults all of them.
+
+// RecommendedSetcap is the setcap invocation granting ptop's whole probe set.
+// It is one string so the README, Diagnose and CapReport cannot drift apart.
+const RecommendedSetcap = "setcap cap_bpf,cap_perfmon,cap_sys_admin,cap_dac_read_search,cap_sys_ptrace+ep"
+
+// CanLoadBPF is true if the process has enough privileges to load eBPF
+// programs (root OR CAP_BPF + CAP_PERFMON). Doesn't consider kernel
+// version — only capabilities.
+//
+// It lives here, outside the build tags, because it is arithmetic on the
+// struct and nothing else: the same fields have to yield the same answer
+// wherever the tests run.
+func (s CapStatus) CanLoadBPF() bool {
+	return s.IsRoot || (s.HasBPF && s.HasPerfmon)
+}
+
+// KernelSupportsBPF is true if kernel >= 5.8 (BTF + ring buffer + CAP_BPF).
+// Earlier versions partially work but ptop assumes 5.8+.
+func (s CapStatus) KernelSupportsBPF() bool {
+	if s.KernelMajor == 0 {
+		return true // unknown; let the load fail with a more specific error
+	}
+	if s.KernelMajor > 5 {
+		return true
+	}
+	return s.KernelMajor == 5 && s.KernelMinor >= 8
+}
+
+// CapGate is one capability, whether this process holds it, and what stops
+// working without it.
+type CapGate struct {
+	// Cap is the kernel's name ("CAP_SYS_ADMIN"); Token is the setcap
+	// spelling ("cap_sys_admin"), so a report names the fix as well as the gap.
+	Cap   string
+	Token string
+	Held  bool
+	// Fatal marks a capability without which nothing attaches at all. Those
+	// are Diagnose's business — it refuses to start rather than reporting a
+	// probe set that would be empty.
+	Fatal bool
+	// Subsystems are the collectors that stop working without this capability,
+	// spelled the way --disable spells them so a report names the flag that
+	// would change it. Empty for a Fatal gate: it gates all of them.
+	//
+	// They are literals here rather than references to pkg/collector, which
+	// imports this package and cannot be imported back. TestCapGateSubsystems
+	// there asserts every name spelled here is one collector knows.
+	Subsystems []string
+	// Why is the mechanism, in one sentence — never just "permission denied".
+	Why string
+	// Conditional is when the gate actually bites, for a capability that is
+	// not always needed ("" = always). Outlook cannot fold these in: it is
+	// asked before a target exists, and the condition is a fact about the
+	// target, not about ptop.
+	Conditional string
+}
+
+// allEBPFSubsystems is every collector with an eBPF lane. A capability that
+// gates the pid filter gates all of them, and listing them by hand would rot.
+func allEBPFSubsystems() []string {
+	out := make([]string, 0, len(ebpfCollectors))
+	for _, c := range ebpfCollectors {
+		out = append(out, c.name)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// Gates reports every capability ptop's probe set depends on, in the order a
+// reader should think about them: the fatal ones first, then the ones that
+// decide how much of the set runs.
+func (s CapStatus) Gates() []CapGate {
+	root := s.IsRoot
+	return []CapGate{
+		{
+			Cap: "CAP_BPF", Token: "cap_bpf", Held: root || s.HasBPF, Fatal: true,
+			Why: "loads BPF programs and creates maps (bpf(2)); without it no probe of any kind attaches",
+		},
+		{
+			Cap: "CAP_PERFMON", Token: "cap_perfmon", Held: root || s.HasPerfmon, Fatal: true,
+			Why: "opens the perf events tracepoints and kprobes attach to, and permits the in-kernel reads the programs do",
+		},
+		{
+			Cap: "CAP_SYS_ADMIN", Token: "cap_sys_admin", Held: root || s.HasSysAdmin,
+			Subsystems: []string{"heap", "tls"},
+			Why:        "creating the dynamic perf_uprobe PMU in perf_event_open(2) is gated on CAP_SYS_ADMIN, which CAP_PERFMON does not satisfy; heap is the only axis carrying func and file:line",
+		},
+		{
+			Cap: "CAP_DAC_READ_SEARCH", Token: "cap_dac_read_search", Held: root || s.HasDACReadSearch,
+			Subsystems: allEBPFSubsystems(),
+			Why:        "a setcap'd ptop is non-dumpable, so its own /proc/self/mem is root-owned — and that is where cilium/ebpf reads the kernel version stamped into every kprobe- AND uprobe-type program; tracefs, where every tracepoint reads its event id, is 0700 root:root besides. Between the two it reaches every collector",
+		},
+		{
+			Cap: "CAP_SYS_PTRACE", Token: "cap_sys_ptrace", Held: root || s.HasSysPtrace,
+			Subsystems:  allEBPFSubsystems(),
+			Why:         "pid-mode targeting stats /proc/<pid>/ns/pid to resolve the target's pid namespace (bpf.resolvePIDTarget), and the uprobe and symbolization paths read /proc/<pid>/{exe,maps,map_files,root} besides — all ptrace-mode access, so against another user's process the whole set fails, not just heap",
+			Conditional: "when the target process belongs to another user",
+		},
+	}
+}
+
+// attachMechanism is how a collector's programs reach the kernel. It is what
+// decides which capability gates the collector, so it is recorded per
+// collector rather than re-derived from a capability list.
+type attachMechanism uint8
+
+const (
+	attachTracepoint attachMechanism = 1 << iota
+	attachKprobe
+	attachUprobe
+)
+
+// ebpfCollectors is every collector that attaches something, with how it
+// attaches and whether a /proc lane keeps the subsystem publishing when the
+// eBPF one cannot start. Kept in step with internal/bpf/*.go by
+// TestEBPFCollectorsMatchPrograms, which reads the .bpf.c sources back.
+var ebpfCollectors = []struct {
+	name         string
+	how          attachMechanism
+	procFallback bool
+}{
+	{"cpu", attachTracepoint, true},
+	{"threads", attachTracepoint, true},
+	{"memory", attachTracepoint | attachKprobe, true},
+	{"io", attachTracepoint, true},
+	{"network", attachTracepoint | attachKprobe, false},
+	{"syscalls", attachTracepoint, false},
+	{"futex", attachTracepoint, false},
+	{"security", attachTracepoint, false},
+	{"lifecycle", attachTracepoint, false},
+	{"signals", attachTracepoint, false},
+	{"heap", attachUprobe, false},
+	{"tls", attachUprobe, false},
+}
+
+// CollectorOutlook is what one subsystem is expected to do with the privileges
+// this process actually holds — decided BEFORE anything attaches, which is the
+// whole point: after the fact it is indistinguishable from a quiet target.
+type CollectorOutlook struct {
+	// Subsystem, spelled as --disable spells it.
+	Subsystem string
+	// WillRun is whether the eBPF lane is expected to start.
+	WillRun bool
+	// Degraded marks a blocked eBPF lane that still has a /proc reader behind
+	// it: the subsystem keeps publishing, less richly. Meaningless if WillRun.
+	Degraded bool
+	// Blocker is what stops it — a capability name, or the read that failed.
+	// Empty if WillRun.
+	Blocker string
+}
+
+// Outlook predicts, from capabilities alone, which collectors will run. It
+// never attaches anything, so it is safe to call before a target is chosen and
+// it is what --caps prints.
+//
+// It is deliberately a prediction and not a result: Set.Probes() reports what
+// actually happened, but only once a target exists and the tracers have tried.
+// An operator provisioning a host needs the answer before that.
+func (s CapStatus) Outlook() []CollectorOutlook { return outlook(s, Available) }
+
+// outlook takes ebpfEmbedded rather than reading the Available const so the
+// table can be exercised in both shapes from a single build — including on a
+// developer's macOS, where Available is false and every verdict would
+// otherwise be the same one.
+func outlook(s CapStatus, ebpfEmbedded bool) []CollectorOutlook {
+	out := make([]CollectorOutlook, 0, len(ebpfCollectors))
+	for _, c := range ebpfCollectors {
+		o := CollectorOutlook{Subsystem: c.name, WillRun: true}
+		switch {
+		case !ebpfEmbedded:
+			o.WillRun, o.Blocker = false, "this ptop build embeds no eBPF programs (build with -tags=ebpf)"
+		case !s.KernelSupportsBPF():
+			o.WillRun, o.Blocker = false, fmt.Sprintf("kernel %d.%d is below the 5.8 minimum", s.KernelMajor, s.KernelMinor)
+		case !s.CanLoadBPF():
+			o.WillRun, o.Blocker = false, "CAP_BPF + CAP_PERFMON"
+		// Load comes before attach, so the kernel-version read is reported
+		// ahead of the uprobe PMU. SEC("uprobe/…") loads as
+		// BPF_PROG_TYPE_KPROBE, which is why the uprobe lanes are on this
+		// branch at all — granting CAP_SYS_ADMIN without CAP_DAC_READ_SEARCH
+		// recovers nothing.
+		case c.how&(attachKprobe|attachUprobe) != 0 && !s.ProcSelfMemReadable:
+			o.WillRun, o.Blocker = false, "/proc/self/mem unreadable — CAP_DAC_READ_SEARCH (kprobe- and uprobe-type programs are loaded with the kernel version read from it)"
+		case c.how&attachUprobe != 0 && !s.IsRoot && !s.HasSysAdmin:
+			o.WillRun, o.Blocker = false, "CAP_SYS_ADMIN (uprobe PMU in perf_event_open)"
+		case c.how&attachTracepoint != 0 && !s.TracefsReadable:
+			o.WillRun, o.Blocker = false, tracefsBlocker(s)
+		}
+		o.Degraded = !o.WillRun && c.procFallback
+		out = append(out, o)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Subsystem < out[j].Subsystem })
+	return out
+}
+
+// tracefsBlocker distinguishes tracefs not being mounted from ptop not being
+// allowed to read it. They look identical in an attach error and have
+// completely different fixes — mount it, versus grant a capability.
+func tracefsBlocker(s CapStatus) string {
+	if s.TracefsPath == "" {
+		return "tracefs is not mounted (mount -t tracefs none /sys/kernel/tracing) — tracepoint event ids are read from it"
+	}
+	return fmt.Sprintf("%s unreadable — CAP_DAC_READ_SEARCH (it is 0700 root:root; tracepoint event ids are read from it)", s.TracefsPath)
+}
+
+// BlockedCollectors names the subsystems Outlook expects not to run, sorted.
+func (s CapStatus) BlockedCollectors() []string { return blockedCollectors(s, Available) }
+
+func blockedCollectors(s CapStatus, ebpfEmbedded bool) []string {
+	var out []string
+	for _, o := range outlook(s, ebpfEmbedded) {
+		if !o.WillRun {
+			out = append(out, o.Subsystem)
+		}
+	}
+	return out
+}
+
+// StartupAdvisory is the one paragraph worth printing on every run whose probe
+// set is short of what the binary can do. Empty when nothing is blocked, or
+// when nothing could have run anyway (no eBPF embedded, kernel too old, no
+// CAP_BPF) — those already have their own, louder message.
+//
+// It exists because the alternative is finding out from the shape of the data,
+// and the shape of the data does not distinguish a collector that never
+// attached from a target that never did the thing.
+//
+// notAsked names the subsystems the operator has already switched off
+// (--disable, or an opt-in like tls nobody opted into). A capability that
+// blocks something nobody wanted is not news, and a warning that cries about
+// it every run is one nobody reads by the time it matters.
+func (s CapStatus) StartupAdvisory(notAsked map[string]bool) string {
+	return startupAdvisory(s, Available, notAsked)
+}
+
+func startupAdvisory(s CapStatus, ebpfEmbedded bool, notAsked map[string]bool) string {
+	if !ebpfEmbedded || !s.CanLoadBPF() || !s.KernelSupportsBPF() {
+		return ""
+	}
+	var blocked []string
+	for _, name := range blockedCollectors(s, ebpfEmbedded) {
+		if !notAsked[name] {
+			blocked = append(blocked, name)
+		}
+	}
+	if len(blocked) == 0 {
+		return ""
+	}
+	// Only the capabilities that gate something still being asked for.
+	stillBlocked := map[string]bool{}
+	for _, name := range blocked {
+		stillBlocked[name] = true
+	}
+	var missing []string
+	for _, g := range s.Gates() {
+		if g.Fatal || g.Held {
+			continue
+		}
+		for _, name := range g.Subsystems {
+			if stillBlocked[name] {
+				missing = append(missing, g.Cap)
+				break
+			}
+		}
+	}
+	var b strings.Builder
+	fmt.Fprintf(&b, "[ptop] ⚠ capability gap: %s will not collect.\n", strings.Join(blocked, ", "))
+	if len(missing) > 0 {
+		fmt.Fprintf(&b, "       Missing: %s\n", strings.Join(missing, ", "))
+	}
+	fmt.Fprintln(&b, "       Their axes publish as zeros, which is not the same as the target not doing it.")
+	fmt.Fprintln(&b, "       `ptop --caps` explains each one; the full grant is:")
+	fmt.Fprintf(&b, "         sudo %s <binary>\n", RecommendedSetcap)
+	return b.String()
+}
+
+// CapReport is the full inventory --caps prints: what ptop holds, what it
+// measured, and what it therefore expects each collector to do.
+func (s CapStatus) CapReport() string {
+	var b strings.Builder
+	fmt.Fprintln(&b, "ptop capability report")
+	fmt.Fprintln(&b, "")
+
+	fmt.Fprintln(&b, "environment")
+	fmt.Fprintf(&b, "  %-26s %s\n", "os", runtime.GOOS+osVerdict())
+	fmt.Fprintf(&b, "  %-26s %s\n", "privilege", privilegeLabel(s))
+	if s.KernelMajor != 0 {
+		fmt.Fprintf(&b, "  %-26s %d.%d%s\n", "kernel", s.KernelMajor, s.KernelMinor, kernelVerdict(s))
+	}
+	fmt.Fprintf(&b, "  %-26s %s\n", "eBPF in this binary", yesNo(Available, "yes", "no — rebuild with -tags=ebpf"))
+	if s.UnprivBPFDisabled >= 0 {
+		fmt.Fprintf(&b, "  %-26s %d\n", "unprivileged_bpf_disabled", s.UnprivBPFDisabled)
+	}
+	fmt.Fprintln(&b, "")
+
+	fmt.Fprintln(&b, "capabilities")
+	for _, g := range s.Gates() {
+		fmt.Fprintf(&b, "  %s %-21s %s\n", mark(g.Held), g.Cap, gateScope(g))
+		fmt.Fprintf(&b, "      %s\n", g.Why)
+	}
+	fmt.Fprintln(&b, "")
+
+	// The measured reads, separately from the cap bits. They are what actually
+	// decides, and they can fail for reasons no capability explains (tracefs
+	// not mounted, an LSM profile, a container without /sys).
+	fmt.Fprintln(&b, "reads ptop needs, as measured now")
+	fmt.Fprintf(&b, "  %s %-21s %s\n", mark(s.ProcSelfMemReadable), "/proc/self/mem",
+		yesNo(s.ProcSelfMemReadable, "readable", "unreadable — kprobe programs will not load"))
+	tracefs := "not mounted — no tracepoint will attach"
+	if s.TracefsPath != "" {
+		tracefs = yesNo(s.TracefsReadable,
+			s.TracefsPath+" readable",
+			s.TracefsPath+" unreadable — no tracepoint will attach")
+	}
+	fmt.Fprintf(&b, "  %s %-21s %s\n", mark(s.TracefsReadable), "tracefs", tracefs)
+	if s.NonDumpable {
+		fmt.Fprintln(&b, "      note: this process is non-dumpable — the kernel sets that at exec when the")
+		fmt.Fprintln(&b, "      new credentials are not a subset of the old, which is what a setcap'd binary")
+		fmt.Fprintln(&b, "      exec'd by an ordinary user does. Its own /proc/self/* then belongs to root,")
+		fmt.Fprintln(&b, "      and reading it back is what CAP_DAC_READ_SEARCH is on the list for.")
+	} else if s.FileCaps {
+		fmt.Fprintln(&b, "      note: these capabilities came from a file capability, but this process is")
+		fmt.Fprintln(&b, "      still dumpable — it gained nothing its parent did not already hold. Exec'd")
+		fmt.Fprintln(&b, "      from an ordinary shell the same binary goes non-dumpable and loses these")
+		fmt.Fprintln(&b, "      reads, so grant CAP_DAC_READ_SEARCH anyway rather than relying on this.")
+	}
+	fmt.Fprintln(&b, "")
+
+	fmt.Fprintln(&b, "collectors, with the privileges this process holds")
+	// One blocker that stops everything is a fact about the host, not about
+	// twelve collectors. Repeating it twelve times buries the section that
+	// matters when the answer is partial.
+	if blocker, uniform := uniformBlocker(s.Outlook()); uniform {
+		fmt.Fprintf(&b, "  %s none of them — %s\n", mark(false), blocker)
+		fmt.Fprintln(&b, "")
+		return b.String() + trailer(s)
+	}
+	for _, o := range s.Outlook() {
+		switch {
+		case o.WillRun:
+			fmt.Fprintf(&b, "  %s %-12s will run\n", mark(true), o.Subsystem)
+		case o.Degraded:
+			fmt.Fprintf(&b, "  %s %-12s eBPF lane blocked, /proc lane still reports — %s\n", "~", o.Subsystem, o.Blocker)
+		default:
+			fmt.Fprintf(&b, "  %s %-12s WILL NOT COLLECT — %s\n", mark(false), o.Subsystem, o.Blocker)
+		}
+	}
+	fmt.Fprintln(&b, "")
+	fmt.Fprintln(&b, "  fd always reads /proc/<pid>/fd and attaches nothing.")
+	fmt.Fprintln(&b, "  tls attaches only with --tls; heap can be switched off with --disable heap.")
+	fmt.Fprint(&b, ptraceCaveat(s))
+	fmt.Fprintln(&b, "")
+	return b.String() + trailer(s)
+}
+
+// ptraceCaveat is the one verdict above that depends on the target rather than
+// on ptop. It is printed as a caveat instead of folded into the table because
+// --caps is answered before any target is named — and overstating it (marking
+// every collector blocked on a host where ptop watches its owner's own
+// processes) would be its own kind of wrong.
+func ptraceCaveat(s CapStatus) string {
+	if s.IsRoot || s.HasSysPtrace {
+		return ""
+	}
+	return "\n" +
+		"  Every verdict above assumes the target belongs to you. Without CAP_SYS_PTRACE,\n" +
+		"  a target owned by another user blocks ALL of them: pid-mode targeting stats\n" +
+		"  /proc/<pid>/ns/pid, and that read is ptrace-mode.\n"
+}
+
+// trailer is the fix, printed however the collector section came out.
+func trailer(s CapStatus) string {
+	var b strings.Builder
+	fmt.Fprintln(&b, "to grant the whole set:")
+	fmt.Fprintf(&b, "  sudo %s ./bin/ptop\n", RecommendedSetcap)
+	fmt.Fprintln(&b, "")
+	fmt.Fprintln(&b, "  CAP_SYS_ADMIN is close to root in practice, and in a container sharing the")
+	fmt.Fprintln(&b, "  host pid namespace it is root. Grant it deliberately, and say so to whoever")
+	fmt.Fprintln(&b, "  owns the host — or run without it and read this report to know what you lost.")
+	return b.String()
+}
+
+// uniformBlocker reports the single reason nothing will run, if there is one.
+func uniformBlocker(outlooks []CollectorOutlook) (string, bool) {
+	if len(outlooks) == 0 {
+		return "", false
+	}
+	first := outlooks[0].Blocker
+	for _, o := range outlooks {
+		if o.WillRun || o.Blocker != first {
+			return "", false
+		}
+	}
+	return first, true
+}
+
+// osVerdict says the obvious out loud on a host where no capability grant
+// would help: eBPF is a Linux interface, and the macOS port is a different
+// mechanism entirely (libproc + Mach, #22).
+func osVerdict() string {
+	if runtime.GOOS == "linux" {
+		return ""
+	}
+	return " — eBPF is Linux-only; collectors here run through the platform port"
+}
+
+func gateScope(g CapGate) string {
+	if g.Fatal {
+		return "required — gates every collector"
+	}
+	scope := "gates: " + strings.Join(g.Subsystems, ", ")
+	if len(g.Subsystems) == len(ebpfCollectors) {
+		scope = "gates: every collector"
+	}
+	if g.Conditional != "" {
+		scope += " — " + g.Conditional
+	}
+	return scope
+}
+
+func privilegeLabel(s CapStatus) string {
+	switch {
+	case s.IsRoot:
+		return "root"
+	case s.FileCaps && s.NonDumpable:
+		return "unprivileged, with file capabilities (setcap) — non-dumpable"
+	case s.FileCaps:
+		return "unprivileged, with file capabilities (setcap) — still dumpable"
+	}
+	return "unprivileged, no capabilities"
+}
+
+func kernelVerdict(s CapStatus) string {
+	if s.KernelSupportsBPF() {
+		return ""
+	}
+	return " — below the 5.8 minimum"
+}
+
+func mark(ok bool) string {
+	if ok {
+		return "✓"
+	}
+	return "✗"
+}
+
+func yesNo(ok bool, yes, no string) string {
+	if ok {
+		return yes
+	}
+	return no
+}

--- a/internal/bpf/capgates_test.go
+++ b/internal/bpf/capgates_test.go
@@ -1,0 +1,369 @@
+package bpf
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"testing"
+)
+
+// fullyPrivileged is the capability set the README now teaches, as measured on
+// a host where the reads it enables actually succeed.
+func fullyPrivileged() CapStatus {
+	return CapStatus{
+		HasBPF: true, HasPerfmon: true, HasSysAdmin: true,
+		HasSysPtrace: true, HasDACReadSearch: true,
+		FileCaps:            true,
+		ProcSelfMemReadable: true,
+		TracefsPath:         "/sys/kernel/tracing",
+		TracefsReadable:     true,
+		KernelMajor:         6, KernelMinor: 8,
+		UnprivBPFDisabled: 2,
+	}
+}
+
+// readmeSetcap is what the README taught before #117: enough to load, not
+// enough to load everything.
+func readmeSetcap() CapStatus {
+	s := fullyPrivileged()
+	s.HasSysAdmin = false
+	s.HasDACReadSearch = false
+	// The consequence of the missing CAP_DAC_READ_SEARCH, as the ADR measured
+	// it: setcap made the process non-dumpable, so its own /proc/self/mem now
+	// belongs to root, and tracefs is 0700 root:root.
+	s.ProcSelfMemReadable = false
+	return s
+}
+
+func outlookFor(t *testing.T, s CapStatus) map[string]CollectorOutlook {
+	t.Helper()
+	m := map[string]CollectorOutlook{}
+	for _, o := range outlook(s, true) {
+		m[o.Subsystem] = o
+	}
+	return m
+}
+
+func TestOutlookFullSetRunsEverything(t *testing.T) {
+	for _, o := range outlook(fullyPrivileged(), true) {
+		if !o.WillRun {
+			t.Errorf("%s should run with the full capability set: %s", o.Subsystem, o.Blocker)
+		}
+	}
+}
+
+// The reported shape of #117: the README's setcap loads, and quietly leaves out
+// every collector whose programs carry the kernel version — the two with a
+// kprobe, AND the uprobe lanes, since SEC("uprobe/…") loads as
+// BPF_PROG_TYPE_KPROBE and takes the same /proc/self/mem read.
+func TestOutlookReadmeSetcapDropsTheVersionStampedCollectors(t *testing.T) {
+	got := blockedCollectors(readmeSetcap(), true)
+	sort.Strings(got)
+	want := []string{"heap", "memory", "network", "tls"}
+	if strings.Join(got, ",") != strings.Join(want, ",") {
+		t.Fatalf("blocked = %v, want %v", got, want)
+	}
+	m := outlookFor(t, readmeSetcap())
+	for _, name := range want {
+		if !strings.Contains(m[name].Blocker, "CAP_DAC_READ_SEARCH") {
+			t.Errorf("%s blocker should name CAP_DAC_READ_SEARCH: %q", name, m[name].Blocker)
+		}
+		if !strings.Contains(m[name].Blocker, "/proc/self/mem") {
+			t.Errorf("%s blocker should name the read that failed: %q", name, m[name].Blocker)
+		}
+	}
+	// memory keeps a /proc reader; network does not, and the difference is the
+	// whole reason Degraded exists.
+	if !m["memory"].Degraded {
+		t.Error("memory has a /proc lane and should report as degraded, not gone")
+	}
+	if m["network"].Degraded {
+		t.Error("network has no /proc lane; calling it degraded overstates what is left")
+	}
+}
+
+// Verified on 7.0.0: with /proc/self/mem still unreadable, adding CAP_SYS_ADMIN
+// buys nothing at all — heap fails at LOAD, before the uprobe PMU is reached.
+// Anyone reading only the CAP_SYS_ADMIN half of #117 would grant exactly this
+// and see no change, so it is pinned.
+func TestOutlookSysAdminAloneRecoversNothing(t *testing.T) {
+	s := readmeSetcap()
+	s.HasSysAdmin = true
+	got := blockedCollectors(s, true)
+	sort.Strings(got)
+	if want := "heap,memory,network,tls"; strings.Join(got, ",") != want {
+		t.Fatalf("blocked = %v, want %v", got, want)
+	}
+}
+
+// The other half: with the version read restored and only CAP_SYS_ADMIN
+// missing, the uprobe PMU is what is left, and only the uprobe lanes go.
+func TestOutlookDACAloneLeavesJustTheUprobePMU(t *testing.T) {
+	s := readmeSetcap()
+	s.HasDACReadSearch, s.ProcSelfMemReadable = true, true
+	got := blockedCollectors(s, true)
+	sort.Strings(got)
+	if want := "heap,tls"; strings.Join(got, ",") != want {
+		t.Fatalf("blocked = %v, want %v", got, want)
+	}
+	m := outlookFor(t, s)
+	if !strings.Contains(m["heap"].Blocker, "CAP_SYS_ADMIN") {
+		t.Errorf("heap blocker should name CAP_SYS_ADMIN: %q", m["heap"].Blocker)
+	}
+}
+
+func TestOutlookUnreadableTracefsTakesOutEveryTracepointCollector(t *testing.T) {
+	s := fullyPrivileged()
+	s.TracefsReadable = false // everything else in place, so tracefs is the only fault
+	m := outlookFor(t, s)
+	for _, c := range ebpfCollectors {
+		if c.how&attachTracepoint == 0 {
+			continue
+		}
+		if m[c.name].WillRun {
+			t.Errorf("%s attaches a tracepoint and should be blocked by an unreadable tracefs", c.name)
+		}
+	}
+	// heap is uprobe-only: tracefs is not its problem.
+	if !m["heap"].WillRun {
+		t.Errorf("heap attaches no tracepoint; tracefs should not block it: %s", m["heap"].Blocker)
+	}
+}
+
+// Not mounted and not readable are different problems with different fixes.
+func TestOutlookDistinguishesUnmountedTracefs(t *testing.T) {
+	s := fullyPrivileged()
+	s.TracefsReadable, s.TracefsPath = false, ""
+	m := outlookFor(t, s)
+	if !strings.Contains(m["syscalls"].Blocker, "not mounted") {
+		t.Errorf("blocker should say tracefs is not mounted: %q", m["syscalls"].Blocker)
+	}
+	if strings.Contains(m["syscalls"].Blocker, "CAP_DAC_READ_SEARCH") {
+		t.Errorf("an unmounted tracefs is not a capability problem: %q", m["syscalls"].Blocker)
+	}
+}
+
+func TestOutlookRootRunsEverything(t *testing.T) {
+	s := CapStatus{
+		IsRoot: true, ProcSelfMemReadable: true,
+		TracefsPath: "/sys/kernel/tracing", TracefsReadable: true,
+		KernelMajor: 6, KernelMinor: 8,
+	}
+	if blocked := blockedCollectors(s, true); len(blocked) != 0 {
+		t.Errorf("root should run every collector, blocked: %v", blocked)
+	}
+}
+
+func TestOutlookNoEBPFInBinary(t *testing.T) {
+	m := map[string]CollectorOutlook{}
+	for _, o := range outlook(fullyPrivileged(), false) {
+		m[o.Subsystem] = o
+	}
+	if m["cpu"].WillRun {
+		t.Error("a build with no eBPF programs runs no eBPF collector")
+	}
+	if !strings.Contains(m["cpu"].Blocker, "-tags=ebpf") {
+		t.Errorf("blocker should name the build tag: %q", m["cpu"].Blocker)
+	}
+}
+
+func TestStartupAdvisory(t *testing.T) {
+	adv := startupAdvisory(readmeSetcap(), true, nil)
+	for _, want := range []string{"heap", "memory", "network", "CAP_SYS_ADMIN", "CAP_DAC_READ_SEARCH", "--caps", RecommendedSetcap} {
+		if !strings.Contains(adv, want) {
+			t.Errorf("advisory does not mention %q:\n%s", want, adv)
+		}
+	}
+	// The point of saying it at all: a dropped axis reads as a quiet target.
+	if !strings.Contains(adv, "zeros") {
+		t.Errorf("advisory should say what a dropped collector looks like downstream:\n%s", adv)
+	}
+}
+
+// A capability that only blocks something the operator already switched off is
+// not a gap; saying so every run is how a warning stops being read.
+func TestStartupAdvisorySkipsWhatWasNotAskedFor(t *testing.T) {
+	adv := startupAdvisory(readmeSetcap(), true, map[string]bool{"tls": true})
+	if strings.Contains(adv, "tls") {
+		t.Errorf("tls was not opted into; the advisory should not list it:\n%s", adv)
+	}
+	if !strings.Contains(adv, "heap") {
+		t.Errorf("heap was still asked for and is still blocked:\n%s", adv)
+	}
+
+	// With every uprobe lane switched off, CAP_SYS_ADMIN gates nothing anyone
+	// wanted and drops out of the message entirely.
+	adv = startupAdvisory(readmeSetcap(), true, map[string]bool{"tls": true, "heap": true})
+	if strings.Contains(adv, "CAP_SYS_ADMIN") {
+		t.Errorf("CAP_SYS_ADMIN no longer gates anything requested:\n%s", adv)
+	}
+	if !strings.Contains(adv, "CAP_DAC_READ_SEARCH") {
+		t.Errorf("memory and network are still blocked by it:\n%s", adv)
+	}
+
+	adv = startupAdvisory(readmeSetcap(), true,
+		map[string]bool{"tls": true, "heap": true, "memory": true, "network": true})
+	if adv != "" {
+		t.Errorf("nothing requested is blocked; advisory should be empty:\n%s", adv)
+	}
+}
+
+func TestStartupAdvisorySilentWhenNothingIsLost(t *testing.T) {
+	if adv := startupAdvisory(fullyPrivileged(), true, nil); adv != "" {
+		t.Errorf("nothing is blocked, advisory should be empty:\n%s", adv)
+	}
+	// A binary with no eBPF, or a process that cannot load any, already gets a
+	// louder message; repeating it per collector is noise.
+	if adv := startupAdvisory(fullyPrivileged(), false, nil); adv != "" {
+		t.Errorf("no-eBPF build should not get a capability advisory:\n%s", adv)
+	}
+	if adv := startupAdvisory(CapStatus{KernelMajor: 6}, true, nil); adv != "" {
+		t.Errorf("a process that cannot load BPF at all should not get this advisory:\n%s", adv)
+	}
+}
+
+func TestCapReportNamesEveryGateAndTheFullGrant(t *testing.T) {
+	out := readmeSetcap().CapReport()
+	for _, want := range []string{
+		"CAP_BPF", "CAP_PERFMON", "CAP_SYS_ADMIN", "CAP_DAC_READ_SEARCH", "CAP_SYS_PTRACE",
+		"/proc/self/mem", "tracefs", RecommendedSetcap,
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("report does not mention %q:\n%s", want, out)
+		}
+	}
+	// The non-obvious one has to be spelled out, not merely listed.
+	if !strings.Contains(out, "non-dumpable") {
+		t.Errorf("report should explain why setcap itself breaks /proc/self:\n%s", out)
+	}
+	if !strings.Contains(out, "root") || !strings.Contains(out, "deliberately") {
+		t.Errorf("report should warn what CAP_SYS_ADMIN amounts to:\n%s", out)
+	}
+}
+
+func TestGatesHeldFollowsRoot(t *testing.T) {
+	for _, g := range (CapStatus{IsRoot: true}).Gates() {
+		if !g.Held {
+			t.Errorf("root holds %s", g.Cap)
+		}
+	}
+	for _, g := range (CapStatus{}).Gates() {
+		if g.Held {
+			t.Errorf("an unprivileged process holds no %s", g.Cap)
+		}
+	}
+}
+
+// Every non-fatal gate must name the collectors it gates, and every gate must
+// carry a mechanism: "permission denied" is exactly the message #117 is about.
+func TestGatesCarryScopeAndMechanism(t *testing.T) {
+	known := map[string]bool{}
+	for _, c := range ebpfCollectors {
+		known[c.name] = true
+	}
+	for _, g := range fullyPrivileged().Gates() {
+		if g.Why == "" {
+			t.Errorf("%s has no mechanism", g.Cap)
+		}
+		if g.Token == "" || !strings.Contains(RecommendedSetcap, g.Token) {
+			t.Errorf("%s token %q is not in RecommendedSetcap", g.Cap, g.Token)
+		}
+		if g.Fatal {
+			if len(g.Subsystems) != 0 {
+				t.Errorf("%s gates everything; listing subsystems understates it", g.Cap)
+			}
+			continue
+		}
+		if len(g.Subsystems) == 0 {
+			t.Errorf("%s is not fatal but names no subsystem it gates", g.Cap)
+		}
+		for _, name := range g.Subsystems {
+			if !known[name] {
+				t.Errorf("%s gates unknown subsystem %q", g.Cap, name)
+			}
+		}
+	}
+}
+
+var secRE = regexp.MustCompile(`SEC\("(kprobe|kretprobe|uprobe|uretprobe|tracepoint)`)
+
+// programToCollector maps a BPF object to the subsystem name --disable uses.
+// Two objects feed heap: the libc allocator lane and the Go one.
+var programToCollector = map[string]string{
+	"cpu.bpf.c": "cpu", "threads.bpf.c": "threads", "memory.bpf.c": "memory",
+	"io.bpf.c": "io", "network.bpf.c": "network", "syscalls.bpf.c": "syscalls",
+	"futex.bpf.c": "futex", "security.bpf.c": "security", "proc.bpf.c": "lifecycle",
+	"signal.bpf.c": "signals", "heap.bpf.c": "heap", "goalloc.bpf.c": "heap",
+	"tls.bpf.c": "tls",
+}
+
+// The gate table is only as good as its claim about how each collector
+// attaches, and that claim lives in the C. Read it back rather than trusting
+// the comment: a new SEC("kprobe/...") in an existing program silently moves
+// that collector under CAP_DAC_READ_SEARCH, and nothing else would notice.
+func TestEBPFCollectorsMatchPrograms(t *testing.T) {
+	files, err := filepath.Glob("programs/*.bpf.c")
+	if err != nil || len(files) == 0 {
+		t.Fatalf("no BPF programs found: %v", err)
+	}
+	fromSource := map[string]attachMechanism{}
+	for _, f := range files {
+		base := filepath.Base(f)
+		name, ok := programToCollector[base]
+		if !ok {
+			t.Errorf("%s maps to no collector — add it to programToCollector and to ebpfCollectors", base)
+			continue
+		}
+		src, err := os.ReadFile(f)
+		if err != nil {
+			t.Fatalf("read %s: %v", f, err)
+		}
+		for _, m := range secRE.FindAllStringSubmatch(string(src), -1) {
+			switch m[1] {
+			case "tracepoint":
+				fromSource[name] |= attachTracepoint
+			case "kprobe", "kretprobe":
+				fromSource[name] |= attachKprobe
+			case "uprobe", "uretprobe":
+				fromSource[name] |= attachUprobe
+			}
+		}
+	}
+	inTable := map[string]attachMechanism{}
+	for _, c := range ebpfCollectors {
+		if _, dup := inTable[c.name]; dup {
+			t.Errorf("%s listed twice in ebpfCollectors", c.name)
+		}
+		inTable[c.name] = c.how
+	}
+	for name, how := range fromSource {
+		if inTable[name] != how {
+			t.Errorf("%s attaches %s in the C but %s in ebpfCollectors",
+				name, mechanismString(how), mechanismString(inTable[name]))
+		}
+	}
+	for name := range inTable {
+		if _, ok := fromSource[name]; !ok {
+			t.Errorf("ebpfCollectors lists %s, but no BPF program attaches for it", name)
+		}
+	}
+}
+
+func mechanismString(m attachMechanism) string {
+	var parts []string
+	if m&attachTracepoint != 0 {
+		parts = append(parts, "tracepoint")
+	}
+	if m&attachKprobe != 0 {
+		parts = append(parts, "kprobe")
+	}
+	if m&attachUprobe != 0 {
+		parts = append(parts, "uprobe")
+	}
+	if len(parts) == 0 {
+		return "nothing"
+	}
+	return strings.Join(parts, "+")
+}

--- a/internal/bpf/caps.go
+++ b/internal/bpf/caps.go
@@ -8,24 +8,39 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"syscall"
+
+	"golang.org/x/sys/unix"
 )
 
 // Capability bits from uapi/linux/capability.h relevant to ptop.
+//
+// The set is larger than CAP_BPF + CAP_PERFMON, and the extra two are not
+// obvious from any error the kernel returns — see capgates.go for what each
+// one gates and why.
 const (
-	capBPF       = 39
-	capPerfmon   = 38
-	capSysAdmin  = 21
-	capSysPtrace = 19
+	capDACReadSearch = 2
+	capSysPtrace     = 19
+	capSysAdmin      = 21
+	capPerfmon       = 38
+	capBPF           = 39
 )
+
+// tracefsCandidates are the mount points cilium/ebpf looks for tracefs at, in
+// the order it tries them. Every tracepoint attach resolves an event id under
+// <mount>/events/<group>/<name>/id, so a mount ptop cannot read is a mount
+// where no tracepoint collector starts.
+var tracefsCandidates = []string{"/sys/kernel/tracing", "/sys/kernel/debug/tracing"}
 
 // CapStatus describes which privileges the current process has at runtime,
 // plus kernel/sysctl info that affects eBPF availability.
 type CapStatus struct {
-	IsRoot       bool
-	HasBPF       bool
-	HasPerfmon   bool
-	HasSysAdmin  bool
-	HasSysPtrace bool
+	IsRoot           bool
+	HasBPF           bool
+	HasPerfmon       bool
+	HasSysAdmin      bool
+	HasSysPtrace     bool
+	HasDACReadSearch bool
 
 	// KernelMajor and KernelMinor are parsed from uname.release.
 	// Zero (=0) if the read failed.
@@ -36,6 +51,39 @@ type CapStatus struct {
 	// 0 = unprivileged eBPF allowed; 1/2 = blocked (default on modern distros).
 	// -1 = sysctl could not be read.
 	UnprivBPFDisabled int
+
+	// FileCaps reports that this process holds capabilities it did not get
+	// from being root — i.e. they came from a file capability on the binary,
+	// which is exactly what the README's setcap line installs.
+	FileCaps bool
+
+	// NonDumpable is PR_GET_DUMPABLE != SUID_DUMP_USER, and it is the fact
+	// that actually costs collectors. The kernel sets it at exec whenever the
+	// new credentials are not a subset of the old — a setcap'd binary exec'd
+	// by an ordinary user — and then task_dump_owner() hands that process's
+	// own /proc/self/* to root. /proc/self/mem, mode 0600, becomes unreadable
+	// to the process itself.
+	//
+	// It is read rather than inferred from FileCaps because it depends on the
+	// exec CHAIN, not on the binary: exec'd from a shell it is set, but exec'd
+	// from a parent that still holds the same capabilities (a privileged
+	// launcher, `setpriv` without --clear-caps) nothing is gained, so nothing
+	// is set and the same binary with the same file capabilities keeps reading
+	// its own memory. Measured on 7.0.0, both ways round.
+	NonDumpable bool
+
+	// ProcSelfMemReadable is whether /proc/self/mem could be opened. This is
+	// not a curiosity: cilium/ebpf reads the running kernel's version out of
+	// the vDSO image through /proc/self/mem, and stamps it into every
+	// kprobe-type program at load time. Unreadable here means the collectors
+	// carrying a kprobe never load, whatever else is granted.
+	ProcSelfMemReadable bool
+
+	// TracefsPath is the tracefs mount found, or "" if none is mounted.
+	// TracefsReadable is whether its events directory could be opened —
+	// it is 0700 root:root on most distributions.
+	TracefsPath     string
+	TracefsReadable bool
 }
 
 // GetCapStatus returns a snapshot of the process's privileges. It never fails:
@@ -49,6 +97,14 @@ func GetCapStatus() CapStatus {
 	s.HasPerfmon = hasCapability(capPerfmon)
 	s.HasSysAdmin = hasCapability(capSysAdmin)
 	s.HasSysPtrace = hasCapability(capSysPtrace)
+	s.HasDACReadSearch = hasCapability(capDACReadSearch)
+	s.FileCaps = !s.IsRoot && (s.HasBPF || s.HasPerfmon || s.HasSysAdmin ||
+		s.HasSysPtrace || s.HasDACReadSearch)
+	if d, err := unix.PrctlRetInt(unix.PR_GET_DUMPABLE, 0, 0, 0, 0); err == nil {
+		s.NonDumpable = d != 1 // 1 == SUID_DUMP_USER
+	}
+	s.ProcSelfMemReadable = canOpen("/proc/self/mem")
+	s.TracefsPath, s.TracefsReadable = probeTracefs()
 	s.KernelMajor, s.KernelMinor = readKernelVersion()
 	if data, err := os.ReadFile("/proc/sys/kernel/unprivileged_bpf_disabled"); err == nil {
 		if v, err := strconv.Atoi(strings.TrimSpace(string(data))); err == nil {
@@ -58,27 +114,12 @@ func GetCapStatus() CapStatus {
 	return s
 }
 
-// CanLoadBPF is true if the process has enough privileges to load eBPF
-// programs (root OR CAP_BPF + CAP_PERFMON). Doesn't consider kernel
-// version — only capabilities.
-func (s CapStatus) CanLoadBPF() bool {
-	return s.IsRoot || (s.HasBPF && s.HasPerfmon)
-}
-
-// KernelSupportsBPF is true if kernel >= 5.8 (BTF + ring buffer + CAP_BPF).
-// Earlier versions partially work but ptop assumes 5.8+.
-func (s CapStatus) KernelSupportsBPF() bool {
-	if s.KernelMajor == 0 {
-		return true // unknown; let the load fail with a more specific error
-	}
-	if s.KernelMajor > 5 {
-		return true
-	}
-	return s.KernelMajor == 5 && s.KernelMinor >= 8
-}
-
 // Diagnose returns a multi-line message explaining the process state and
 // how to obtain eBPF privileges (or fall back to --no-ebpf). Empty if OK.
+//
+// It answers only the fatal question — can any eBPF load at all. The partial
+// answer, where the load succeeds and individual collectors do not, is
+// CapReport (capgates.go); Diagnose points at it rather than repeating it.
 func (s CapStatus) Diagnose() string {
 	if s.CanLoadBPF() && s.KernelSupportsBPF() {
 		return ""
@@ -119,7 +160,9 @@ func (s CapStatus) Diagnose() string {
 	fmt.Fprintln(&b, "  1) Run with sudo:")
 	fmt.Fprintln(&b, "       sudo ./bin/ptop --pid <PID>")
 	fmt.Fprintln(&b, "  2) Apply caps to the binary (one-time):")
-	fmt.Fprintln(&b, "       sudo setcap cap_bpf,cap_perfmon+ep ./bin/ptop")
+	fmt.Fprintf(&b, "       sudo %s ./bin/ptop\n", RecommendedSetcap)
+	fmt.Fprintln(&b, "     cap_bpf,cap_perfmon alone loads only part of the probe set;")
+	fmt.Fprintln(&b, "     `ptop --caps` reports which collectors each capability gates.")
 	fmt.Fprintln(&b, "  3) /proc-only mode (no eBPF, no privileges):")
 	fmt.Fprintln(&b, "       ./bin/ptop --pid <PID> --no-ebpf")
 
@@ -128,6 +171,11 @@ func (s CapStatus) Diagnose() string {
 
 // hasCapability reads /proc/self/status (CapEff field) and tests the cap bit.
 // Returns false on any error.
+//
+// This read keeps working after setcap even though it goes through the same
+// root-owned /proc/self: status is world-readable (0444), where mem is 0600.
+// That asymmetry is why a capability-starved ptop can still report accurately
+// on its own capabilities.
 func hasCapability(capBit int) bool {
 	f, err := os.Open("/proc/self/status")
 	if err != nil {
@@ -148,6 +196,35 @@ func hasCapability(capBit int) bool {
 		return eff&(uint64(1)<<uint(capBit)) != 0
 	}
 	return false
+}
+
+// canOpen reports whether path can be opened for reading. Opening is the test
+// rather than stat-plus-arithmetic because the answer depends on capabilities,
+// LSM policy and mount options at once, and only the open consults all three.
+func canOpen(path string) bool {
+	f, err := os.Open(path)
+	if err != nil {
+		return false
+	}
+	_ = f.Close()
+	return true
+}
+
+// probeTracefs finds the tracefs mount and reports whether its event directory
+// can be read. Not being mounted and not being readable are different problems
+// with different fixes, so the path is returned alongside the verdict.
+func probeTracefs() (path string, readable bool) {
+	for _, candidate := range tracefsCandidates {
+		var st syscall.Stat_t
+		if err := syscall.Stat(candidate, &st); err != nil {
+			continue
+		}
+		if st.Mode&syscall.S_IFMT != syscall.S_IFDIR {
+			continue
+		}
+		return candidate, canOpen(candidate + "/events")
+	}
+	return "", false
 }
 
 // readKernelVersion parses "X.Y" from the start of /proc/sys/kernel/osrelease.

--- a/internal/bpf/caps_stub.go
+++ b/internal/bpf/caps_stub.go
@@ -3,25 +3,30 @@
 package bpf
 
 // CapStatus on non-Linux OSes: always indicates eBPF cannot run.
-// We keep the same shape so main.go doesn't need a build tag.
+// We keep the same shape so main.go doesn't need a build tag — and so
+// capgates.go, which is build-tag-free, compiles against one struct.
 type CapStatus struct {
-	IsRoot       bool
-	HasBPF       bool
-	HasPerfmon   bool
-	HasSysAdmin  bool
-	HasSysPtrace bool
+	IsRoot           bool
+	HasBPF           bool
+	HasPerfmon       bool
+	HasSysAdmin      bool
+	HasSysPtrace     bool
+	HasDACReadSearch bool
 
 	KernelMajor       int
 	KernelMinor       int
 	UnprivBPFDisabled int
+
+	FileCaps            bool
+	NonDumpable         bool
+	ProcSelfMemReadable bool
+	TracefsPath         string
+	TracefsReadable     bool
 }
 
 func GetCapStatus() CapStatus {
 	return CapStatus{UnprivBPFDisabled: -1}
 }
-
-func (CapStatus) CanLoadBPF() bool         { return false }
-func (CapStatus) KernelSupportsBPF() bool  { return false }
 
 func (CapStatus) Diagnose() string {
 	return "" +

--- a/internal/bpf/goalloc.go
+++ b/internal/bpf/goalloc.go
@@ -154,7 +154,7 @@ func OpenGoAllocTracer(pid int, sampleBytes uint64) (*GoAllocTracer, error) {
 	exePath := fmt.Sprintf("/proc/%d/exe", pid)
 	mallocOff, err := goMallocFileOffset(exePath)
 	if err != nil {
-		return nil, err
+		return nil, targetReadError("locate "+goMallocSymbol+" in the target executable", err)
 	}
 
 	spec, err := ebpf.LoadCollectionSpecFromReader(bytes.NewReader(goallocBPFObj))
@@ -163,7 +163,7 @@ func OpenGoAllocTracer(pid int, sampleBytes uint64) (*GoAllocTracer, error) {
 	}
 	coll, err := ebpf.NewCollection(spec)
 	if err != nil {
-		return nil, fmt.Errorf("load goalloc collection: %w", err)
+		return nil, kprobeLoadError("load goalloc collection", err)
 	}
 	t := &GoAllocTracer{coll: coll}
 
@@ -225,7 +225,8 @@ func OpenGoAllocTracer(pid int, sampleBytes uint64) (*GoAllocTracer, error) {
 	})
 	if err != nil {
 		t.Close()
-		return nil, fmt.Errorf("attach uprobe %s at file offset %#x: %w", goMallocSymbol, mallocOff, err)
+		return nil, uprobeAttachError(
+			fmt.Sprintf("attach uprobe %s at file offset %#x", goMallocSymbol, mallocOff), err)
 	}
 	t.links = append(t.links, l)
 

--- a/internal/bpf/heap.go
+++ b/internal/bpf/heap.go
@@ -109,7 +109,7 @@ func OpenHeapTracer(pid int) (*HeapTracer, error) {
 
 	libcPath, lo, hi, err := resolveLibc(pid)
 	if err != nil {
-		return nil, err
+		return nil, targetReadError(fmt.Sprintf("locate libc in pid %d", pid), err)
 	}
 
 	spec, err := ebpf.LoadCollectionSpecFromReader(bytes.NewReader(heapBPFObj))
@@ -118,7 +118,7 @@ func OpenHeapTracer(pid int) (*HeapTracer, error) {
 	}
 	coll, err := ebpf.NewCollection(spec)
 	if err != nil {
-		return nil, fmt.Errorf("load heap collection: %w", err)
+		return nil, kprobeLoadError("load heap collection", err)
 	}
 	t := &HeapTracer{coll: coll, libcLo: lo, libcHi: hi}
 
@@ -167,6 +167,9 @@ func OpenHeapTracer(pid int) (*HeapTracer, error) {
 		{"free", "uprobe_free", false},
 	}
 	var mallocEntry, mallocRet bool
+	// Keep the first malloc failure: the loop tolerates a missing symbol, so by
+	// the time the verdict is known the error that explains it is long gone.
+	var mallocErr error
 	for _, p := range probes {
 		prog := coll.Programs[p.prog]
 		if prog == nil {
@@ -182,6 +185,9 @@ func OpenHeapTracer(pid int) (*HeapTracer, error) {
 		if err != nil {
 			// Tolerate a missing symbol (rare for libc); malloc is required.
 			fmt.Fprintf(os.Stderr, "warning: heap uprobe %s (%s): %v\n", p.sym, p.prog, err)
+			if p.sym == "malloc" && mallocErr == nil {
+				mallocErr = err
+			}
 			continue
 		}
 		t.links = append(t.links, l)
@@ -195,7 +201,7 @@ func OpenHeapTracer(pid int) (*HeapTracer, error) {
 	}
 	if !mallocEntry || !mallocRet {
 		t.Close()
-		return nil, fmt.Errorf("could not attach malloc uprobes on %s", libcPath)
+		return nil, uprobeAttachError("could not attach malloc uprobes on "+libcPath, mallocErr)
 	}
 
 	eventsMap := coll.Maps["heap_events"]

--- a/internal/bpf/memory.go
+++ b/internal/bpf/memory.go
@@ -47,7 +47,7 @@ func OpenMemoryTracer(target Target) (*MemoryTracer, error) {
 	}
 	coll, err := ebpf.NewCollection(spec)
 	if err != nil {
-		return nil, fmt.Errorf("load memory collection: %w", err)
+		return nil, kprobeLoadError("load memory collection", err)
 	}
 	t := &MemoryTracer{coll: coll}
 

--- a/internal/bpf/network.go
+++ b/internal/bpf/network.go
@@ -104,7 +104,7 @@ func OpenNetTracer(target Target) (*NetTracer, error) {
 	}
 	coll, err := ebpf.NewCollection(spec)
 	if err != nil {
-		return nil, fmt.Errorf("load net collection: %w", err)
+		return nil, kprobeLoadError("load net collection", err)
 	}
 	t := &NetTracer{coll: coll}
 

--- a/internal/bpf/target.go
+++ b/internal/bpf/target.go
@@ -43,7 +43,7 @@ func resolveTarget(t Target) (targetFilter, error) {
 func resolvePIDTarget(pid int) (targetFilter, error) {
 	var st unix.Stat_t
 	if err := unix.Stat(fmt.Sprintf("/proc/%d/ns/pid", pid), &st); err != nil {
-		return targetFilter{}, fmt.Errorf("stat pid namespace of %d: %w", pid, err)
+		return targetFilter{}, targetReadError(fmt.Sprintf("stat pid namespace of %d", pid), err)
 	}
 	return targetFilter{Mode: targetModePID, Pid: uint32(pid), Dev: st.Dev, Ino: st.Ino}, nil
 }

--- a/internal/bpf/tls.go
+++ b/internal/bpf/tls.go
@@ -71,7 +71,7 @@ func OpenTLSTracer(pid, maxBytes int) (*TLSTracer, error) {
 
 	libsslPath, err := resolveLibSSL(pid)
 	if err != nil {
-		return nil, err
+		return nil, targetReadError(fmt.Sprintf("locate libssl in pid %d", pid), err)
 	}
 
 	spec, err := ebpf.LoadCollectionSpecFromReader(bytes.NewReader(tlsBPFObj))
@@ -80,7 +80,7 @@ func OpenTLSTracer(pid, maxBytes int) (*TLSTracer, error) {
 	}
 	coll, err := ebpf.NewCollection(spec)
 	if err != nil {
-		return nil, fmt.Errorf("load tls collection: %w", err)
+		return nil, kprobeLoadError("load tls collection", err)
 	}
 	t := &TLSTracer{coll: coll}
 
@@ -137,6 +137,9 @@ func OpenTLSTracer(pid, maxBytes int) (*TLSTracer, error) {
 		{"SSL_set_fd", "uprobe_ssl_set_fd", false},
 	}
 	var haveWrite, haveRead bool
+	// As in heap.go: the loop tolerates individual failures, so the first one
+	// has to be kept or the verdict below carries no reason at all.
+	var attachErr error
 	for _, p := range probes {
 		prog := coll.Programs[p.prog]
 		if prog == nil {
@@ -153,6 +156,9 @@ func OpenTLSTracer(pid, maxBytes int) (*TLSTracer, error) {
 			// Tolerate a missing symbol (BoringSSL/version drift); we only
 			// need one of SSL_write/SSL_read to be useful.
 			fmt.Fprintf(os.Stderr, "warning: tls uprobe %s (%s): %v\n", p.sym, p.prog, err)
+			if attachErr == nil {
+				attachErr = err
+			}
 			continue
 		}
 		t.links = append(t.links, l)
@@ -165,7 +171,7 @@ func OpenTLSTracer(pid, maxBytes int) (*TLSTracer, error) {
 	}
 	if !haveWrite && !haveRead {
 		t.Close()
-		return nil, fmt.Errorf("could not attach SSL_write/SSL_read uprobes on %s", libsslPath)
+		return nil, uprobeAttachError("could not attach SSL_write/SSL_read uprobes on "+libsslPath, attachErr)
 	}
 
 	eventsMap := coll.Maps["tls_events"]

--- a/internal/bpf/uprobe_caps.go
+++ b/internal/bpf/uprobe_caps.go
@@ -1,0 +1,104 @@
+package bpf
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+)
+
+// Naming the capability in the error, instead of only the path.
+//
+// A uprobe that will not attach reports something like "no such file or
+// directory" or "operation not permitted" against the target binary, which
+// reads as a problem with the TARGET — wrong path, stripped symbol, wrong
+// architecture. It is usually not. It is almost always the dynamic perf_uprobe
+// PMU in perf_event_open(2), whose gate is CAP_SYS_ADMIN and which CAP_PERFMON
+// does not satisfy (#117).
+//
+// The distinction matters more than the wording suggests. heap is the only
+// axis carrying func and file:line, so losing it loses attribution entirely —
+// and in a pipeline that keeps only the capture, the axis comes out as zeros
+// rather than as an error, which a human then reads as "this process does not
+// allocate". Whatever we can say at the moment of the failure is the last
+// chance to say it.
+
+// uprobeCapHint names the capability that most likely explains a failed uprobe
+// attach, or "" when the capabilities are all in place and the fault really is
+// somewhere else. It reads the current process's own capabilities, so it is
+// only ever called on an error path.
+func uprobeCapHint() string {
+	s := GetCapStatus()
+	switch {
+	case s.IsRoot:
+		return ""
+	case !s.HasSysAdmin:
+		return "this process has no CAP_SYS_ADMIN: the perf_uprobe PMU that perf_event_open(2) " +
+			"creates for a uprobe is gated on it, and CAP_PERFMON does not satisfy it — run `ptop --caps`"
+	case !s.HasSysPtrace:
+		return "this process has no CAP_SYS_PTRACE: attaching reads the target's " +
+			"/proc/<pid>/{exe,maps,map_files}, which needs ptrace-mode access when the target " +
+			"belongs to another user — run `ptop --caps`"
+	}
+	return ""
+}
+
+// targetReadError annotates a failed read of the TARGET's /proc entry —
+// /proc/<pid>/ns/pid, /proc/<pid>/exe, /proc/<pid>/maps. Measured on 7.0.0
+// with every other capability granted, a root-owned target loses nine of the
+// twelve collectors here, eight of them at the pid-namespace stat alone; the
+// bare error says "permission denied" against a path in /proc and gives no
+// hint that one capability recovers all of them.
+//
+// Only permission failures are annotated. The same call sites legitimately
+// return ErrNotGo and plain not-found, and attaching a capability hint to
+// those would send the reader somewhere there is nothing to find. The cause is
+// always wrapped with %w, so errors.Is on the sentinel keeps working.
+func targetReadError(what string, err error) error {
+	s := GetCapStatus()
+	if errors.Is(err, fs.ErrPermission) && !s.IsRoot && !s.HasSysPtrace {
+		return fmt.Errorf("%s: %w (this process has no CAP_SYS_PTRACE, and reading "+
+			"another user's /proc/<pid>/{ns/pid,exe,maps} is ptrace-mode access — run `ptop --caps`)", what, err)
+	}
+	return fmt.Errorf("%s: %w", what, err)
+}
+
+// kprobeLoadError annotates a failed load of a collection containing a
+// kprobe-type program. cilium/ebpf stamps the running kernel's version into
+// those at load time and reads it out of the vDSO through /proc/self/mem —
+// which a setcap'd ptop cannot open, because the privilege gained at exec made
+// it non-dumpable and handed its own /proc/self/* to root. What surfaces is
+// "detecting kernel version: opening mem: … permission denied", naming neither
+// the capability that fixes it nor the setcap that caused it (#117).
+//
+// UPROBE programs count: SEC("uprobe/…") loads as BPF_PROG_TYPE_KPROBE, so the
+// heap and TLS collections take the same version read and fail the same way.
+// That is why heap needs CAP_DAC_READ_SEARCH as well as CAP_SYS_ADMIN, and why
+// granting only the latter recovers nothing.
+//
+// The trigger is the measured read, not the text of the error: whatever
+// upstream calls the failure, an unreadable /proc/self/mem is the reason.
+func kprobeLoadError(what string, err error) error {
+	if s := GetCapStatus(); !s.ProcSelfMemReadable && !s.IsRoot && !s.HasDACReadSearch {
+		return fmt.Errorf("%s: %w (this process cannot read its own /proc/self/mem, where the "+
+			"kernel version stamped into every kprobe- and uprobe-type program is read from — a "+
+			"setcap'd binary is non-dumpable and needs CAP_DAC_READ_SEARCH to read it back; "+
+			"run `ptop --caps`)", what, err)
+	}
+	return fmt.Errorf("%s: %w", what, err)
+}
+
+// uprobeAttachError builds the error a failed uprobe attach returns, appending
+// uprobeCapHint when there is one. cause may be nil, for a call site that
+// aggregated several attempts and has only the verdict.
+func uprobeAttachError(what string, cause error) error {
+	hint := uprobeCapHint()
+	switch {
+	case cause != nil && hint != "":
+		return fmt.Errorf("%s: %w (%s)", what, cause, hint)
+	case cause != nil:
+		return fmt.Errorf("%s: %w", what, cause)
+	case hint != "":
+		return fmt.Errorf("%s (%s)", what, hint)
+	}
+	return fmt.Errorf("%s", what)
+}

--- a/pkg/collector/capgates_guard_test.go
+++ b/pkg/collector/capgates_guard_test.go
@@ -1,0 +1,53 @@
+package collector
+
+import (
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/trentas/ptop/internal/bpf"
+)
+
+// internal/bpf spells subsystem names as literals in its capability table
+// (capgates.go): it cannot import this package, because this package imports
+// it. That is fine as long as the two agree, and a divergence would be silent
+// — `ptop --caps` would report on a collector nobody can name to --disable, or
+// omit one that exists. These tests are the join the compiler cannot make.
+
+func TestCapGateSubsystemsAreKnown(t *testing.T) {
+	for _, g := range bpf.GetCapStatus().Gates() {
+		for _, name := range g.Subsystems {
+			if !knownSubsystems[name] {
+				t.Errorf("%s claims to gate %q, which --disable does not know; known: %s",
+					g.Cap, name, KnownSubsystems())
+			}
+		}
+	}
+}
+
+func TestCapOutlookCoversEveryEBPFSubsystem(t *testing.T) {
+	inOutlook := map[string]bool{}
+	for _, o := range bpf.GetCapStatus().Outlook() {
+		if !knownSubsystems[o.Subsystem] {
+			t.Errorf("--caps reports on %q, which --disable does not know; known: %s",
+				o.Subsystem, KnownSubsystems())
+		}
+		inOutlook[o.Subsystem] = true
+	}
+	// fd is the one subsystem that attaches nothing: it reads /proc/<pid>/fd
+	// and needs no capability beyond being able to read it. Everything else
+	// has an eBPF lane, so a missing name means a new collector nobody
+	// answered the capability question for.
+	var missing []string
+	for name := range knownSubsystems {
+		if name == SubsystemFD || inOutlook[name] {
+			continue
+		}
+		missing = append(missing, name)
+	}
+	sort.Strings(missing)
+	if len(missing) > 0 {
+		t.Errorf("no capability gate answers for %s — add them to ebpfCollectors in internal/bpf/capgates.go",
+			strings.Join(missing, ", "))
+	}
+}


### PR DESCRIPTION
Closes #117.

`setcap cap_bpf,cap_perfmon+ep` — what the README taught — loads the eBPF lane and then runs about three quarters of the probe set. The remainder does not announce itself: the capture is well-formed and the dropped axes publish as zeros, and zero is a measurement — it asserts the process did not allocate.

## Measured, not assumed

Linux 7.0.0, unprivileged uid, the binary `setcap`'d at each grant in turn, against a uid-matched target. Left column is what `ptop --caps` predicted **before** attaching; right is what actually attached:

| grant | predicted blocked | actually blocked |
|---|---|---|
| `cap_bpf,cap_perfmon` | cpu futex heap io lifecycle memory network security signals syscalls threads | same |
| `+ cap_sys_admin` | same 11 | same — **no change at all** |
| `+ cap_dac_read_search` (no sys_admin) | heap | heap |
| `+ both` | none | none |

## Four mechanisms, only one of them obvious

- **uprobe** → the dynamic `perf_uprobe` PMU in `perf_event_open(2)` is gated on `CAP_SYS_ADMIN`, and **`CAP_PERFMON` does not satisfy it**. Observed verbatim with `CAP_PERFMON` held: `creating perf_uprobe PMU: … opening perf event: permission denied`.
- **kprobe-*type* program** → loaded with the kernel version stamped in, which cilium/ebpf reads out of the vDSO through `/proc/self/mem`. `SEC("uprobe/…")` loads as `BPF_PROG_TYPE_KPROBE` too, so this reaches `memory`, `network`, `heap` **and** `tls`. That is why granting `cap_sys_admin` alone recovers nothing — heap dies at load, never reaching the PMU it was missing. The issue predicted this pair from measurement; the kprobe/vDSO path is why it is exactly that pair.
- **tracepoint** → reads its event id from `<tracefs>/events/…/id`, and tracefs is `0700 root:root`.
- **any pid-mode collector** → stats `/proc/<pid>/ns/pid`, a ptrace-mode read. Not in the issue, found here: with everything else granted, a **root-owned** target loses nine of twelve; the same grant against a uid-matched target runs all twelve. So `cap_sys_ptrace` is the fifth, and it is conditional on target ownership.

**The trap.** The `setcap` is itself the cause of the middle two. The kernel marks a process non-dumpable when an `exec` gains credentials the parent lacked, and `task_dump_owner()` then hands that process its own `/proc/self/*` to root. `CapStatus.NonDumpable` reads `PR_GET_DUMPABLE` rather than inferring it from the cap bits, because it depends on the exec *chain*, not the binary: exec'd from a still-privileged parent the identical binary stays dumpable and reads its own memory fine. (Worth knowing if you reproduce this — that, and a `setcap` binary on a `nosuid` mount having its capabilities silently ignored while `getcap` still shows them.)

## What is in the change

Against the issue's three boxes:

- [x] **README Permissions** carries the full grant, a table of what each capability costs, and the non-dumpable mechanism spelled out. `SECURITY.md` frames `cap_bpf,cap_perfmon` as a real hardening choice with a stated price rather than as the recommendation. `CLAUDE.md` gets the mechanism and three rules for anything added later.
- [x] **The attach and load errors name the probable capability** instead of only a path in `/proc` — `heap`, `goalloc`, `tls`, plus the two that were never in the issue and cost two more collectors (`memory`/`network` collection load) and the one that costs nine (`resolvePIDTarget`). They ride `ProbeStatus.Detail` onto the wire, so a downstream consumer gets them too.
- [x] **`ptop --caps`** reports capabilities held, the reads as measured now, and the per-collector verdict — no pid, nothing attached, so it answers while a host is being provisioned. A partial set also prints an advisory on stderr before collecting, skipping whatever `--disable` or a missing `--tls` already switched off (a warning about something nobody asked for is one nobody reads by the time it matters).

## Notes for review

- Gates are decided by **measured reads**, not cap bits — AppArmor, mount options and file modes all get a vote and only the `open` consults all three. The issue's ADR ruled out AppArmor and `perf_event_paranoid` the same way.
- `internal/bpf/capgates.go` spells subsystem names as literals because `pkg/collector` imports this package and cannot be imported back; `pkg/collector/capgates_guard_test.go` is the join the compiler cannot make.
- `TestEBPFCollectorsMatchPrograms` reads the `.bpf.c` sources back, so adding a `SEC("kprobe/…")` to an existing program cannot silently move that collector under a different capability.
- `CanLoadBPF`/`KernelSupportsBPF` moved to the build-tag-free file — they are arithmetic on the struct, and the tests need the same answer on macOS.
- Five pre-existing macOS test failures (4 DWARF/ELF fixtures, 1 `--disable` case needing the eBPF lane) are unchanged; verified identical on a clean tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)